### PR TITLE
feat: add advanced color formats

### DIFF
--- a/src/color/__test__/baseColor.test.ts
+++ b/src/color/__test__/baseColor.test.ts
@@ -1,5 +1,6 @@
 import { Color } from '../color';
 import * as utils from '../utils';
+import { rgbToLCH, rgbToOKLCH } from '../conversions';
 
 describe('Color', () => {
   it('should initialize color correctly from hex', () => {
@@ -8,24 +9,56 @@ describe('Color', () => {
     expect(new Color('#00ff00').toHex()).toEqual('#00ff00');
     expect(new Color('#00ff00').toHSL()).toEqual({ h: 120, s: 100, l: 50 });
     expect(new Color('#00ff00').toHSLA()).toEqual({ h: 120, s: 100, l: 50 });
+    expect(new Color('#00ff00').toHSV()).toEqual({ h: 120, s: 100, v: 100 });
+    expect(new Color('#00ff00').toCMYK()).toEqual({ c: 100, m: 0, y: 100, k: 0 });
+    expect(new Color('#00ff00').toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 255, b: 0 })
+    );
+    expect(new Color('#00ff00').toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 255, b: 0 })
+    );
 
     expect(new Color('#ffffff').toRGBA()).toEqual({ r: 255, g: 255, b: 255 });
     expect(new Color('#ffffff').toRGB()).toEqual({ r: 255, g: 255, b: 255 });
     expect(new Color('#ffffff').toHex()).toEqual('#ffffff');
     expect(new Color('#ffffff').toHSL()).toEqual({ h: 0, s: 0, l: 100 });
     expect(new Color('#ffffff').toHSLA()).toEqual({ h: 0, s: 0, l: 100 });
+    expect(new Color('#ffffff').toHSV()).toEqual({ h: 0, s: 0, v: 100 });
+    expect(new Color('#ffffff').toCMYK()).toEqual({ c: 0, m: 0, y: 0, k: 0 });
+    expect(new Color('#ffffff').toLCH()).toEqual(
+      rgbToLCH({ r: 255, g: 255, b: 255 })
+    );
+    expect(new Color('#ffffff').toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 255, g: 255, b: 255 })
+    );
 
     expect(new Color('#00ffff').toRGBA()).toEqual({ r: 0, g: 255, b: 255 });
     expect(new Color('#00ffff').toRGB()).toEqual({ r: 0, g: 255, b: 255 });
     expect(new Color('#00ffff').toHex()).toEqual('#00ffff');
     expect(new Color('#00ffff').toHSL()).toEqual({ h: 180, s: 100, l: 50 });
     expect(new Color('#00ffff').toHSLA()).toEqual({ h: 180, s: 100, l: 50 });
+    expect(new Color('#00ffff').toHSV()).toEqual({ h: 180, s: 100, v: 100 });
+    expect(new Color('#00ffff').toCMYK()).toEqual({ c: 100, m: 0, y: 0, k: 0 });
+    expect(new Color('#00ffff').toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 255, b: 255 })
+    );
+    expect(new Color('#00ffff').toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 255, b: 255 })
+    );
 
     expect(new Color('#00000000').toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     expect(new Color('#00000000').toRGB()).toEqual({ r: 0, g: 0, b: 0 });
     expect(new Color('#00000000').toHex()).toEqual('#00000000');
     expect(new Color('#00000000').toHSL()).toEqual({ h: 0, s: 0, l: 0 });
     expect(new Color('#00000000').toHSLA()).toEqual({ h: 0, s: 0, l: 0, a: 0 });
+    expect(new Color('#00000000').toHSV()).toEqual({ h: 0, s: 0, v: 0 });
+    expect(new Color('#00000000').toCMYK()).toEqual({ c: 0, m: 0, y: 0, k: 100 });
+    expect(new Color('#00000000').toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 0, b: 0 })
+    );
+    expect(new Color('#00000000').toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 0, b: 0 })
+    );
   });
 
   it('should initialize color correctly from RGBA', () => {
@@ -43,6 +76,23 @@ describe('Color', () => {
       l: 50,
       a: 1,
     });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toHSV()).toEqual({
+      h: 120,
+      s: 100,
+      v: 100,
+    });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toCMYK()).toEqual({
+      c: 100,
+      m: 0,
+      y: 100,
+      k: 0,
+    });
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 255, b: 0 })
+    );
+    expect(new Color({ r: 0, g: 255, b: 0, a: 1 }).toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 255, b: 0 })
+    );
 
     expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 255,
@@ -67,6 +117,23 @@ describe('Color', () => {
       l: 100,
       a: 1,
     });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toHSV()).toEqual({
+      h: 0,
+      s: 0,
+      v: 100,
+    });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toCMYK()).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 0,
+    });
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toLCH()).toEqual(
+      rgbToLCH({ r: 255, g: 255, b: 255 })
+    );
+    expect(new Color({ r: 255, g: 255, b: 255, a: 1 }).toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 255, g: 255, b: 255 })
+    );
 
     expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toRGBA()).toEqual({
       r: 0,
@@ -91,6 +158,23 @@ describe('Color', () => {
       l: 50,
       a: 1,
     });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toHSV()).toEqual({
+      h: 180,
+      s: 100,
+      v: 100,
+    });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toCMYK()).toEqual({
+      c: 100,
+      m: 0,
+      y: 0,
+      k: 0,
+    });
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 255, b: 255 })
+    );
+    expect(new Color({ r: 0, g: 255, b: 255, a: 1 }).toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 255, b: 255 })
+    );
 
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGBA()).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toRGB()).toEqual({ r: 0, g: 0, b: 0 });
@@ -102,6 +186,23 @@ describe('Color', () => {
       l: 0,
       a: 0,
     });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toHSV()).toEqual({
+      h: 0,
+      s: 0,
+      v: 0,
+    });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toCMYK()).toEqual({
+      c: 0,
+      m: 0,
+      y: 0,
+      k: 100,
+    });
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 0, b: 0 })
+    );
+    expect(new Color({ r: 0, g: 0, b: 0, a: 0 }).toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 0, b: 0 })
+    );
   });
 
   it('should initialize color correctly from RGB', () => {
@@ -114,6 +215,23 @@ describe('Color', () => {
       s: 100,
       l: 50,
     });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toHSV()).toEqual({
+      h: 120,
+      s: 100,
+      v: 100,
+    });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toCMYK()).toEqual({
+      c: 100,
+      m: 0,
+      y: 100,
+      k: 0,
+    });
+    expect(new Color({ r: 0, g: 255, b: 0 }).toLCH()).toEqual(
+      rgbToLCH({ r: 0, g: 255, b: 0 })
+    );
+    expect(new Color({ r: 0, g: 255, b: 0 }).toOKLCH()).toEqual(
+      rgbToOKLCH({ r: 0, g: 255, b: 0 })
+    );
   });
 
   it('should initialize color correctly from HSL', () => {
@@ -154,6 +272,45 @@ describe('Color', () => {
       l: 0,
       a: 0.5,
     });
+  });
+
+  it('should initialize color correctly from HSV', () => {
+    expect(new Color({ h: 120, s: 100, v: 100 }).toRGB()).toEqual({
+      r: 0,
+      g: 255,
+      b: 0,
+    });
+    expect(new Color({ h: 120, s: 100, v: 100 }).toHSV()).toEqual({
+      h: 120,
+      s: 100,
+      v: 100,
+    });
+  });
+
+  it('should initialize color correctly from CMYK', () => {
+    expect(new Color({ c: 100, m: 0, y: 100, k: 0 }).toRGB()).toEqual({
+      r: 0,
+      g: 255,
+      b: 0,
+    });
+    expect(new Color({ c: 100, m: 0, y: 100, k: 0 }).toCMYK()).toEqual({
+      c: 100,
+      m: 0,
+      y: 100,
+      k: 0,
+    });
+  });
+
+  it('should initialize color correctly from LCH', () => {
+    const lch = rgbToLCH({ r: 0, g: 255, b: 0 });
+    expect(new Color(lch).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color(lch).toLCH()).toEqual(lch);
+  });
+
+  it('should initialize color correctly from OKLCH', () => {
+    const oklch = rgbToOKLCH({ r: 0, g: 255, b: 0 });
+    expect(new Color(oklch).toRGB()).toEqual({ r: 0, g: 255, b: 0 });
+    expect(new Color(oklch).toOKLCH()).toEqual(oklch);
   });
 
   it('should initialize color correctly with no input', () => {

--- a/src/color/__test__/conversions.test.ts
+++ b/src/color/__test__/conversions.test.ts
@@ -9,6 +9,22 @@ import {
   hslaToRGBA,
   rgbToHSL,
   rgbaToHSLA,
+  rgbToHSV,
+  rgbaToHSV,
+  hsvToRGB,
+  hsvToRGBA,
+  rgbToCMYK,
+  rgbaToCMYK,
+  cmykToRGB,
+  cmykToRGBA,
+  rgbToLCH,
+  rgbaToLCH,
+  lchToRGB,
+  lchToRGBA,
+  rgbToOKLCH,
+  rgbaToOKLCH,
+  oklchToRGB,
+  oklchToRGBA,
 } from '../conversions';
 
 describe('conversions', () => {
@@ -64,5 +80,29 @@ describe('conversions', () => {
       l: 0,
       a: 0.5,
     });
+  });
+
+  it('converts RGB and RGBA to HSV and back', () => {
+    const hsv = { h: 120, s: 100, v: 100 };
+    expect(rgbToHSV({ r: 0, g: 255, b: 0 })).toEqual(hsv);
+    expect(rgbaToHSV({ r: 0, g: 255, b: 0, a: 1 })).toEqual(hsv);
+    expect(hsvToRGB(hsv)).toEqual({ r: 0, g: 255, b: 0 });
+    expect(hsvToRGBA(hsv, 0.5)).toEqual({ r: 0, g: 255, b: 0, a: 0.5 });
+  });
+
+  it('converts RGB and RGBA to CMYK and back', () => {
+    const cmyk = { c: 100, m: 0, y: 100, k: 0 };
+    expect(rgbToCMYK({ r: 0, g: 255, b: 0 })).toEqual(cmyk);
+    expect(rgbaToCMYK({ r: 0, g: 255, b: 0, a: 1 })).toEqual(cmyk);
+    expect(cmykToRGB(cmyk)).toEqual({ r: 0, g: 255, b: 0 });
+    expect(cmykToRGBA(cmyk, 0.5)).toEqual({ r: 0, g: 255, b: 0, a: 0.5 });
+  });
+
+  it('converts RGB to LCH and OKLCH and back', () => {
+    const rgb = { r: 0, g: 255, b: 0 };
+    const lch = rgbToLCH(rgb);
+    expect(lchToRGB(lch)).toEqual(rgb);
+    const oklch = rgbToOKLCH(rgb);
+    expect(oklchToRGB(oklch)).toEqual(rgb);
   });
 });

--- a/src/color/color.constants.ts
+++ b/src/color/color.constants.ts
@@ -1,3 +1,3 @@
 import { ColorRGBA } from './formats';
 
-export const BLACK: ColorRGBA = { r: 0, g: 0, b: 0, a: 1 } as const;
+export const BLACK: ColorRGBA = { r: 0, g: 0, b: 0, a: 1 };

--- a/src/color/color.constants.ts
+++ b/src/color/color.constants.ts
@@ -1,3 +1,3 @@
 import { ColorRGBA } from './formats';
 
-export const BLACK: ColorRGBA = { r: 0, g: 0, b: 0, a: 1 };
+export const BLACK: ColorRGBA = { r: 0, g: 0, b: 0, a: 1 } as const;

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,4 +1,14 @@
-import { toHex, toRGB, toRGBA, rgbaToHSL, rgbaToHSLA } from './conversions';
+import {
+  toHex,
+  toRGB,
+  toRGBA,
+  rgbaToHSL,
+  rgbaToHSLA,
+  rgbaToHSV,
+  rgbaToCMYK,
+  rgbaToLCH,
+  rgbaToOKLCH,
+} from './conversions';
 import {
   ColorFormat,
   ColorHex,
@@ -6,6 +16,10 @@ import {
   ColorRGBA,
   ColorHSL,
   ColorHSLA,
+  ColorHSV,
+  ColorCMYK,
+  ColorLCH,
+  ColorOKLCH,
 } from './formats';
 import { getRandomColorRGBA } from './utils';
 
@@ -34,5 +48,21 @@ export class Color {
 
   toHSLA(): ColorHSLA {
     return rgbaToHSLA(this.color);
+  }
+
+  toHSV(): ColorHSV {
+    return rgbaToHSV(this.color);
+  }
+
+  toCMYK(): ColorCMYK {
+    return rgbaToCMYK(this.color);
+  }
+
+  toLCH(): ColorLCH {
+    return rgbaToLCH(this.color);
+  }
+
+  toOKLCH(): ColorOKLCH {
+    return rgbaToOKLCH(this.color);
   }
 }

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -20,12 +20,41 @@ export interface ColorHSLA extends ColorHSL {
   a?: number; // 0-1
 }
 
+export interface ColorHSV {
+  h: number; // 0-360
+  s: number; // 0-100
+  v: number; // 0-100
+}
+
+export interface ColorCMYK {
+  c: number; // 0-100
+  m: number; // 0-100
+  y: number; // 0-100
+  k: number; // 0-100
+}
+
+export interface ColorLCH {
+  l: number; // 0-100
+  c: number; // >=0
+  h: number; // 0-360
+}
+
+export interface ColorOKLCH {
+  l: number; // 0-1
+  c: number; // >=0
+  h: number; // 0-360
+}
+
 export type ColorFormat =
   | ColorHex
   | ColorRGB
   | ColorRGBA
   | ColorHSL
-  | ColorHSLA;
+  | ColorHSLA
+  | ColorHSV
+  | ColorCMYK
+  | ColorLCH
+  | ColorOKLCH;
 
 export enum ColorFormatType {
   HEX = 'hex',
@@ -33,6 +62,10 @@ export enum ColorFormatType {
   RGBA = 'rgba',
   HSL = 'hsl',
   HSLA = 'hsla',
+  HSV = 'hsv',
+  CMYK = 'cmyk',
+  LCH = 'lch',
+  OKLCH = 'oklch',
 }
 
 export type TypedColorFormat =
@@ -40,17 +73,41 @@ export type TypedColorFormat =
   | { formatType: ColorFormatType.RGB; value: ColorRGB }
   | { formatType: ColorFormatType.RGBA; value: ColorRGBA }
   | { formatType: ColorFormatType.HSL; value: ColorHSL }
-  | { formatType: ColorFormatType.HSLA; value: ColorHSLA };
+  | { formatType: ColorFormatType.HSLA; value: ColorHSLA }
+  | { formatType: ColorFormatType.HSV; value: ColorHSV }
+  | { formatType: ColorFormatType.CMYK; value: ColorCMYK }
+  | { formatType: ColorFormatType.LCH; value: ColorLCH }
+  | { formatType: ColorFormatType.OKLCH; value: ColorOKLCH };
 
 export function getColorFormat(color: ColorFormat): TypedColorFormat {
   if (typeof color === 'string') {
     return { formatType: ColorFormatType.HEX, value: color };
   }
 
+  if ('c' in color && 'm' in color && 'y' in color && 'k' in color) {
+    return { formatType: ColorFormatType.CMYK, value: color };
+  }
+
   if ('h' in color) {
-    return 'a' in color
-      ? { formatType: ColorFormatType.HSLA, value: color }
-      : { formatType: ColorFormatType.HSL, value: color };
+    if ('s' in color && 'v' in color) {
+      return { formatType: ColorFormatType.HSV, value: color };
+    }
+
+    if ('s' in color && 'l' in color) {
+      return 'a' in color
+        ? { formatType: ColorFormatType.HSLA, value: color }
+        : { formatType: ColorFormatType.HSL, value: color };
+    }
+
+    if ('l' in color && 'c' in color) {
+      const { l, c, h } = color;
+      if (l <= 1) {
+        const oklch: ColorOKLCH = { l, c, h };
+        return { formatType: ColorFormatType.OKLCH, value: oklch };
+      }
+      const lch: ColorLCH = { l, c, h };
+      return { formatType: ColorFormatType.LCH, value: lch };
+    }
   }
 
   if ('a' in color) {

--- a/src/color/validations.ts
+++ b/src/color/validations.ts
@@ -1,4 +1,11 @@
-import { ColorRGBA, ColorHSLA } from './formats';
+import {
+  ColorRGBA,
+  ColorHSLA,
+  ColorHSV,
+  ColorCMYK,
+  ColorLCH,
+  ColorOKLCH,
+} from './formats';
 
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
@@ -35,5 +42,54 @@ export function isValidHSLAColor(color: ColorHSLA): boolean {
     l >= 0 &&
     l <= 100 &&
     (a === undefined || (typeof a === 'number' && a >= 0 && a <= 1))
+  );
+}
+
+export function isValidHSVColor(color: ColorHSV): boolean {
+  const { h, s, v } = color;
+  return (
+    Number.isInteger(h) &&
+    h >= 0 &&
+    h <= 360 &&
+    Number.isInteger(s) &&
+    s >= 0 &&
+    s <= 100 &&
+    Number.isInteger(v) &&
+    v >= 0 &&
+    v <= 100
+  );
+}
+
+export function isValidCMYKColor(color: ColorCMYK): boolean {
+  const { c, m, y, k } = color;
+  const check = (value: number) => typeof value === 'number' && value >= 0 && value <= 100;
+  return [c, m, y, k].every(check);
+}
+
+export function isValidLCHColor(color: ColorLCH): boolean {
+  const { l, c, h } = color;
+  return (
+    typeof l === 'number' &&
+    l >= 0 &&
+    l <= 100 &&
+    typeof c === 'number' &&
+    c >= 0 &&
+    typeof h === 'number' &&
+    h >= 0 &&
+    h <= 360
+  );
+}
+
+export function isValidOKLCHColor(color: ColorOKLCH): boolean {
+  const { l, c, h } = color;
+  return (
+    typeof l === 'number' &&
+    l >= 0 &&
+    l <= 1 &&
+    typeof c === 'number' &&
+    c >= 0 &&
+    typeof h === 'number' &&
+    h >= 0 &&
+    h <= 360
   );
 }


### PR DESCRIPTION
## Summary
- add HSV, CMYK, LCH, and OKLCH color formats
- support converting between all formats and RGBA
- extend Color API and tests for new formats
- remove `any` and simplify format detection to avoid casts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891435087d4832a954dfe51e1bb6db2