### PR TITLE
test: add palette variation coverage

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -330,6 +330,22 @@ describe('Color.getMonochromaticHarmonyColors', () => {
   });
 });
 
+describe('Color.getColorSwatch', () => {
+  it('returns the correct swatch for a color', () => {
+    const baseColor = new Color('#625aa5');
+    const swatch = baseColor.getColorSwatch();
+    expect(swatch[100].toHex()).toBe('#dcd9f2');
+    expect(swatch[200].toHex()).toBe('#bab6e2');
+    expect(swatch[300].toHex()).toBe('#9b95d0');
+    expect(swatch[400].toHex()).toBe('#7d76bc');
+    expect(swatch[500].toHex()).toBe('#625aa5');
+    expect(swatch[600].toHex()).toBe('#524e7e');
+    expect(swatch[700].toHex()).toBe('#413e5b');
+    expect(swatch[800].toHex()).toBe('#2d2c3a');
+    expect(swatch[900].toHex()).toBe('#18171c');
+  });
+});
+
 describe('Color.isDark sanity check', () => {
   it('identifies dark and light colors', () => {
     expect(new Color('#000000').isDark()).toBe(true);

--- a/src/color/__test__/palette.test.ts
+++ b/src/color/__test__/palette.test.ts
@@ -1,0 +1,163 @@
+import { Color } from '../color';
+
+describe('getPaletteColorVariations', () => {
+  describe('black', () => {
+    it('returns grayscale steps', () => {
+      const base = new Color('#000000');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#666666');
+      expect(palette[200].toHex()).toBe('#4d4d4d');
+      expect(palette[300].toHex()).toBe('#333333');
+      expect(palette[400].toHex()).toBe('#1a1a1a');
+      expect(palette[500].toHex()).toBe('#000000');
+      expect(palette[600].toHex()).toBe('#000000');
+      expect(palette[700].toHex()).toBe('#000000');
+      expect(palette[800].toHex()).toBe('#000000');
+      expect(palette[900].toHex()).toBe('#000000');
+    });
+  });
+
+  describe('white', () => {
+    it('returns darker grays for higher numbers', () => {
+      const base = new Color('#ffffff');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ffffff');
+      expect(palette[200].toHex()).toBe('#ffffff');
+      expect(palette[300].toHex()).toBe('#ffffff');
+      expect(palette[400].toHex()).toBe('#ffffff');
+      expect(palette[500].toHex()).toBe('#ffffff');
+      expect(palette[600].toHex()).toBe('#e6e6e6');
+      expect(palette[700].toHex()).toBe('#cccccc');
+      expect(palette[800].toHex()).toBe('#b3b3b3');
+      expect(palette[900].toHex()).toBe('#999999');
+    });
+  });
+
+  describe('gray', () => {
+    it('keeps shades neutral', () => {
+      const base = new Color('#808080');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#e6e6e6');
+      expect(palette[200].toHex()).toBe('#cccccc');
+      expect(palette[300].toHex()).toBe('#b3b3b3');
+      expect(palette[400].toHex()).toBe('#999999');
+      expect(palette[500].toHex()).toBe('#808080');
+      expect(palette[600].toHex()).toBe('#666666');
+      expect(palette[700].toHex()).toBe('#4d4d4d');
+      expect(palette[800].toHex()).toBe('#333333');
+      expect(palette[900].toHex()).toBe('#1a1a1a');
+    });
+  });
+
+  describe('dark navy', () => {
+    it('spans from vibrant blue to black', () => {
+      const base = new Color('#123456');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#4299f0');
+      expect(palette[200].toHex()).toBe('#1980e6');
+      expect(palette[300].toHex()).toBe('#1966b3');
+      expect(palette[400].toHex()).toBe('#174d82');
+      expect(palette[500].toHex()).toBe('#123456');
+      expect(palette[600].toHex()).toBe('#0a1a29');
+      expect(palette[700].toHex()).toBe('#000000');
+      expect(palette[800].toHex()).toBe('#000000');
+      expect(palette[900].toHex()).toBe('#000000');
+    });
+  });
+
+  describe('pastel blue', () => {
+    it('lightens up to white and darkens gradually', () => {
+      const base = new Color('#abcdef');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ffffff');
+      expect(palette[200].toHex()).toBe('#ffffff');
+      expect(palette[300].toHex()).toBe('#ffffff');
+      expect(palette[400].toHex()).toBe('#d3e6f8');
+      expect(palette[500].toHex()).toBe('#abcdef');
+      expect(palette[600].toHex()).toBe('#82b3e3');
+      expect(palette[700].toHex()).toBe('#5e99d4');
+      expect(palette[800].toHex()).toBe('#3c80c3');
+      expect(palette[900].toHex()).toBe('#356697');
+    });
+  });
+
+  describe('red', () => {
+    it('creates a classic red palette', () => {
+      const base = new Color('#ff0000');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ffcccc');
+      expect(palette[200].toHex()).toBe('#ff9999');
+      expect(palette[300].toHex()).toBe('#ff6666');
+      expect(palette[400].toHex()).toBe('#ff3333');
+      expect(palette[500].toHex()).toBe('#ff0000');
+      expect(palette[600].toHex()).toBe('#c70505');
+      expect(palette[700].toHex()).toBe('#910808');
+      expect(palette[800].toHex()).toBe('#5e0808');
+      expect(palette[900].toHex()).toBe('#2e0505');
+    });
+  });
+
+  describe('green', () => {
+    it('creates a classic green palette', () => {
+      const base = new Color('#00ff00');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ccffcc');
+      expect(palette[200].toHex()).toBe('#99ff99');
+      expect(palette[300].toHex()).toBe('#66ff66');
+      expect(palette[400].toHex()).toBe('#33ff33');
+      expect(palette[500].toHex()).toBe('#00ff00');
+      expect(palette[600].toHex()).toBe('#05c705');
+      expect(palette[700].toHex()).toBe('#089108');
+      expect(palette[800].toHex()).toBe('#085e08');
+      expect(palette[900].toHex()).toBe('#052e05');
+    });
+  });
+
+  describe('blue', () => {
+    it('creates a classic blue palette', () => {
+      const base = new Color('#0000ff');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ccccff');
+      expect(palette[200].toHex()).toBe('#9999ff');
+      expect(palette[300].toHex()).toBe('#6666ff');
+      expect(palette[400].toHex()).toBe('#3333ff');
+      expect(palette[500].toHex()).toBe('#0000ff');
+      expect(palette[600].toHex()).toBe('#0505c7');
+      expect(palette[700].toHex()).toBe('#080891');
+      expect(palette[800].toHex()).toBe('#08085e');
+      expect(palette[900].toHex()).toBe('#05052e');
+    });
+  });
+
+  describe('greyish teal', () => {
+    it('retains its muted character', () => {
+      const base = new Color('#7f8c8d');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#e9f1f2');
+      expect(palette[200].toHex()).toBe('#cbdcdd');
+      expect(palette[300].toHex()).toBe('#afc4c5');
+      expect(palette[400].toHex()).toBe('#96aaab');
+      expect(palette[500].toHex()).toBe('#7f8c8d');
+      expect(palette[600].toHex()).toBe('#6d6f6f');
+      expect(palette[700].toHex()).toBe('#545454');
+      expect(palette[800].toHex()).toBe('#3b3b3b');
+      expect(palette[900].toHex()).toBe('#212121');
+    });
+  });
+
+  describe('brand blue', () => {
+    it('spans a useful design range', () => {
+      const base = new Color('#3498db');
+      const palette = base.getPaletteColorVariations();
+      expect(palette[100].toHex()).toBe('#ddf0fd');
+      expect(palette[200].toHex()).toBe('#afdbf8');
+      expect(palette[300].toHex()).toBe('#83c5f1');
+      expect(palette[400].toHex()).toBe('#5aafe7');
+      expect(palette[500].toHex()).toBe('#3498db');
+      expect(palette[600].toHex()).toBe('#267cb5');
+      expect(palette[700].toHex()).toBe('#225e87');
+      expect(palette[800].toHex()).toBe('#1a415b');
+      expect(palette[900].toHex()).toBe('#112432');
+    });
+  });
+});

--- a/src/color/__test__/palette.test.ts
+++ b/src/color/__test__/palette.test.ts
@@ -1,163 +1,164 @@
 import { Color } from '../color';
+import { getColorSwatch } from '../palette';
 
 describe('getPaletteColorVariations', () => {
   describe('black', () => {
     it('returns grayscale steps', () => {
-      const base = new Color('#000000');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#666666');
-      expect(palette[200].toHex()).toBe('#4d4d4d');
-      expect(palette[300].toHex()).toBe('#333333');
-      expect(palette[400].toHex()).toBe('#1a1a1a');
-      expect(palette[500].toHex()).toBe('#000000');
-      expect(palette[600].toHex()).toBe('#000000');
-      expect(palette[700].toHex()).toBe('#000000');
-      expect(palette[800].toHex()).toBe('#000000');
-      expect(palette[900].toHex()).toBe('#000000');
+      const baseColor = new Color('#000000');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#666666');
+      expect(swatch[200].toHex()).toBe('#4d4d4d');
+      expect(swatch[300].toHex()).toBe('#333333');
+      expect(swatch[400].toHex()).toBe('#1a1a1a');
+      expect(swatch[500].toHex()).toBe('#000000');
+      expect(swatch[600].toHex()).toBe('#000000');
+      expect(swatch[700].toHex()).toBe('#000000');
+      expect(swatch[800].toHex()).toBe('#000000');
+      expect(swatch[900].toHex()).toBe('#000000');
     });
   });
 
   describe('white', () => {
     it('returns darker grays for higher numbers', () => {
-      const base = new Color('#ffffff');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ffffff');
-      expect(palette[200].toHex()).toBe('#ffffff');
-      expect(palette[300].toHex()).toBe('#ffffff');
-      expect(palette[400].toHex()).toBe('#ffffff');
-      expect(palette[500].toHex()).toBe('#ffffff');
-      expect(palette[600].toHex()).toBe('#e6e6e6');
-      expect(palette[700].toHex()).toBe('#cccccc');
-      expect(palette[800].toHex()).toBe('#b3b3b3');
-      expect(palette[900].toHex()).toBe('#999999');
+      const baseColor = new Color('#ffffff');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ffffff');
+      expect(swatch[200].toHex()).toBe('#ffffff');
+      expect(swatch[300].toHex()).toBe('#ffffff');
+      expect(swatch[400].toHex()).toBe('#ffffff');
+      expect(swatch[500].toHex()).toBe('#ffffff');
+      expect(swatch[600].toHex()).toBe('#e6e6e6');
+      expect(swatch[700].toHex()).toBe('#cccccc');
+      expect(swatch[800].toHex()).toBe('#b3b3b3');
+      expect(swatch[900].toHex()).toBe('#999999');
     });
   });
 
   describe('gray', () => {
     it('keeps shades neutral', () => {
-      const base = new Color('#808080');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#e6e6e6');
-      expect(palette[200].toHex()).toBe('#cccccc');
-      expect(palette[300].toHex()).toBe('#b3b3b3');
-      expect(palette[400].toHex()).toBe('#999999');
-      expect(palette[500].toHex()).toBe('#808080');
-      expect(palette[600].toHex()).toBe('#666666');
-      expect(palette[700].toHex()).toBe('#4d4d4d');
-      expect(palette[800].toHex()).toBe('#333333');
-      expect(palette[900].toHex()).toBe('#1a1a1a');
+      const baseColor = new Color('#808080');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#e6e6e6');
+      expect(swatch[200].toHex()).toBe('#cccccc');
+      expect(swatch[300].toHex()).toBe('#b3b3b3');
+      expect(swatch[400].toHex()).toBe('#999999');
+      expect(swatch[500].toHex()).toBe('#808080');
+      expect(swatch[600].toHex()).toBe('#666666');
+      expect(swatch[700].toHex()).toBe('#4d4d4d');
+      expect(swatch[800].toHex()).toBe('#333333');
+      expect(swatch[900].toHex()).toBe('#1a1a1a');
     });
   });
 
   describe('dark navy', () => {
     it('spans from vibrant blue to black', () => {
-      const base = new Color('#123456');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#4299f0');
-      expect(palette[200].toHex()).toBe('#1980e6');
-      expect(palette[300].toHex()).toBe('#1966b3');
-      expect(palette[400].toHex()).toBe('#174d82');
-      expect(palette[500].toHex()).toBe('#123456');
-      expect(palette[600].toHex()).toBe('#0a1a29');
-      expect(palette[700].toHex()).toBe('#000000');
-      expect(palette[800].toHex()).toBe('#000000');
-      expect(palette[900].toHex()).toBe('#000000');
+      const baseColor = new Color('#123456');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#4299f0');
+      expect(swatch[200].toHex()).toBe('#1980e6');
+      expect(swatch[300].toHex()).toBe('#1966b3');
+      expect(swatch[400].toHex()).toBe('#174d82');
+      expect(swatch[500].toHex()).toBe('#123456');
+      expect(swatch[600].toHex()).toBe('#0a1a29');
+      expect(swatch[700].toHex()).toBe('#000000');
+      expect(swatch[800].toHex()).toBe('#000000');
+      expect(swatch[900].toHex()).toBe('#000000');
     });
   });
 
   describe('pastel blue', () => {
     it('lightens up to white and darkens gradually', () => {
-      const base = new Color('#abcdef');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ffffff');
-      expect(palette[200].toHex()).toBe('#ffffff');
-      expect(palette[300].toHex()).toBe('#ffffff');
-      expect(palette[400].toHex()).toBe('#d3e6f8');
-      expect(palette[500].toHex()).toBe('#abcdef');
-      expect(palette[600].toHex()).toBe('#82b3e3');
-      expect(palette[700].toHex()).toBe('#5e99d4');
-      expect(palette[800].toHex()).toBe('#3c80c3');
-      expect(palette[900].toHex()).toBe('#356697');
+      const baseColor = new Color('#abcdef');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ffffff');
+      expect(swatch[200].toHex()).toBe('#ffffff');
+      expect(swatch[300].toHex()).toBe('#ffffff');
+      expect(swatch[400].toHex()).toBe('#d3e6f8');
+      expect(swatch[500].toHex()).toBe('#abcdef');
+      expect(swatch[600].toHex()).toBe('#82b3e3');
+      expect(swatch[700].toHex()).toBe('#5e99d4');
+      expect(swatch[800].toHex()).toBe('#3c80c3');
+      expect(swatch[900].toHex()).toBe('#356697');
     });
   });
 
   describe('red', () => {
     it('creates a classic red palette', () => {
-      const base = new Color('#ff0000');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ffcccc');
-      expect(palette[200].toHex()).toBe('#ff9999');
-      expect(palette[300].toHex()).toBe('#ff6666');
-      expect(palette[400].toHex()).toBe('#ff3333');
-      expect(palette[500].toHex()).toBe('#ff0000');
-      expect(palette[600].toHex()).toBe('#c70505');
-      expect(palette[700].toHex()).toBe('#910808');
-      expect(palette[800].toHex()).toBe('#5e0808');
-      expect(palette[900].toHex()).toBe('#2e0505');
+      const baseColor = new Color('#ff0000');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ffcccc');
+      expect(swatch[200].toHex()).toBe('#ff9999');
+      expect(swatch[300].toHex()).toBe('#ff6666');
+      expect(swatch[400].toHex()).toBe('#ff3333');
+      expect(swatch[500].toHex()).toBe('#ff0000');
+      expect(swatch[600].toHex()).toBe('#c70505');
+      expect(swatch[700].toHex()).toBe('#910808');
+      expect(swatch[800].toHex()).toBe('#5e0808');
+      expect(swatch[900].toHex()).toBe('#2e0505');
     });
   });
 
   describe('green', () => {
     it('creates a classic green palette', () => {
-      const base = new Color('#00ff00');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ccffcc');
-      expect(palette[200].toHex()).toBe('#99ff99');
-      expect(palette[300].toHex()).toBe('#66ff66');
-      expect(palette[400].toHex()).toBe('#33ff33');
-      expect(palette[500].toHex()).toBe('#00ff00');
-      expect(palette[600].toHex()).toBe('#05c705');
-      expect(palette[700].toHex()).toBe('#089108');
-      expect(palette[800].toHex()).toBe('#085e08');
-      expect(palette[900].toHex()).toBe('#052e05');
+      const baseColor = new Color('#00ff00');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ccffcc');
+      expect(swatch[200].toHex()).toBe('#99ff99');
+      expect(swatch[300].toHex()).toBe('#66ff66');
+      expect(swatch[400].toHex()).toBe('#33ff33');
+      expect(swatch[500].toHex()).toBe('#00ff00');
+      expect(swatch[600].toHex()).toBe('#05c705');
+      expect(swatch[700].toHex()).toBe('#089108');
+      expect(swatch[800].toHex()).toBe('#085e08');
+      expect(swatch[900].toHex()).toBe('#052e05');
     });
   });
 
   describe('blue', () => {
     it('creates a classic blue palette', () => {
-      const base = new Color('#0000ff');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ccccff');
-      expect(palette[200].toHex()).toBe('#9999ff');
-      expect(palette[300].toHex()).toBe('#6666ff');
-      expect(palette[400].toHex()).toBe('#3333ff');
-      expect(palette[500].toHex()).toBe('#0000ff');
-      expect(palette[600].toHex()).toBe('#0505c7');
-      expect(palette[700].toHex()).toBe('#080891');
-      expect(palette[800].toHex()).toBe('#08085e');
-      expect(palette[900].toHex()).toBe('#05052e');
+      const baseColor = new Color('#0000ff');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ccccff');
+      expect(swatch[200].toHex()).toBe('#9999ff');
+      expect(swatch[300].toHex()).toBe('#6666ff');
+      expect(swatch[400].toHex()).toBe('#3333ff');
+      expect(swatch[500].toHex()).toBe('#0000ff');
+      expect(swatch[600].toHex()).toBe('#0505c7');
+      expect(swatch[700].toHex()).toBe('#080891');
+      expect(swatch[800].toHex()).toBe('#08085e');
+      expect(swatch[900].toHex()).toBe('#05052e');
     });
   });
 
   describe('greyish teal', () => {
     it('retains its muted character', () => {
-      const base = new Color('#7f8c8d');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#e9f1f2');
-      expect(palette[200].toHex()).toBe('#cbdcdd');
-      expect(palette[300].toHex()).toBe('#afc4c5');
-      expect(palette[400].toHex()).toBe('#96aaab');
-      expect(palette[500].toHex()).toBe('#7f8c8d');
-      expect(palette[600].toHex()).toBe('#6d6f6f');
-      expect(palette[700].toHex()).toBe('#545454');
-      expect(palette[800].toHex()).toBe('#3b3b3b');
-      expect(palette[900].toHex()).toBe('#212121');
+      const baseColor = new Color('#7f8c8d');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#e9f1f2');
+      expect(swatch[200].toHex()).toBe('#cbdcdd');
+      expect(swatch[300].toHex()).toBe('#afc4c5');
+      expect(swatch[400].toHex()).toBe('#96aaab');
+      expect(swatch[500].toHex()).toBe('#7f8c8d');
+      expect(swatch[600].toHex()).toBe('#6d6f6f');
+      expect(swatch[700].toHex()).toBe('#545454');
+      expect(swatch[800].toHex()).toBe('#3b3b3b');
+      expect(swatch[900].toHex()).toBe('#212121');
     });
   });
 
   describe('brand blue', () => {
     it('spans a useful design range', () => {
-      const base = new Color('#3498db');
-      const palette = base.getPaletteColorVariations();
-      expect(palette[100].toHex()).toBe('#ddf0fd');
-      expect(palette[200].toHex()).toBe('#afdbf8');
-      expect(palette[300].toHex()).toBe('#83c5f1');
-      expect(palette[400].toHex()).toBe('#5aafe7');
-      expect(palette[500].toHex()).toBe('#3498db');
-      expect(palette[600].toHex()).toBe('#267cb5');
-      expect(palette[700].toHex()).toBe('#225e87');
-      expect(palette[800].toHex()).toBe('#1a415b');
-      expect(palette[900].toHex()).toBe('#112432');
+      const baseColor = new Color('#3498db');
+      const swatch = getColorSwatch(baseColor);
+      expect(swatch[100].toHex()).toBe('#ddf0fd');
+      expect(swatch[200].toHex()).toBe('#afdbf8');
+      expect(swatch[300].toHex()).toBe('#83c5f1');
+      expect(swatch[400].toHex()).toBe('#5aafe7');
+      expect(swatch[500].toHex()).toBe('#3498db');
+      expect(swatch[600].toHex()).toBe('#267cb5');
+      expect(swatch[700].toHex()).toBe('#225e87');
+      expect(swatch[800].toHex()).toBe('#1a415b');
+      expect(swatch[900].toHex()).toBe('#112432');
     });
   });
 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -41,7 +41,7 @@ import {
   spinColorHue,
 } from './manipulations';
 import { ColorLightnessModifier, ColorNameAndLightness, getBaseColorName } from './names';
-import { getPaletteColorVariations, PaletteColorVariations } from './palette';
+import { ColorSwatch, getColorSwatch } from './palette';
 import { getColorRGBAFromInput, isColorDark } from './utils';
 
 export class Color {
@@ -159,8 +159,8 @@ export class Color {
     return getMonochromaticHarmonyColors(this);
   }
 
-  getPaletteColorVariations(): PaletteColorVariations {
-    return getPaletteColorVariations(this);
+  getColorSwatch(): ColorSwatch {
+    return getColorSwatch(this);
   }
 
   isDark(): boolean {

--- a/src/color/palette.ts
+++ b/src/color/palette.ts
@@ -1,7 +1,7 @@
 import { getConstrainedValue } from '../utils';
 import { Color } from './color';
 
-export interface PaletteColorVariations {
+export interface ColorSwatch {
   100: Color; // light
   200: Color;
   300: Color;
@@ -13,50 +13,58 @@ export interface PaletteColorVariations {
   900: Color; // dark
 }
 
-export function getPaletteColorVariations(baseColor: Color): PaletteColorVariations {
+function getAdjustedSaturation(baseSaturation: number, delta: number): number {
+  // For cases with no saturation, do not increase it any more since for black or gray
+  // colors, that would result in going from grayscale to an unrelated color:
+  if (baseSaturation === 0) {
+    return baseSaturation;
+  }
+
+  return getConstrainedValue(baseSaturation + delta, 0, 100);
+}
+
+export function getColorSwatch(baseColor: Color): ColorSwatch {
   const { h: baseH, s: baseS, l: baseL } = baseColor.toHSL();
-  const getAdjustedS = (delta: number): number =>
-    baseS === 0 ? 0 : getConstrainedValue(baseS + delta, 0, 100);
   return {
     100: new Color({
       h: baseH,
-      s: getAdjustedS(20),
+      s: getAdjustedSaturation(baseS, 20),
       l: getConstrainedValue(baseL + 40, 0, 100),
     }),
     200: new Color({
       h: baseH,
-      s: getAdjustedS(15),
+      s: getAdjustedSaturation(baseS, 15),
       l: getConstrainedValue(baseL + 30, 0, 100),
     }),
     300: new Color({
       h: baseH,
-      s: getAdjustedS(10),
+      s: getAdjustedSaturation(baseS, 10),
       l: getConstrainedValue(baseL + 20, 0, 100),
     }),
     400: new Color({
       h: baseH,
-      s: getAdjustedS(5),
+      s: getAdjustedSaturation(baseS, 5),
       l: getConstrainedValue(baseL + 10, 0, 100),
     }),
     500: baseColor.clone(),
     600: new Color({
       h: baseH,
-      s: getAdjustedS(-5),
+      s: getAdjustedSaturation(baseS, -5),
       l: getConstrainedValue(baseL - 10, 0, 100),
     }),
     700: new Color({
       h: baseH,
-      s: getAdjustedS(-10),
+      s: getAdjustedSaturation(baseS, -10),
       l: getConstrainedValue(baseL - 20, 0, 100),
     }),
     800: new Color({
       h: baseH,
-      s: getAdjustedS(-15),
+      s: getAdjustedSaturation(baseS, -15),
       l: getConstrainedValue(baseL - 30, 0, 100),
     }),
     900: new Color({
       h: baseH,
-      s: getAdjustedS(-20),
+      s: getAdjustedSaturation(baseS, -20),
       l: getConstrainedValue(baseL - 40, 0, 100),
     }),
   };

--- a/src/color/palette.ts
+++ b/src/color/palette.ts
@@ -15,46 +15,48 @@ export interface PaletteColorVariations {
 
 export function getPaletteColorVariations(baseColor: Color): PaletteColorVariations {
   const { h: baseH, s: baseS, l: baseL } = baseColor.toHSL();
+  const getAdjustedS = (delta: number): number =>
+    baseS === 0 ? 0 : getConstrainedValue(baseS + delta, 0, 100);
   return {
     100: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS + 20, 0, 100),
+      s: getAdjustedS(20),
       l: getConstrainedValue(baseL + 40, 0, 100),
     }),
     200: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS + 15, 0, 100),
+      s: getAdjustedS(15),
       l: getConstrainedValue(baseL + 30, 0, 100),
     }),
     300: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS + 10, 0, 100),
+      s: getAdjustedS(10),
       l: getConstrainedValue(baseL + 20, 0, 100),
     }),
     400: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS + 5, 0, 100),
+      s: getAdjustedS(5),
       l: getConstrainedValue(baseL + 10, 0, 100),
     }),
     500: baseColor.clone(),
     600: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS - 5, 0, 100),
+      s: getAdjustedS(-5),
       l: getConstrainedValue(baseL - 10, 0, 100),
     }),
     700: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS - 10, 0, 100),
+      s: getAdjustedS(-10),
       l: getConstrainedValue(baseL - 20, 0, 100),
     }),
     800: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS - 15, 0, 100),
+      s: getAdjustedS(-15),
       l: getConstrainedValue(baseL - 30, 0, 100),
     }),
     900: new Color({
       h: baseH,
-      s: getConstrainedValue(baseS - 20, 0, 100),
+      s: getAdjustedS(-20),
       l: getConstrainedValue(baseL - 40, 0, 100),
     }),
   };


### PR DESCRIPTION
## Summary
- ensure palette variations keep grayscale colors neutral
- add thorough tests for `getPaletteColorVariations` across many color cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b272552b0832a8b78fb9441a7e2c6