### PR TITLE
test: add toXString color tests

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -400,3 +400,16 @@ describe('Color.clone', () => {
     expect(cloned).not.toBe(color);
   });
 });
+
+describe('Color.toXString methods', () => {
+  it('returns string representations of the color', () => {
+    const color = new Color({ ...BASE_RGB, a: 0.5 });
+    expect(color.toRGBString()).toBe('rgb(255, 0, 0)');
+    expect(color.toRGBAString()).toBe('rgba(255, 0, 0, 0.5)');
+    expect(color.toHSLString()).toBe('hsl(0, 100%, 50%)');
+    expect(color.toHSLAString()).toBe('hsla(0, 100%, 50%, 0.5)');
+    expect(color.toCMYKString()).toBe('cmyk(0%, 100%, 100%, 0%)');
+    expect(color.toLCHString()).toBe('lch(53.233% 104.576 40)');
+    expect(color.toOKLCHString()).toBe('oklch(0.627955 0.257683 29.234)');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering Color.toXString string conversion helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb5f5e30832aa7e2976939b6d7ee