### PR TITLE
feat: parse CSS color strings

### DIFF
--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -1,0 +1,90 @@
+import { parseCSSColorFormatString } from '../parse';
+
+describe('parseCSSColorFormatString', () => {
+  describe('rgb and rgba', () => {
+    it('parses rgb with integers', () => {
+      const color = parseCSSColorFormatString('rgb(255, 0, 0)');
+      expect(color?.toRGB()).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it('parses rgb with percentages and whitespace', () => {
+      const color = parseCSSColorFormatString(' rgb(100% , 0% , 0% ) ');
+      expect(color?.toRGB()).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it('parses rgba with decimal alpha', () => {
+      const color = parseCSSColorFormatString('rgba(255,0,0,0.5)');
+      expect(color?.toRGBA()).toEqual({ r: 255, g: 0, b: 0, a: 0.5 });
+    });
+
+    it('parses rgba with percentage alpha and is case insensitive', () => {
+      const color = parseCSSColorFormatString('RGBA(255,0,0,50%)');
+      expect(color?.toRGBA()).toEqual({ r: 255, g: 0, b: 0, a: 0.5 });
+    });
+  });
+
+  describe('hsl and hsla', () => {
+    it('parses hsl with degree unit', () => {
+      const color = parseCSSColorFormatString('hsl(120deg, 100%, 25%)');
+      expect(color?.toHSL()).toEqual({ h: 120, s: 100, l: 25 });
+    });
+
+    it('parses hsla with percentage alpha', () => {
+      const color = parseCSSColorFormatString('hsla(240,100%,50%,25%)');
+      expect(color?.toHSLA()).toEqual({ h: 240, s: 100, l: 50, a: 0.25 });
+    });
+  });
+
+  describe('cmyk', () => {
+    it('parses cmyk format', () => {
+      const color = parseCSSColorFormatString('cmyk(0%,100%,100%,0%)');
+      expect(color?.toHex()).toBe('#ff0000');
+    });
+  });
+
+  describe('hsv and hsva', () => {
+    it('parses hsv format', () => {
+      const color = parseCSSColorFormatString('hsv(0,100%,100%)');
+      expect(color?.toHex()).toBe('#ff0000');
+    });
+
+    it('parses hsva format with alpha', () => {
+      const color = parseCSSColorFormatString('hsva(0,100%,100%,50%)');
+      expect(color?.toRGBA()).toEqual({ r: 255, g: 0, b: 0, a: 0.5 });
+    });
+  });
+
+  describe('lch', () => {
+    it('parses lch format with percentage lightness', () => {
+      const color = parseCSSColorFormatString('lch(53.233% 104.576 40)');
+      expect(color?.toHex()).toBe('#ff0000');
+    });
+  });
+
+  describe('oklch', () => {
+    it('parses oklch format', () => {
+      const color = parseCSSColorFormatString('oklch(0.627955 0.257683 29.234)');
+      expect(color?.toHex()).toBe('#ff0000');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    const invalidStrings = [
+      'rgb(300,0,0)',
+      'rgba(0,0,0,2)',
+      'hsl(400,50%,50%)',
+      'hsla(0,0%,0%,200%)',
+      'cmyk(0%,0%,0%,101%)',
+      'lch(120% 0 0)',
+      'oklch(1.1 0 0)',
+      'foo(1,2,3)',
+    ];
+
+    invalidStrings.forEach((str) => {
+      it(`returns null for "${str}"`, () => {
+        expect(parseCSSColorFormatString(str)).toBeNull();
+      });
+    });
+  });
+});
+

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -1,9 +1,143 @@
 import { Color } from './color';
+import type { ColorFormat } from './formats';
+
+function parseNumberOrPercent(value: string, scale: number): number {
+  const num = parseFloat(value);
+  if (isNaN(num)) {
+    return NaN;
+  }
+  return value.trim().endsWith('%') ? (num / 100) * scale : num;
+}
+
+function parseAlpha(value: string): number {
+  const num = parseFloat(value);
+  if (isNaN(num)) {
+    return NaN;
+  }
+  const normalized = value.trim().endsWith('%') ? num / 100 : num;
+  return +normalized.toFixed(3);
+}
 
 export function parseCSSColorFormatString(colorFormatString: string): Color | null {
-  // TODO: implement
-  if (colorFormatString) {
+  if (!colorFormatString) {
     return null;
   }
+
+  const str = colorFormatString.trim().toLowerCase();
+
+  const makeColor = (format: ColorFormat): Color | null => {
+    try {
+      return new Color(format);
+    } catch {
+      return null;
+    }
+  };
+
+  const rgbMatch = str.match(/^rgb\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*\)$/);
+  if (rgbMatch) {
+    const r = Math.round(parseNumberOrPercent(rgbMatch[1], 255));
+    const g = Math.round(parseNumberOrPercent(rgbMatch[2], 255));
+    const b = Math.round(parseNumberOrPercent(rgbMatch[3], 255));
+    if ([r, g, b].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ r, g, b });
+  }
+
+  const rgbaMatch = str.match(/^rgba\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (rgbaMatch) {
+    const r = Math.round(parseNumberOrPercent(rgbaMatch[1], 255));
+    const g = Math.round(parseNumberOrPercent(rgbaMatch[2], 255));
+    const b = Math.round(parseNumberOrPercent(rgbaMatch[3], 255));
+    const a = parseAlpha(rgbaMatch[4]);
+    if ([r, g, b, a].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ r, g, b, a });
+  }
+
+  const hslMatch = str.match(/^hsl\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (hslMatch) {
+    const h = Math.round(parseFloat(hslMatch[1]));
+    const s = Math.round(parseNumberOrPercent(hslMatch[2], 100));
+    const l = Math.round(parseNumberOrPercent(hslMatch[3], 100));
+    if ([h, s, l].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ h, s, l });
+  }
+
+  const hslaMatch = str.match(/^hsla\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (hslaMatch) {
+    const h = Math.round(parseFloat(hslaMatch[1]));
+    const s = Math.round(parseNumberOrPercent(hslaMatch[2], 100));
+    const l = Math.round(parseNumberOrPercent(hslaMatch[3], 100));
+    const a = parseAlpha(hslaMatch[4]);
+    if ([h, s, l, a].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ h, s, l, a });
+  }
+
+  const hsvMatch = str.match(/^hsv\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (hsvMatch) {
+    const h = Math.round(parseFloat(hsvMatch[1]));
+    const s = Math.round(parseNumberOrPercent(hsvMatch[2], 100));
+    const v = Math.round(parseNumberOrPercent(hsvMatch[3], 100));
+    if ([h, s, v].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ h, s, v });
+  }
+
+  const hsvaMatch = str.match(/^hsva\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (hsvaMatch) {
+    const h = Math.round(parseFloat(hsvaMatch[1]));
+    const s = Math.round(parseNumberOrPercent(hsvaMatch[2], 100));
+    const v = Math.round(parseNumberOrPercent(hsvaMatch[3], 100));
+    const a = parseAlpha(hsvaMatch[4]);
+    if ([h, s, v, a].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ h, s, v, a });
+  }
+
+  const cmykMatch = str.match(/^cmyk\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^\)]+)\)$/);
+  if (cmykMatch) {
+    const c = parseNumberOrPercent(cmykMatch[1], 100);
+    const m = parseNumberOrPercent(cmykMatch[2], 100);
+    const y = parseNumberOrPercent(cmykMatch[3], 100);
+    const k = parseNumberOrPercent(cmykMatch[4], 100);
+    if ([c, m, y, k].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ c, m, y, k });
+  }
+
+  const lchMatch = str.match(/^lch\(\s*([^ ]+)\s+([^ ]+)\s+([^\)]+)\)$/);
+  if (lchMatch) {
+    const l = parseNumberOrPercent(lchMatch[1], 100);
+    const c = parseFloat(lchMatch[2]);
+    const h = parseFloat(lchMatch[3]);
+    if ([l, c, h].some((v) => isNaN(v))) {
+      return null;
+    }
+    return makeColor({ l, c, h });
+  }
+
+  const oklchMatch = str.match(/^oklch\(\s*([^ ]+)\s+([^ ]+)\s+([^\)]+)\)$/);
+  if (oklchMatch) {
+    const l = parseFloat(oklchMatch[1]);
+    const c = parseFloat(oklchMatch[2]);
+    const h = parseFloat(oklchMatch[3]);
+    if ([l, c, h].some((v) => isNaN(v))) {
+      return null;
+    }
+    if (l < 0 || l > 1) {
+      return null;
+    }
+    return makeColor({ l, c, h });
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary
- implement robust CSS color string parsing (rgb, rgba, hsl, hsla, hsv, hsva, cmyk, lch, oklch)
- add thorough tests for parsing including edge cases and invalid inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22656bd80832abeb122411f240019