### PR TITLE
feat: add HSL color conversions

### DIFF
--- a/src/color/__test__/baseColor.test.ts
+++ b/src/color/__test__/baseColor.test.ts
@@ -6,24 +6,43 @@ describe('Color', () => {
     expect(new Color('#00ff00').toRGBA()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color('#00ff00').toRGB()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color('#00ff00').toHex()).toEqual('#00ff00');
+    expect(new Color('#00ff00').toHSL()).toEqual({ h: 120, s: 100, l: 50 });
+    expect(new Color('#00ff00').toHSLA()).toEqual({ h: 120, s: 100, l: 50 });
 
     expect(new Color('#ffffff').toRGBA()).toEqual({ r: 255, g: 255, b: 255 });
     expect(new Color('#ffffff').toRGB()).toEqual({ r: 255, g: 255, b: 255 });
     expect(new Color('#ffffff').toHex()).toEqual('#ffffff');
+    expect(new Color('#ffffff').toHSL()).toEqual({ h: 0, s: 0, l: 100 });
+    expect(new Color('#ffffff').toHSLA()).toEqual({ h: 0, s: 0, l: 100 });
 
     expect(new Color('#00ffff').toRGBA()).toEqual({ r: 0, g: 255, b: 255 });
     expect(new Color('#00ffff').toRGB()).toEqual({ r: 0, g: 255, b: 255 });
     expect(new Color('#00ffff').toHex()).toEqual('#00ffff');
+    expect(new Color('#00ffff').toHSL()).toEqual({ h: 180, s: 100, l: 50 });
+    expect(new Color('#00ffff').toHSLA()).toEqual({ h: 180, s: 100, l: 50 });
 
     expect(new Color('#00000000').toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     expect(new Color('#00000000').toRGB()).toEqual({ r: 0, g: 0, b: 0 });
     expect(new Color('#00000000').toHex()).toEqual('#00000000');
+    expect(new Color('#00000000').toHSL()).toEqual({ h: 0, s: 0, l: 0 });
+    expect(new Color('#00000000').toHSLA()).toEqual({ h: 0, s: 0, l: 0, a: 0 });
   });
 
   it('should initialize color correctly from RGBA', () => {
     expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toRGBA()).toEqual({ r: 0, g: 255, b: 0, a: 1 });
     expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHex()).toEqual('#00ff00ff');
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHSL()).toEqual({
+      h: 120,
+      s: 100,
+      l: 50,
+    });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHSLA()).toEqual({
+      h: 120,
+      s: 100,
+      l: 50,
+      a: 1,
+    });
 
     expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 255,
@@ -37,6 +56,17 @@ describe('Color', () => {
       b: 255,
     });
     expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toEqual('#ffffffff');
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHSL()).toEqual({
+      h: 0,
+      s: 0,
+      l: 100,
+    });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHSLA()).toEqual({
+      h: 0,
+      s: 0,
+      l: 100,
+      a: 1,
+    });
 
     expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 0,
@@ -50,16 +80,80 @@ describe('Color', () => {
       b: 255,
     });
     expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHex()).toEqual('#00ffffff');
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHSL()).toEqual({
+      h: 180,
+      s: 100,
+      l: 50,
+    });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHSLA()).toEqual({
+      h: 180,
+      s: 100,
+      l: 50,
+      a: 1,
+    });
 
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGB()).toEqual({ r: 0, g: 0, b: 0 });
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHex()).toEqual('#00000000');
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHSL()).toEqual({ h: 0, s: 0, l: 0 });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHSLA()).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 0,
+    });
   });
 
   it('should initialize color correctly from RGB', () => {
     expect(new Color({ r: 0, g: 255, b: 0 }).toRGBA()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color({ r: 0, g: 255, b: 0 }).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
     expect(new Color({ r: 0, g: 255, b: 0 }).toHex()).toEqual('#00ff00');
+    expect(new Color({ r: 0, g: 255, b: 0 }).toHSL()).toEqual({ h: 120, s: 100, l: 50 });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toHSLA()).toEqual({
+      h: 120,
+      s: 100,
+      l: 50,
+    });
+  });
+
+  it('should initialize color correctly from HSL', () => {
+    expect(new Color({ h: 120, s: 100, l: 50 }).toRGB()).toEqual({
+      r: 0,
+      g: 255,
+      b: 0,
+    });
+    expect(new Color({ h: 120, s: 100, l: 50 }).toHex()).toEqual('#00ff00');
+    expect(new Color({ h: 120, s: 100, l: 50 }).toHSL()).toEqual({
+      h: 120,
+      s: 100,
+      l: 50,
+    });
+    expect(new Color({ h: 120, s: 100, l: 50 }).toHSLA()).toEqual({
+      h: 120,
+      s: 100,
+      l: 50,
+    });
+  });
+
+  it('should initialize color correctly from HSLA', () => {
+    expect(new Color({ h: 0, s: 0, l: 0, a: 0.5 }).toRGBA()).toEqual({
+      r: 0,
+      g: 0,
+      b: 0,
+      a: 0.5,
+    });
+    expect(new Color({ h: 0, s: 0, l: 0, a: 0.5 }).toHex()).toEqual('#00000080');
+    expect(new Color({ h: 0, s: 0, l: 0, a: 0.5 }).toHSL()).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+    });
+    expect(new Color({ h: 0, s: 0, l: 0, a: 0.5 }).toHSLA()).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 0.5,
+    });
   });
 
   it('should initialize color correctly with no input', () => {
@@ -70,6 +164,8 @@ describe('Color', () => {
     expect(new Color().toRGBA()).toEqual({ r: 5, g: 10, b: 15, a: 1 });
     expect(new Color().toRGB()).toEqual({ r: 5, g: 10, b: 15 });
     expect(new Color().toHex()).toEqual('#050a0fff');
+    expect(new Color().toHSL()).toEqual({ h: 210, s: 50, l: 4 });
+    expect(new Color().toHSLA()).toEqual({ h: 210, s: 50, l: 4, a: 1 });
 
     mockGetRandomColor.mockRestore();
   });

--- a/src/color/__test__/conversions.test.ts
+++ b/src/color/__test__/conversions.test.ts
@@ -5,6 +5,10 @@ import {
   rgbaToHex,
   rgbToRGBA,
   rgbaToRGB,
+  hslToRGB,
+  hslaToRGBA,
+  rgbToHSL,
+  rgbaToHSLA,
 } from '../conversions';
 
 describe('conversions', () => {
@@ -28,5 +32,37 @@ describe('conversions', () => {
     expect(rgbToRGBA(rgb, 0.5)).toEqual(rgba);
     expect(rgbToRGBA(rgb)).toEqual(rgb);
     expect(rgbaToRGB(rgba)).toEqual(rgb);
+  });
+
+  it('converts HSL and HSLA to RGB and RGBA', () => {
+    expect(hslToRGB({ h: 0, s: 100, l: 50 })).toEqual({ r: 255, g: 0, b: 0 });
+    expect(hslToRGB({ h: 120, s: 100, l: 50 })).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hslToRGB({ h: 240, s: 100, l: 50 })).toEqual({ r: 0, g: 0, b: 255 });
+    expect(hslToRGB({ h: 0, s: 0, l: 0 })).toEqual({ r: 0, g: 0, b: 0 });
+    expect(hslaToRGBA({ h: 0, s: 0, l: 0, a: 0.5 })).toEqual({
+      r: 0,
+      g: 0,
+      b: 0,
+      a: 0.5,
+    });
+  });
+
+  it('converts RGB and RGBA to HSL and HSLA', () => {
+    expect(rgbToHSL({ r: 255, g: 0, b: 0 })).toEqual({ h: 0, s: 100, l: 50 });
+    expect(rgbToHSL({ r: 0, g: 255, b: 0 })).toEqual({ h: 120, s: 100, l: 50 });
+    expect(rgbToHSL({ r: 0, g: 0, b: 255 })).toEqual({ h: 240, s: 100, l: 50 });
+    expect(rgbToHSL({ r: 255, g: 255, b: 255 })).toEqual({
+      h: 0,
+      s: 0,
+      l: 100,
+    });
+    expect(rgbToHSL({ r: 0, g: 0, b: 0 })).toEqual({ h: 0, s: 0, l: 0 });
+    expect(rgbToHSL({ r: 128, g: 128, b: 128 })).toEqual({ h: 0, s: 0, l: 50 });
+    expect(rgbaToHSLA({ r: 0, g: 0, b: 0, a: 0.5 })).toEqual({
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 0.5,
+    });
   });
 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,5 +1,12 @@
-import { toHex, toRGB, toRGBA } from './conversions';
-import { ColorFormat, ColorHex, ColorRGB, ColorRGBA } from './formats';
+import { toHex, toRGB, toRGBA, rgbaToHSL, rgbaToHSLA } from './conversions';
+import {
+  ColorFormat,
+  ColorHex,
+  ColorRGB,
+  ColorRGBA,
+  ColorHSL,
+  ColorHSLA,
+} from './formats';
 import { getRandomColorRGBA } from './utils';
 
 export class Color {
@@ -19,5 +26,13 @@ export class Color {
 
   toHex(): ColorHex {
     return toHex(this.color);
+  }
+
+  toHSL(): ColorHSL {
+    return rgbaToHSL(this.color);
+  }
+
+  toHSLA(): ColorHSLA {
+    return rgbaToHSLA(this.color);
   }
 }

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -1,5 +1,16 @@
-import { ColorFormat, ColorHex, ColorRGB, ColorRGBA } from './formats';
-import { isValidHexColor, isValidRGBAColor } from './validations';
+import {
+  ColorFormat,
+  ColorHex,
+  ColorRGB,
+  ColorRGBA,
+  ColorHSL,
+  ColorHSLA,
+} from './formats';
+import {
+  isValidHexColor,
+  isValidRGBAColor,
+  isValidHSLAColor,
+} from './validations';
 
 function parseHex(hex: string): { r: number; g: number; b: number; a?: number } {
   if (!isValidHexColor(hex)) {
@@ -67,9 +78,114 @@ export function rgbToHex(color: ColorRGB): ColorHex {
   return rgbaToHex(rgbToRGBA(color));
 }
 
+export function rgbToHSL(color: ColorRGB): ColorHSL {
+  const { r, g, b } = color;
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rNorm:
+        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
+        break;
+      case gNorm:
+        h = (bNorm - rNorm) / d + 2;
+        break;
+      case bNorm:
+        h = (rNorm - gNorm) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+export function rgbaToHSL(color: ColorRGBA): ColorHSL {
+  return rgbToHSL(color);
+}
+
+export function rgbaToHSLA(color: ColorRGBA): ColorHSLA {
+  const hsl = rgbToHSL(color);
+  return color.a === undefined ? hsl : { ...hsl, a: color.a };
+}
+
+export function hslToRGB(color: ColorHSL): ColorRGB {
+  if (!isValidHSLAColor(color)) {
+    throw new Error(`Invalid HSLA color: "${JSON.stringify(color)}"`);
+  }
+
+  const h = (((color.h % 360) + 360) % 360) / 360;
+  const s = color.s / 100;
+  const l = color.l / 100;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h * 6) % 2) - 1));
+  const m = l - c / 2;
+
+  let r1 = 0;
+  let g1 = 0;
+  let b1 = 0;
+
+  if (0 <= h && h < 1 / 6) {
+    r1 = c;
+    g1 = x;
+    b1 = 0;
+  } else if (1 / 6 <= h && h < 1 / 3) {
+    r1 = x;
+    g1 = c;
+    b1 = 0;
+  } else if (1 / 3 <= h && h < 1 / 2) {
+    r1 = 0;
+    g1 = c;
+    b1 = x;
+  } else if (1 / 2 <= h && h < 2 / 3) {
+    r1 = 0;
+    g1 = x;
+    b1 = c;
+  } else if (2 / 3 <= h && h < 5 / 6) {
+    r1 = x;
+    g1 = 0;
+    b1 = c;
+  } else {
+    r1 = c;
+    g1 = 0;
+    b1 = x;
+  }
+
+  return {
+    r: Math.round((r1 + m) * 255),
+    g: Math.round((g1 + m) * 255),
+    b: Math.round((b1 + m) * 255),
+  };
+}
+
+export function hslaToRGBA(color: ColorHSLA): ColorRGBA {
+  const { a, ...hsl } = color;
+  const rgb = hslToRGB(hsl);
+  return rgbToRGBA(rgb, a);
+}
+
 export function toRGBA(color: ColorFormat): ColorRGBA {
   if (typeof color === 'string') {
     return hexToRGBA(color);
+  }
+
+  if ('h' in color) {
+    return hslaToRGBA(color);
   }
 
   if ('a' in color) {
@@ -85,6 +201,10 @@ export function toRGB(color: ColorFormat): ColorRGB {
     return hexToRGB(color);
   }
 
+  if ('h' in color) {
+    return hslToRGB(color);
+  }
+
   return 'a' in color ? rgbaToRGB(color) : color;
 }
 
@@ -94,6 +214,10 @@ export function toHex(color: ColorFormat): ColorHex {
       throw new Error(`Invalid hex color: "${color}"`);
     }
     return color.toLowerCase() as ColorHex;
+  }
+
+  if ('h' in color) {
+    return rgbToHex(hslToRGB(color));
   }
 
   return 'a' in color ? rgbaToHex(color) : rgbToHex(color);

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -10,4 +10,19 @@ export interface ColorRGBA extends ColorRGB {
   a?: number; // 0-1
 }
 
-export type ColorFormat = ColorHex | ColorRGB | ColorRGBA;
+export interface ColorHSL {
+  h: number; // 0-360
+  s: number; // 0-100
+  l: number; // 0-100
+}
+
+export interface ColorHSLA extends ColorHSL {
+  a?: number; // 0-1
+}
+
+export type ColorFormat =
+  | ColorHex
+  | ColorRGB
+  | ColorRGBA
+  | ColorHSL
+  | ColorHSLA;

--- a/src/color/validations.ts
+++ b/src/color/validations.ts
@@ -1,4 +1,4 @@
-import { ColorRGBA } from './formats';
+import { ColorRGBA, ColorHSLA } from './formats';
 
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
@@ -18,6 +18,22 @@ export function isValidRGBAColor(color: ColorRGBA): boolean {
     Number.isInteger(b) &&
     b >= 0 &&
     b <= 255 &&
+    (a === undefined || (typeof a === 'number' && a >= 0 && a <= 1))
+  );
+}
+
+export function isValidHSLAColor(color: ColorHSLA): boolean {
+  const { h, s, l, a } = color;
+  return (
+    Number.isInteger(h) &&
+    h >= 0 &&
+    h <= 360 &&
+    Number.isInteger(s) &&
+    s >= 0 &&
+    s <= 100 &&
+    Number.isInteger(l) &&
+    l >= 0 &&
+    l <= 100 &&
     (a === undefined || (typeof a === 'number' && a >= 0 && a <= 1))
   );
 }


### PR DESCRIPTION
## Summary
- support HSL/HSLA color formats and validation
- convert between RGB/HEX/HSL and expose Color.toHSL()/toHSLA()
- test HSL and HSLA conversion edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d4d51570832a8c426d1598618d93