### PR TITLE
feat: add color harmony utilities

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["OKLCH", "unpivot"]
+  "cSpell.words": ["desaturated", "OKLCH", "unpivot"]
 }

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -1,49 +1,131 @@
 import { Color } from '../color';
 import {
-  getComplementaryColors,
-  getSplitComplementaryColors,
-  getTriadicHarmonyColors,
-  getTetradicHarmonyColors,
   getAnalogousHarmonyColors,
+  getComplementaryColors,
   getMonochromaticHarmonyColors,
+  getSplitComplementaryColors,
+  getSquareHarmonyColors,
+  getTetradicHarmonyColors,
+  getTriadicHarmonyColors,
 } from '../harmonies';
 
 describe('color harmonies', () => {
-  const base = new Color('#ff0000');
+  const red = new Color('#ff0000');
+  const green = new Color('#00ff00');
+  const blue = new Color('#0000ff');
 
   it('computes complementary colors', () => {
-    const [orig, comp] = getComplementaryColors(base);
-    expect(orig.toHex()).toBe('#ff0000');
-    expect(comp.toHex()).toBe('#00ffff');
+    const [redOrig, redComp] = getComplementaryColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redComp.toHex()).toBe('#00ffff');
+
+    const [greenOrig, greenComp] = getComplementaryColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenComp.toHex()).toBe('#ff00ff');
+
+    const [blueOrig, blueComp] = getComplementaryColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueComp.toHex()).toBe('#ffff00');
   });
 
   it('computes split complementary colors', () => {
-    const [orig, c2, c3] = getSplitComplementaryColors(base);
-    expect(orig.toHex()).toBe('#ff0000');
-    expect(c2.toHex()).toBe('#00ff80');
-    expect(c3.toHex()).toBe('#0080ff');
+    const [redOrig, redComp2, redComp3] = getSplitComplementaryColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redComp2.toHex()).toBe('#0080ff');
+    expect(redComp3.toHex()).toBe('#00ff80');
+
+    const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenComp2.toHex()).toBe('#ff0080');
+    expect(greenComp3.toHex()).toBe('#8000ff');
+
+    const [blueOrig, blueComp2, blueComp3] = getSplitComplementaryColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueComp2.toHex()).toBe('#80ff00');
+    expect(blueComp3.toHex()).toBe('#ff8000');
   });
 
   it('computes triadic harmony colors', () => {
-    const [orig, c2, c3] = getTriadicHarmonyColors(base);
-    expect(orig.toHex()).toBe('#ff0000');
-    expect(c2.toHex()).toBe('#00ff00');
-    expect(c3.toHex()).toBe('#0000ff');
+    const [redOrig, redTriad2, redTriad3] = getTriadicHarmonyColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redTriad2.toHex()).toBe('#0000ff');
+    expect(redTriad3.toHex()).toBe('#00ff00');
+
+    const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenTriad2.toHex()).toBe('#ff0000');
+    expect(greenTriad3.toHex()).toBe('#0000ff');
+
+    const [blueOrig, blueTriad2, blueTriad3] = getTriadicHarmonyColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueTriad2.toHex()).toBe('#00ff00');
+    expect(blueTriad3.toHex()).toBe('#ff0000');
+  });
+
+  it('computes square harmony colors', () => {
+    const [redOrig, redSq1, redSq2, redSq3] = getSquareHarmonyColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redSq1.toHex()).toBe('#80ff00');
+    expect(redSq2.toHex()).toBe('#00ffff');
+    expect(redSq3.toHex()).toBe('#8000ff');
+
+    const [greenOrig, greenSq1, greenSq2, greenSq3] = getSquareHarmonyColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenSq1.toHex()).toBe('#0080ff');
+    expect(greenSq2.toHex()).toBe('#ff00ff');
+    expect(greenSq3.toHex()).toBe('#ff8000');
+
+    const [blueOrig, blueSq1, blueSq2, blueSq3] = getSquareHarmonyColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueSq1.toHex()).toBe('#ff0080');
+    expect(blueSq2.toHex()).toBe('#ffff00');
+    expect(blueSq3.toHex()).toBe('#00ff80');
   });
 
   it('computes tetradic harmony colors', () => {
-    const [orig, c2, c3, c4] = getTetradicHarmonyColors(base);
-    expect(orig.toHex()).toBe('#ff0000');
-    expect(c2.toHex()).toBe('#ffff00');
-    expect(c3.toHex()).toBe('#00ffff');
-    expect(c4.toHex()).toBe('#0000ff');
+    const [redOrig, redTet2, redTet3, redTet4] = getTetradicHarmonyColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redTet2.toHex()).toBe('#ffff00');
+    expect(redTet3.toHex()).toBe('#00ffff');
+    expect(redTet4.toHex()).toBe('#0000ff');
+
+    const [greenOrig, greenTet2, greenTet3, greenTet4] = getTetradicHarmonyColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenTet2.toHex()).toBe('#00ffff');
+    expect(greenTet3.toHex()).toBe('#ff00ff');
+    expect(greenTet4.toHex()).toBe('#ff0000');
+
+    const [blueOrig, blueTet2, blueTet3, blueTet4] = getTetradicHarmonyColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueTet2.toHex()).toBe('#ff00ff');
+    expect(blueTet3.toHex()).toBe('#ffff00');
+    expect(blueTet4.toHex()).toBe('#00ff00');
   });
 
   it('computes analogous harmony colors', () => {
-    const [orig, c2, c3] = getAnalogousHarmonyColors(base);
-    expect(orig.toHex()).toBe('#ff0000');
-    expect(c2.toHex()).toBe('#ff0080');
-    expect(c3.toHex()).toBe('#ff8000');
+    const [redOrig, redAnalog2, redAnalog3, redAnalog4, redAnalog5] =
+      getAnalogousHarmonyColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redAnalog2.toHex()).toBe('#ff0080');
+    expect(redAnalog3.toHex()).toBe('#ff8000');
+    expect(redAnalog4.toHex()).toBe('#ff00ff');
+    expect(redAnalog5.toHex()).toBe('#ffff00');
+
+    const [greenOrig, greenAnalog2, greenAnalog3, greenAnalog4, greenAnalog5] =
+      getAnalogousHarmonyColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenAnalog2.toHex()).toBe('#80ff00');
+    expect(greenAnalog3.toHex()).toBe('#00ff80');
+    expect(greenAnalog4.toHex()).toBe('#ffff00');
+    expect(greenAnalog5.toHex()).toBe('#00ffff');
+
+    const [blueOrig, blueAnalog2, blueAnalog3, blueAnalog4, blueAnalog5] =
+      getAnalogousHarmonyColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueAnalog2.toHex()).toBe('#0080ff');
+    expect(blueAnalog3.toHex()).toBe('#8000ff');
+    expect(blueAnalog4.toHex()).toBe('#00ffff');
+    expect(blueAnalog5.toHex()).toBe('#ff00ff');
   });
 
   it('computes monochromatic harmony colors', () => {
@@ -55,5 +137,28 @@ describe('color harmonies', () => {
     expect(darker.toHSL()).toEqual({ h: 210, s: 59, l: 30 });
     expect(saturated.toHSL()).toEqual({ h: 210, s: 80, l: 50 });
     expect(desaturated.toHSL()).toEqual({ h: 210, s: 40, l: 50 });
+
+    const [redOrig, redMono2, redMono3, redMono4, redMono5] = getMonochromaticHarmonyColors(red);
+    expect(redOrig.toHex()).toBe('#ff0000');
+    expect(redMono2.toHex()).toBe('#ff6666');
+    expect(redMono3.toHex()).toBe('#990000');
+    expect(redMono4.toHex()).toBe('#ff0000');
+    expect(redMono5.toHex()).toBe('#e61919');
+
+    const [greenOrig, greenMono2, greenMono3, greenMono4, greenMono5] =
+      getMonochromaticHarmonyColors(green);
+    expect(greenOrig.toHex()).toBe('#00ff00');
+    expect(greenMono2.toHex()).toBe('#66ff66');
+    expect(greenMono3.toHex()).toBe('#009900');
+    expect(greenMono4.toHex()).toBe('#00ff00');
+    expect(greenMono5.toHex()).toBe('#19e619');
+
+    const [blueOrig, blueMono2, blueMono3, blueMono4, blueMono5] =
+      getMonochromaticHarmonyColors(blue);
+    expect(blueOrig.toHex()).toBe('#0000ff');
+    expect(blueMono2.toHex()).toBe('#6666ff');
+    expect(blueMono3.toHex()).toBe('#000099');
+    expect(blueMono4.toHex()).toBe('#0000ff');
+    expect(blueMono5.toHex()).toBe('#1919e6');
   });
 });

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -2,39 +2,43 @@ import { Color } from './color';
 
 // TODO: consider using LCH or OKLCH space mode for more human perceptual accuracy
 
-function clamp(value: number, min = 0, max = 100): number {
-  return Math.min(Math.max(value, min), max);
-}
-
 export function getComplementaryColors(color: Color): [Color, Color] {
   return [color.clone(), color.spin(180)];
 }
 
 export function getSplitComplementaryColors(color: Color): [Color, Color, Color] {
-  return [color.clone(), color.spin(150), color.spin(-150)];
+  return [color.clone(), color.spin(-150), color.spin(150)];
 }
 
 export function getTriadicHarmonyColors(color: Color): [Color, Color, Color] {
-  return [color.clone(), color.spin(120), color.spin(-120)];
+  return [color.clone(), color.spin(-120), color.spin(120)];
 }
 
-export function getTetradicHarmonyColors(
-  color: Color,
-): [Color, Color, Color, Color] {
+export function getSquareHarmonyColors(color: Color): [Color, Color, Color, Color] {
+  return [color.clone(), color.spin(90), color.spin(180), color.spin(270)];
+}
+
+export function getTetradicHarmonyColors(color: Color): [Color, Color, Color, Color] {
+  // TODO: tetradic harmonies can also be "wide" (120, 180, 300) or go in the other direction, or potentially any rectangle
+  // e.g. #0000ff => #0000ff, #ff00ff, #ffff00, #00ff00
+  // vs.  #0000ff => #0000ff, #00ffff, #ffff00, #ff0000
   return [color.clone(), color.spin(60), color.spin(180), color.spin(240)];
 }
 
-export function getAnalogousHarmonyColors(color: Color): [Color, Color, Color] {
-  return [color.clone(), color.spin(-30), color.spin(30)];
+export function getAnalogousHarmonyColors(color: Color): [Color, Color, Color, Color, Color] {
+  // TODO: verify, because other libraries seem to have a slightly narrower angle
+  return [color.clone(), color.spin(-30), color.spin(30), color.spin(-60), color.spin(60)];
 }
 
-export function getMonochromaticHarmonyColors(
-  color: Color,
-): [Color, Color, Color, Color, Color] {
+function clampValue0To100(value: number): number {
+  return Math.min(Math.max(value, 0), 100);
+}
+
+export function getMonochromaticHarmonyColors(color: Color): [Color, Color, Color, Color, Color] {
   const hsl = color.toHSL();
-  const lighter = new Color({ ...hsl, l: clamp(hsl.l + 20) });
-  const darker = new Color({ ...hsl, l: clamp(hsl.l - 20) });
-  const saturated = new Color({ ...hsl, s: clamp(hsl.s + 20) });
-  const desaturated = new Color({ ...hsl, s: clamp(hsl.s - 20) });
+  const lighter = new Color({ ...hsl, l: clampValue0To100(hsl.l + 20) });
+  const darker = new Color({ ...hsl, l: clampValue0To100(hsl.l - 20) });
+  const saturated = new Color({ ...hsl, s: clampValue0To100(hsl.s + 20) });
+  const desaturated = new Color({ ...hsl, s: clampValue0To100(hsl.s - 20) });
   return [color.clone(), lighter, darker, saturated, desaturated];
 }


### PR DESCRIPTION
## Summary
- add split complementary, triadic, tetradic, analogous and monochromatic harmony helpers
- cover all harmony helpers with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a0e9ebcc0832a9750b714a026c915