### PR TITLE
Sync playground color with URL query parameter

### DIFF
--- a/demo/src/playground/Playground.tsx
+++ b/demo/src/playground/Playground.tsx
@@ -8,8 +8,35 @@ import { ColorHarmonyDemo } from './ColorHarmonyDemo';
 import { ColorSwatch } from './ColorSwatch';
 import { ColorPaletteDemo } from './ColorPaletteDemo';
 
+function initializeColor(): Color {
+  const params = new URLSearchParams(window.location.search);
+  const colorParam = params.get('color');
+  if (colorParam) {
+    try {
+      return new Color(colorParam);
+    } catch {
+      const fallbackColor = new Color();
+      params.set('color', fallbackColor.toHex());
+      window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+      return fallbackColor;
+    }
+  }
+  return new Color();
+}
+
+function setColorQueryParam(color: Color) {
+  const params = new URLSearchParams(window.location.search);
+  params.set('color', color.toHex());
+  window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+}
+
 export function Playground() {
-  const [color, setColor] = useState<Color>(new Color());
+  const [color, setColorState] = useState<Color>(() => initializeColor());
+
+  const setColor = (newColor: Color) => {
+    setColorState(newColor);
+    setColorQueryParam(newColor);
+  };
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- initialize playground color from the `color` search param, defaulting to a random color if invalid
- keep the `color` query parameter in sync whenever the color changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a257acbf08832a8ff8080144ab9b64