### PR TITLE
test: expand named color format cases

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -163,6 +163,15 @@ describe('Named color support', () => {
   it('throws on unknown color names', () => {
     expect(() => new Color('notacolor')).toThrow();
   });
+
+  it('accepts CSS color format strings', () => {
+    expect(new Color('rgb(255, 0, 0)').toHex()).toEqual('#ff0000');
+    expect(new Color('hsla(0, 100%, 50%, 0.5)').toHex8()).toEqual('#ff000080');
+  });
+
+  it('throws on invalid color format strings', () => {
+    expect(() => new Color('rgb(255, 0)')).toThrow();
+  });
 });
 
 describe('Color.getAlpha', () => {


### PR DESCRIPTION
## Summary
- verify Color handles CSS color format string inputs
- ensure invalid format strings throw

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a24ca5de24832a9aa0c6c74b24e68c