### PR TITLE
feat: add RGB conversions

### DIFF
--- a/src/color/__test__/baseColor.test.ts
+++ b/src/color/__test__/baseColor.test.ts
@@ -3,22 +3,27 @@ import * as utils from '../utils';
 
 describe('Color', () => {
   it('should initialize color correctly from hex', () => {
-    expect(new Color('#00ff00').toRGBA()).toEqual({ r: 0, g: 255, b: 0, a: 1 });
+    expect(new Color('#00ff00').toRGBA()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color('#00ff00').toRGB()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color('#00ff00').toHex()).toEqual('#00ff00');
 
-    expect(new Color('#ffffff').toRGBA()).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    expect(new Color('#ffffff').toRGBA()).toEqual({ r: 255, g: 255, b: 255 });
+    expect(new Color('#ffffff').toRGB()).toEqual({ r: 255, g: 255, b: 255 });
     expect(new Color('#ffffff').toHex()).toEqual('#ffffff');
 
-    expect(new Color('#00ffff').toRGBA()).toEqual({ r: 0, g: 255, b: 255, a: 1 });
+    expect(new Color('#00ffff').toRGBA()).toEqual({ r: 0, g: 255, b: 255 });
+    expect(new Color('#00ffff').toRGB()).toEqual({ r: 0, g: 255, b: 255 });
     expect(new Color('#00ffff').toHex()).toEqual('#00ffff');
 
     expect(new Color('#00000000').toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(new Color('#00000000').toRGB()).toEqual({ r: 0, g: 0, b: 0 });
     expect(new Color('#00000000').toHex()).toEqual('#00000000');
   });
 
   it('should initialize color correctly from RGBA', () => {
     expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toRGBA()).toEqual({ r: 0, g: 255, b: 0, a: 1 });
-    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHex()).toEqual('#00ff00');
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHex()).toEqual('#00ff00ff');
 
     expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 255,
@@ -26,7 +31,12 @@ describe('Color', () => {
       b: 255,
       a: 1,
     });
-    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toEqual('#ffffff');
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toRGB()).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+    });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toEqual('#ffffffff');
 
     expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 0,
@@ -34,10 +44,22 @@ describe('Color', () => {
       b: 255,
       a: 1,
     });
-    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHex()).toEqual('#00ffff');
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toRGB()).toEqual({
+      r: 0,
+      g: 255,
+      b: 255,
+    });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHex()).toEqual('#00ffffff');
 
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGB()).toEqual({ r: 0, g: 0, b: 0 });
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHex()).toEqual('#00000000');
+  });
+
+  it('should initialize color correctly from RGB', () => {
+    expect(new Color({ r: 0, g: 255, b: 0 }).toRGBA()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toHex()).toEqual('#00ff00');
   });
 
   it('should initialize color correctly with no input', () => {
@@ -46,7 +68,8 @@ describe('Color', () => {
       .mockReturnValue({ r: 5, g: 10, b: 15, a: 1 });
 
     expect(new Color().toRGBA()).toEqual({ r: 5, g: 10, b: 15, a: 1 });
-    expect(new Color().toHex()).toEqual('#050a0f');
+    expect(new Color().toRGB()).toEqual({ r: 5, g: 10, b: 15 });
+    expect(new Color().toHex()).toEqual('#050a0fff');
 
     mockGetRandomColor.mockRestore();
   });

--- a/src/color/__test__/conversions.test.ts
+++ b/src/color/__test__/conversions.test.ts
@@ -1,0 +1,32 @@
+import {
+  hexToRGB,
+  hexToRGBA,
+  rgbToHex,
+  rgbaToHex,
+  rgbToRGBA,
+  rgbaToRGB,
+} from '../conversions';
+
+describe('conversions', () => {
+  it('converts hex to RGB and RGBA', () => {
+    expect(hexToRGB('#00ff00')).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hexToRGBA('#00ff00')).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hexToRGBA('#00000000')).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(hexToRGBA('#000000ff')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  });
+
+  it('converts RGB and RGBA to hex', () => {
+    expect(rgbToHex({ r: 0, g: 255, b: 0 })).toEqual('#00ff00');
+    expect(rgbaToHex({ r: 0, g: 0, b: 0 })).toEqual('#000000');
+    expect(rgbaToHex({ r: 0, g: 0, b: 0, a: 0 })).toEqual('#00000000');
+    expect(rgbaToHex({ r: 0, g: 0, b: 0, a: 1 })).toEqual('#000000ff');
+  });
+
+  it('converts between RGB and RGBA', () => {
+    const rgb = { r: 0, g: 255, b: 0 };
+    const rgba = { r: 0, g: 255, b: 0, a: 0.5 };
+    expect(rgbToRGBA(rgb, 0.5)).toEqual(rgba);
+    expect(rgbToRGBA(rgb)).toEqual(rgb);
+    expect(rgbaToRGB(rgba)).toEqual(rgb);
+  });
+});

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,5 +1,5 @@
-import { toHex, toRGBA } from './conversions';
-import { ColorFormat, ColorHex, ColorRGBA } from './formats';
+import { toHex, toRGB, toRGBA } from './conversions';
+import { ColorFormat, ColorHex, ColorRGB, ColorRGBA } from './formats';
 import { getRandomColorRGBA } from './utils';
 
 export class Color {
@@ -11,6 +11,10 @@ export class Color {
 
   toRGBA(): ColorRGBA {
     return this.color;
+  }
+
+  toRGB(): ColorRGB {
+    return toRGB(this.color);
   }
 
   toHex(): ColorHex {

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -1,54 +1,91 @@
-import { ColorFormat, ColorHex, ColorRGBA } from './formats';
+import { ColorFormat, ColorHex, ColorRGB, ColorRGBA } from './formats';
 import { isValidHexColor, isValidRGBAColor } from './validations';
 
-function hexToRGBA(hex: string): ColorRGBA {
+function parseHex(hex: string): { r: number; g: number; b: number; a?: number } {
   if (!isValidHexColor(hex)) {
     throw new Error(`Invalid hex color: "${hex}"`);
   }
 
   const raw = hex.replace(/^#/, '');
-
   let r = 0;
   let g = 0;
   let b = 0;
-  let a = 255; // conversion to 0-1 below
+  let a: number | undefined;
 
   if (raw.length === 3) {
     r = parseInt(raw[0] + raw[0], 16);
     g = parseInt(raw[1] + raw[1], 16);
     b = parseInt(raw[2] + raw[2], 16);
-  } else if (raw.length === 6) {
+  } else {
     r = parseInt(raw.slice(0, 2), 16);
     g = parseInt(raw.slice(2, 4), 16);
     b = parseInt(raw.slice(4, 6), 16);
-  } else if (raw.length === 8) {
-    r = parseInt(raw.slice(0, 2), 16);
-    g = parseInt(raw.slice(2, 4), 16);
-    b = parseInt(raw.slice(4, 6), 16);
-    a = parseInt(raw.slice(6, 8), 16);
+
+    if (raw.length === 8) {
+      a = parseInt(raw.slice(6, 8), 16) / 255;
+    }
   }
 
-  return { r, g, b, a: +(a / 255).toFixed(3) };
+  return a === undefined ? { r, g, b } : { r, g, b, a: +a.toFixed(3) };
 }
 
-function rgbaToHex(rgba: ColorRGBA): ColorHex {
-  if (!isValidRGBAColor(rgba)) {
-    throw new Error(`Invalid RGBA color: "${JSON.stringify(rgba)}"`);
+export function hexToRGB(hex: ColorHex): ColorRGB {
+  const { r, g, b } = parseHex(hex);
+  return { r, g, b };
+}
+
+export function hexToRGBA(hex: ColorHex): ColorRGBA {
+  return parseHex(hex);
+}
+
+export function rgbaToRGB(color: ColorRGBA): ColorRGB {
+  const { r, g, b } = color;
+  return { r, g, b };
+}
+
+export function rgbToRGBA(color: ColorRGB, alpha?: number): ColorRGBA {
+  const { r, g, b } = color;
+  return alpha === undefined ? { r, g, b } : { r, g, b, a: alpha };
+}
+
+function formatHex(value: number): string {
+  return value.toString(16).padStart(2, '0');
+}
+
+export function rgbaToHex(color: ColorRGBA): ColorHex {
+  if (!isValidRGBAColor(color)) {
+    throw new Error(`Invalid RGBA color: "${JSON.stringify(color)}"`);
   }
 
-  const { r, g, b, a = 1 } = rgba;
-  const toHex = (value: number) => value.toString(16).padStart(2, '0');
-  const alpha = Math.round(a * 255);
-  const alphaHex = alpha < 255 ? toHex(alpha) : '';
+  const { r, g, b, a } = color;
+  const alphaHex = a !== undefined ? formatHex(Math.round(a * 255)) : '';
 
-  return (`#${toHex(r)}${toHex(g)}${toHex(b)}${alphaHex}`).toLowerCase() as ColorHex;
+  return (`#${formatHex(r)}${formatHex(g)}${formatHex(b)}${alphaHex}`).toLowerCase() as ColorHex;
+}
+
+export function rgbToHex(color: ColorRGB): ColorHex {
+  return rgbaToHex(rgbToRGBA(color));
 }
 
 export function toRGBA(color: ColorFormat): ColorRGBA {
   if (typeof color === 'string') {
     return hexToRGBA(color);
   }
-  return color;
+
+  if ('a' in color) {
+    const { a, ...rgb } = color;
+    return rgbToRGBA(rgb, a);
+  }
+
+  return rgbToRGBA(color);
+}
+
+export function toRGB(color: ColorFormat): ColorRGB {
+  if (typeof color === 'string') {
+    return hexToRGB(color);
+  }
+
+  return 'a' in color ? rgbaToRGB(color) : color;
 }
 
 export function toHex(color: ColorFormat): ColorHex {
@@ -58,5 +95,6 @@ export function toHex(color: ColorFormat): ColorHex {
     }
     return color.toLowerCase() as ColorHex;
   }
-  return rgbaToHex(color);
+
+  return 'a' in color ? rgbaToHex(color) : rgbToHex(color);
 }

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -1,10 +1,13 @@
 export type ColorHex = `#${string}`;
 
-export interface ColorRGBA {
+export interface ColorRGB {
   r: number; // 0-255
   g: number; // 0-255
   b: number; // 0-255
+}
+
+export interface ColorRGBA extends ColorRGB {
   a?: number; // 0-1
 }
 
-export type ColorFormat = ColorHex | ColorRGBA;
+export type ColorFormat = ColorHex | ColorRGB | ColorRGBA;


### PR DESCRIPTION
## Summary
- introduce `ColorRGB` type and make `ColorRGBA` extend it
- add `toRGB` and broaden conversions across hex, rgb, and rgba
- expose `toRGB` on `Color` class and expand tests
- split color conversion logic into dedicated helpers without casting hacks
- keep alpha optional across conversions and include hex alpha only when provided

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ac2872a4832ab561c890442780e8