### PR TITLE
refactor: centralize color format detection

### DIFF
--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -5,7 +5,10 @@ import {
   ColorRGBA,
   ColorHSL,
   ColorHSLA,
+  ColorFormatType,
+  getColorFormat,
 } from './formats';
+
 import {
   isValidHexColor,
   isValidRGBAColor,
@@ -180,45 +183,52 @@ export function hslaToRGBA(color: ColorHSLA): ColorRGBA {
 }
 
 export function toRGBA(color: ColorFormat): ColorRGBA {
-  if (typeof color === 'string') {
-    return hexToRGBA(color);
+  const { formatType, value } = getColorFormat(color);
+  switch (formatType) {
+    case ColorFormatType.HEX:
+      return hexToRGBA(value);
+    case ColorFormatType.HSL:
+      return rgbToRGBA(hslToRGB(value));
+    case ColorFormatType.HSLA:
+      return hslaToRGBA(value);
+    case ColorFormatType.RGBA:
+      return value;
+    default:
+      return rgbToRGBA(value);
   }
-
-  if ('h' in color) {
-    return hslaToRGBA(color);
-  }
-
-  if ('a' in color) {
-    const { a, ...rgb } = color;
-    return rgbToRGBA(rgb, a);
-  }
-
-  return rgbToRGBA(color);
 }
 
 export function toRGB(color: ColorFormat): ColorRGB {
-  if (typeof color === 'string') {
-    return hexToRGB(color);
+  const { formatType, value } = getColorFormat(color);
+  switch (formatType) {
+    case ColorFormatType.HEX:
+      return hexToRGB(value);
+    case ColorFormatType.HSL:
+      return hslToRGB(value);
+    case ColorFormatType.HSLA:
+      return hslToRGB(value);
+    case ColorFormatType.RGBA:
+      return rgbaToRGB(value);
+    default:
+      return value;
   }
-
-  if ('h' in color) {
-    return hslToRGB(color);
-  }
-
-  return 'a' in color ? rgbaToRGB(color) : color;
 }
 
 export function toHex(color: ColorFormat): ColorHex {
-  if (typeof color === 'string') {
-    if (!isValidHexColor(color)) {
-      throw new Error(`Invalid hex color: "${color}"`);
-    }
-    return color.toLowerCase() as ColorHex;
+  const { formatType, value } = getColorFormat(color);
+  switch (formatType) {
+    case ColorFormatType.HEX:
+      if (!isValidHexColor(value)) {
+        throw new Error(`Invalid hex color: "${value}"`);
+      }
+      return value.toLowerCase() as ColorHex;
+    case ColorFormatType.HSL:
+      return rgbToHex(hslToRGB(value));
+    case ColorFormatType.HSLA:
+      return rgbaToHex(hslaToRGBA(value));
+    case ColorFormatType.RGBA:
+      return rgbaToHex(value);
+    default:
+      return rgbToHex(value);
   }
-
-  if ('h' in color) {
-    return rgbToHex(hslToRGB(color));
-  }
-
-  return 'a' in color ? rgbaToHex(color) : rgbToHex(color);
 }

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -26,3 +26,36 @@ export type ColorFormat =
   | ColorRGBA
   | ColorHSL
   | ColorHSLA;
+
+export enum ColorFormatType {
+  HEX = 'hex',
+  RGB = 'rgb',
+  RGBA = 'rgba',
+  HSL = 'hsl',
+  HSLA = 'hsla',
+}
+
+export type TypedColorFormat =
+  | { formatType: ColorFormatType.HEX; value: ColorHex }
+  | { formatType: ColorFormatType.RGB; value: ColorRGB }
+  | { formatType: ColorFormatType.RGBA; value: ColorRGBA }
+  | { formatType: ColorFormatType.HSL; value: ColorHSL }
+  | { formatType: ColorFormatType.HSLA; value: ColorHSLA };
+
+export function getColorFormat(color: ColorFormat): TypedColorFormat {
+  if (typeof color === 'string') {
+    return { formatType: ColorFormatType.HEX, value: color };
+  }
+
+  if ('h' in color) {
+    return 'a' in color
+      ? { formatType: ColorFormatType.HSLA, value: color }
+      : { formatType: ColorFormatType.HSL, value: color };
+  }
+
+  if ('a' in color) {
+    return { formatType: ColorFormatType.RGBA, value: color };
+  }
+
+  return { formatType: ColorFormatType.RGB, value: color };
+}


### PR DESCRIPTION
## Summary
- rename enum to `ColorFormatType` and move detection helper into `formats.ts`
- add `getColorFormat` returning typed value to eliminate casts in conversions
- switch conversions to use typed helper and rename returned field to `formatType`
- tidy spacing between import groups in conversions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890de48a668832a86326faa32544367