### PR TITLE
feat: add hex conversion

### DIFF
--- a/src/color/__test__/baseColor.test.ts
+++ b/src/color/__test__/baseColor.test.ts
@@ -4,26 +4,40 @@ import * as utils from '../utils';
 describe('Color', () => {
   it('should initialize color correctly from hex', () => {
     expect(new Color('#00ff00').toRGBA()).toEqual({ r: 0, g: 255, b: 0, a: 1 });
+    expect(new Color('#00ff00').toHex()).toEqual('#00ff00');
+
     expect(new Color('#ffffff').toRGBA()).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(new Color('#ffffff').toHex()).toEqual('#ffffff');
+
     expect(new Color('#00ffff').toRGBA()).toEqual({ r: 0, g: 255, b: 255, a: 1 });
+    expect(new Color('#00ffff').toHex()).toEqual('#00ffff');
+
     expect(new Color('#00000000').toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(new Color('#00000000').toHex()).toEqual('#00000000');
   });
 
   it('should initialize color correctly from RGBA', () => {
     expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toRGBA()).toEqual({ r: 0, g: 255, b: 0, a: 1 });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHex()).toEqual('#00ff00');
+
     expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 255,
       g: 255,
       b: 255,
       a: 1,
     });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toEqual('#ffffff');
+
     expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 0,
       g: 255,
       b: 255,
       a: 1,
     });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHex()).toEqual('#00ffff');
+
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHex()).toEqual('#00000000');
   });
 
   it('should initialize color correctly with no input', () => {
@@ -32,6 +46,7 @@ describe('Color', () => {
       .mockReturnValue({ r: 5, g: 10, b: 15, a: 1 });
 
     expect(new Color().toRGBA()).toEqual({ r: 5, g: 10, b: 15, a: 1 });
+    expect(new Color().toHex()).toEqual('#050a0f');
 
     mockGetRandomColor.mockRestore();
   });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,6 +1,5 @@
-import { BLACK } from './color.constants';
-import { toRGBA } from './conversions';
-import { ColorFormat, ColorRGBA } from './formats';
+import { toHex, toRGBA } from './conversions';
+import { ColorFormat, ColorHex, ColorRGBA } from './formats';
 import { getRandomColorRGBA } from './utils';
 
 export class Color {
@@ -12,5 +11,9 @@ export class Color {
 
   toRGBA(): ColorRGBA {
     return this.color;
+  }
+
+  toHex(): ColorHex {
+    return toHex(this.color);
   }
 }

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -1,5 +1,5 @@
-import { ColorFormat, ColorRGBA } from './formats';
-import { isValidHexColor } from './validations';
+import { ColorFormat, ColorHex, ColorRGBA } from './formats';
+import { isValidHexColor, isValidRGBAColor } from './validations';
 
 function hexToRGBA(hex: string): ColorRGBA {
   if (!isValidHexColor(hex)) {
@@ -31,9 +31,32 @@ function hexToRGBA(hex: string): ColorRGBA {
   return { r, g, b, a: +(a / 255).toFixed(3) };
 }
 
+function rgbaToHex(rgba: ColorRGBA): ColorHex {
+  if (!isValidRGBAColor(rgba)) {
+    throw new Error(`Invalid RGBA color: "${JSON.stringify(rgba)}"`);
+  }
+
+  const { r, g, b, a = 1 } = rgba;
+  const toHex = (value: number) => value.toString(16).padStart(2, '0');
+  const alpha = Math.round(a * 255);
+  const alphaHex = alpha < 255 ? toHex(alpha) : '';
+
+  return (`#${toHex(r)}${toHex(g)}${toHex(b)}${alphaHex}`).toLowerCase() as ColorHex;
+}
+
 export function toRGBA(color: ColorFormat): ColorRGBA {
   if (typeof color === 'string') {
     return hexToRGBA(color);
   }
   return color;
+}
+
+export function toHex(color: ColorFormat): ColorHex {
+  if (typeof color === 'string') {
+    if (!isValidHexColor(color)) {
+      throw new Error(`Invalid hex color: "${color}"`);
+    }
+    return color.toLowerCase() as ColorHex;
+  }
+  return rgbaToHex(color);
 }


### PR DESCRIPTION
## Summary
- expose Color.toHex() for hex output
- convert between RGBA and hex values
- test Color hex conversions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f8a68b330832aa59a417ad7ef71a4