### PR TITLE
Add color name classification utility with tests

### DIFF
--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,5 +1,11 @@
 import { Color } from '../color';
-import { getRandomColorRGBA, isColorDark } from '../utils';
+import {
+  getRandomColorRGBA,
+  isColorDark,
+  getBaseColorName,
+  BaseColorName,
+  ColorLightnessModifier,
+} from '../utils';
 import type { ColorHex } from '../formats';
 
 describe('getRandomColorRGBA', () => {
@@ -167,5 +173,73 @@ describe('isColorDark', () => {
 
   it.each(cases)('classifies %s correctly', (hex, expected) => {
     expect(isColorDark(new Color(hex))).toBe(expected);
+  });
+});
+
+describe('getBaseColorName', () => {
+  const cases: Array<[ColorHex, BaseColorName, ColorLightnessModifier]> = [
+    ['#660000', BaseColorName.Red, ColorLightnessModifier.Dark],
+    ['#ff0000', BaseColorName.Red, ColorLightnessModifier.Normal],
+    ['#ff9999', BaseColorName.Red, ColorLightnessModifier.Light],
+    ['#663300', BaseColorName.Orange, ColorLightnessModifier.Dark],
+    ['#ff8000', BaseColorName.Orange, ColorLightnessModifier.Normal],
+    ['#ffcc99', BaseColorName.Orange, ColorLightnessModifier.Light],
+    ['#666600', BaseColorName.Yellow, ColorLightnessModifier.Dark],
+    ['#ffff00', BaseColorName.Yellow, ColorLightnessModifier.Normal],
+    ['#ffff99', BaseColorName.Yellow, ColorLightnessModifier.Light],
+    ['#006600', BaseColorName.Green, ColorLightnessModifier.Dark],
+    ['#00ff00', BaseColorName.Green, ColorLightnessModifier.Normal],
+    ['#99ff99', BaseColorName.Green, ColorLightnessModifier.Light],
+    ['#002266', BaseColorName.Blue, ColorLightnessModifier.Dark],
+    ['#0055ff', BaseColorName.Blue, ColorLightnessModifier.Normal],
+    ['#99bbff', BaseColorName.Blue, ColorLightnessModifier.Light],
+    ['#330066', BaseColorName.Purple, ColorLightnessModifier.Dark],
+    ['#8000ff', BaseColorName.Purple, ColorLightnessModifier.Normal],
+    ['#cc99ff', BaseColorName.Purple, ColorLightnessModifier.Light],
+    ['#660033', BaseColorName.Pink, ColorLightnessModifier.Dark],
+    ['#ff0080', BaseColorName.Pink, ColorLightnessModifier.Normal],
+    ['#ff99cc', BaseColorName.Pink, ColorLightnessModifier.Light],
+    ['#333333', BaseColorName.Gray, ColorLightnessModifier.Dark],
+    ['#808080', BaseColorName.Gray, ColorLightnessModifier.Normal],
+    ['#cccccc', BaseColorName.Gray, ColorLightnessModifier.Light],
+    ['#000000', BaseColorName.Black, ColorLightnessModifier.Normal],
+    ['#ffffff', BaseColorName.White, ColorLightnessModifier.Normal],
+  ];
+
+  it.each(cases)(
+    'classifies %s correctly',
+    (hex, expectedName, expectedLightness) => {
+      const result = getBaseColorName(new Color(hex));
+      expect(result).toEqual({ name: expectedName, lightness: expectedLightness });
+    },
+  );
+
+  const boundaryCases: Array<[ColorHex, BaseColorName]> = [
+    ['#ff4000', BaseColorName.Orange], // h=15 -> Orange
+    ['#ffbb00', BaseColorName.Orange], // h=44 -> Orange
+    ['#ffbf00', BaseColorName.Yellow], // h=45 -> Yellow
+    ['#c3ff00', BaseColorName.Yellow], // h=74 -> Yellow
+    ['#bfff00', BaseColorName.Green], // h=75 -> Green
+    ['#00ffbb', BaseColorName.Green], // h=164 -> Green
+    ['#00ffbf', BaseColorName.Blue], // h=165 -> Blue
+    ['#3c00ff', BaseColorName.Blue], // h=254 -> Blue
+    ['#4000ff', BaseColorName.Purple], // h=255 -> Purple
+    ['#bb00ff', BaseColorName.Purple], // h=284 -> Purple
+    ['#bf00ff', BaseColorName.Pink], // h=285 -> Pink
+    ['#ff0044', BaseColorName.Pink], // h=344 -> Pink
+    ['#ff0040', BaseColorName.Red], // h=345 -> Red
+  ];
+
+  it.each(boundaryCases)('handles boundary color %s', (hex, expectedName) => {
+    const result = getBaseColorName(new Color(hex));
+    expect(result.name).toBe(expectedName);
+  });
+
+  it('treats low saturation as gray', () => {
+    const colorful = getBaseColorName(new Color('#718e71')); // s=11
+    expect(colorful.name).toBe(BaseColorName.Green);
+
+    const grayish = getBaseColorName(new Color('#738c73')); // s=10
+    expect(grayish.name).toBe(BaseColorName.Gray);
   });
 });

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -24,3 +24,74 @@ export function isColorDark(color: Color): boolean {
   }
   return brightness < 128;
 }
+
+export enum BaseColorName {
+  Red = 'Red',
+  Orange = 'Orange',
+  Yellow = 'Yellow',
+  Green = 'Green',
+  Blue = 'Blue',
+  Purple = 'Purple',
+  Pink = 'Pink',
+  Black = 'Black',
+  Gray = 'Gray',
+  White = 'White',
+}
+
+export enum ColorLightnessModifier {
+  Light = 'Light',
+  Normal = 'Normal',
+  Dark = 'Dark',
+}
+
+export function getBaseColorName(
+  color: Color,
+): { name: BaseColorName; lightness: ColorLightnessModifier } {
+  const { h, s, l } = color.toHSL();
+
+  if (s <= 10) {
+    if (l <= 10) {
+      return { name: BaseColorName.Black, lightness: ColorLightnessModifier.Normal };
+    }
+    if (l >= 90) {
+      return { name: BaseColorName.White, lightness: ColorLightnessModifier.Normal };
+    }
+    return { name: BaseColorName.Gray, lightness: getLightnessModifier(l) };
+  }
+
+  const name = getHueName(h);
+  const lightness = getLightnessModifier(l);
+  return { name, lightness };
+}
+
+function getLightnessModifier(l: number): ColorLightnessModifier {
+  if (l <= 30) {
+    return ColorLightnessModifier.Dark;
+  }
+  if (l >= 70) {
+    return ColorLightnessModifier.Light;
+  }
+  return ColorLightnessModifier.Normal;
+}
+
+function getHueName(h: number): BaseColorName {
+  if (h < 15 || h >= 345) {
+    return BaseColorName.Red;
+  }
+  if (h < 45) {
+    return BaseColorName.Orange;
+  }
+  if (h < 75) {
+    return BaseColorName.Yellow;
+  }
+  if (h < 165) {
+    return BaseColorName.Green;
+  }
+  if (h < 255) {
+    return BaseColorName.Blue;
+  }
+  if (h < 285) {
+    return BaseColorName.Purple;
+  }
+  return BaseColorName.Pink;
+}


### PR DESCRIPTION
## Summary
- rename enums to `BaseColorName` and `ColorLightnessModifier`
- expose `getBaseColorName` returning lightness metadata
- expand color-name tests with hex inputs and boundary coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898dbad3b40832a8a31a9a000a29187