### PR TITLE
docs: add Color class overview comment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["CIEL", "desaturate", "desaturated", "OKLCH", "unpivot"]
+  "cSpell.words": ["CIEL", "desaturate", "desaturated", "desaturating", "OKLCH", "unpivot"]
 }

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -60,12 +60,14 @@ import { ColorSwatch, getColorSwatch } from './swatch';
 import { getColorRGBAFromInput, isColorDark } from './utils';
 
 /**
- * Immutable utility class for representing and working with colors.
+ * The base omni-color object.
  *
- * A {@link Color} provides helpers for converting between formats, generating
- * palettes, and performing operations like darkening or desaturating. Instances
- * do not change once created; methods that might normally mutate a color instead
- * return computed values or new {@link Color} objects.
+ * The {@link Color} class represents a specific color and provides methods for
+ * converting between formats, performing manipulations like darkening or desaturating,
+ * and generating harmonies and color palettes.
+ *
+ * {@link Color} instances are immutable - all operations except `setAlpha()` will return
+ * a new {@link Color} instance representing the modified color.
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary
- document the Color class with an overview, usage example, and immutability note

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3508069e0832a82e24cf7dd2501fc