### PR TITLE
Add CSS string helpers for color conversions

### DIFF
--- a/src/color/__test__/formats.test.ts
+++ b/src/color/__test__/formats.test.ts
@@ -1,0 +1,49 @@
+import { Color } from '../color';
+import {
+  cmykToString,
+  hslaToString,
+  hslToString,
+  lchToString,
+  oklchToString,
+  rgbaToString,
+  rgbToString,
+} from '../formats';
+
+describe('format string helpers', () => {
+  const color = new Color('#ff0000');
+
+  it('generates rgb string', () => {
+    expect(rgbToString(color.toRGB())).toBe('rgb(255, 0, 0)');
+    expect(color.toRGBString()).toBe('rgb(255, 0, 0)');
+  });
+
+  it('generates rgba string', () => {
+    expect(rgbaToString(color.toRGBA())).toBe('rgba(255, 0, 0, 1)');
+    expect(color.toRGBAString()).toBe('rgba(255, 0, 0, 1)');
+  });
+
+  it('generates hsl string', () => {
+    expect(hslToString(color.toHSL())).toBe('hsl(0, 100%, 50%)');
+    expect(color.toHSLString()).toBe('hsl(0, 100%, 50%)');
+  });
+
+  it('generates hsla string', () => {
+    expect(hslaToString(color.toHSLA())).toBe('hsla(0, 100%, 50%, 1)');
+    expect(color.toHSLAString()).toBe('hsla(0, 100%, 50%, 1)');
+  });
+
+  it('generates cmyk string', () => {
+    expect(cmykToString(color.toCMYK())).toBe('cmyk(0%, 100%, 100%, 0%)');
+    expect(color.toCMYKString()).toBe('cmyk(0%, 100%, 100%, 0%)');
+  });
+
+  it('generates lch string', () => {
+    expect(lchToString(color.toLCH())).toBe('lch(53.233% 104.576 40)');
+    expect(color.toLCHString()).toBe('lch(53.233% 104.576 40)');
+  });
+
+  it('generates oklch string', () => {
+    expect(oklchToString(color.toOKLCH())).toBe('oklch(0.627955 0.257683 29.234)');
+    expect(color.toOKLCHString()).toBe('oklch(0.627955 0.257683 29.234)');
+  });
+});

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -11,6 +11,7 @@ import {
   toRGB,
 } from './conversions';
 import {
+  cmykToString,
   ColorCMYK,
   ColorFormat,
   ColorHex,
@@ -22,6 +23,12 @@ import {
   ColorOKLCH,
   ColorRGB,
   ColorRGBA,
+  hslaToString,
+  hslToString,
+  lchToString,
+  oklchToString,
+  rgbaToString,
+  rgbToString,
 } from './formats';
 import {
   ColorHarmony,
@@ -99,6 +106,34 @@ export class Color {
 
   toOKLCH(): ColorOKLCH {
     return toOKLCH(this.color);
+  }
+
+  toRGBString(): string {
+    return rgbToString(this.toRGB());
+  }
+
+  toRGBAString(): string {
+    return rgbaToString(this.toRGBA());
+  }
+
+  toHSLString(): string {
+    return hslToString(this.toHSL());
+  }
+
+  toHSLAString(): string {
+    return hslaToString(this.toHSLA());
+  }
+
+  toCMYKString(): string {
+    return cmykToString(this.toCMYK());
+  }
+
+  toLCHString(): string {
+    return lchToString(this.toLCH());
+  }
+
+  toOKLCHString(): string {
+    return oklchToString(this.toOKLCH());
   }
 
   getAlpha(): number {

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -108,6 +108,38 @@ function getHexColorFormatType(color: ColorHex): ColorFormatTypeAndValue {
   throw new Error(`[getColorFormatType] unknown color format: "${JSON.stringify(color)}"`);
 }
 
+function format(value: number, digits = 3): number {
+  return +value.toFixed(digits);
+}
+
+export function rgbToString({ r, g, b }: ColorRGB): string {
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+export function rgbaToString({ r, g, b, a }: ColorRGBA): string {
+  return `rgba(${r}, ${g}, ${b}, ${format(a)})`;
+}
+
+export function hslToString({ h, s, l }: ColorHSL): string {
+  return `hsl(${format(h)}, ${format(s)}%, ${format(l)}%)`;
+}
+
+export function hslaToString({ h, s, l, a }: ColorHSLA): string {
+  return `hsla(${format(h)}, ${format(s)}%, ${format(l)}%, ${format(a)})`;
+}
+
+export function cmykToString({ c, m, y, k }: ColorCMYK): string {
+  return `cmyk(${format(c)}%, ${format(m)}%, ${format(y)}%, ${format(k)}%)`;
+}
+
+export function lchToString({ l, c, h }: ColorLCH): string {
+  return `lch(${format(l)}% ${format(c)} ${format(h)})`;
+}
+
+export function oklchToString({ l, c, h }: ColorOKLCH): string {
+  return `oklch(${format(l, 6)} ${format(c, 6)} ${format(h)})`;
+}
+
 export function getColorFormatType(color: ColorFormat): ColorFormatTypeAndValue {
   if (typeof color === 'string') {
     return getHexColorFormatType(color);


### PR DESCRIPTION
## Summary
- add stringification helpers for RGB, HSL, CMYK, LCH and OKLCH formats
- expose `to*String` methods on `Color` for CSS color strings
- test string outputs for all supported color spaces

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a134722540832aaaef2659af679f53