### PR TITLE
test: expand random color coverage

### DIFF
--- a/src/color/__test__/random.test.ts
+++ b/src/color/__test__/random.test.ts
@@ -4,16 +4,21 @@ import { BASE_COLOR_HUE_RANGES, BaseColorName } from '../names';
 import { getRandomColorRGBA } from '../random';
 
 describe('getRandomColorRGBA', () => {
-  it('generates components within valid ranges', () => {
-    const colorRGBA = getRandomColorRGBA();
-    expect(colorRGBA.r).toBeGreaterThanOrEqual(0);
-    expect(colorRGBA.r).toBeLessThanOrEqual(255);
-    expect(colorRGBA.g).toBeGreaterThanOrEqual(0);
-    expect(colorRGBA.g).toBeLessThanOrEqual(255);
-    expect(colorRGBA.b).toBeGreaterThanOrEqual(0);
-    expect(colorRGBA.b).toBeLessThanOrEqual(255);
-    expect(colorRGBA.a).toBe(1);
-  });
+  it.each([0, 0.01, 0.2, 0.37, 0.5, 0.66, 0.75, 0.9, 0.99, 0.9999])(
+    'generates valid random colors with no options for different random values (%f)',
+    (randomValue) => {
+      const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
+      const colorRGBA = getRandomColorRGBA();
+      expect(colorRGBA.r).toBeGreaterThanOrEqual(0);
+      expect(colorRGBA.r).toBeLessThanOrEqual(255);
+      expect(colorRGBA.g).toBeGreaterThanOrEqual(0);
+      expect(colorRGBA.g).toBeLessThanOrEqual(255);
+      expect(colorRGBA.b).toBeGreaterThanOrEqual(0);
+      expect(colorRGBA.b).toBeLessThanOrEqual(255);
+      expect(colorRGBA.a).toBe(1);
+      spy.mockRestore();
+    }
+  );
 
   it.each([0, 0.37, 0.75])('respects Math.random results (%f)', (randomValue) => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
@@ -28,26 +33,45 @@ describe('getRandomColorRGBA', () => {
     spy.mockRestore();
   });
 
-  it.each([0, 0.45, 0.89])(
-    'clamps provided alpha and overrides randomization (%f)',
-    (randomValue) => {
-      const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
-      expect(getRandomColorRGBA({ alpha: -0.5 }).a).toBe(0);
-      expect(getRandomColorRGBA({ alpha: 2 }).a).toBe(1);
-      expect(getRandomColorRGBA({ alpha: 0.3, randomizeAlpha: true }).a).toBe(0.3);
-      spy.mockRestore();
-    },
-  );
+  it('clamps provided alpha and overrides randomization (%f)', () => {
+    expect(getRandomColorRGBA({ alpha: -0.5 }).a).toBe(0);
+    expect(getRandomColorRGBA({ alpha: 2 }).a).toBe(1);
+    expect(getRandomColorRGBA({ alpha: 0.3, randomizeAlpha: true }).a).toBe(0.3);
+  });
 
-  it.each([0, 0.2, 0.5, 0.987])(
-    'randomizes alpha when requested (%f)',
-    (randomValue) => {
-      const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
-      const colorRGBA = getRandomColorRGBA({ randomizeAlpha: true });
-      expect(colorRGBA.a).toBe(+randomValue.toFixed(3));
-      spy.mockRestore();
-    },
-  );
+  it('randomizes alpha when option is enabled', () => {
+    const spy = jest
+      .spyOn(Math, 'random')
+      // First color:
+      .mockReturnValueOnce(0) // h
+      .mockReturnValueOnce(0) // s
+      .mockReturnValueOnce(0) // l
+      .mockReturnValueOnce(0) // a
+      // Second color:
+      .mockReturnValueOnce(0.2) // h
+      .mockReturnValueOnce(0.5) // s
+      .mockReturnValueOnce(0.7) // l
+      .mockReturnValueOnce(0.2) // a
+      // Third color:
+      .mockReturnValueOnce(0.1) // h
+      .mockReturnValueOnce(0.2) // s
+      .mockReturnValueOnce(0.35) // l
+      .mockReturnValueOnce(0.55555) // a
+      // Fourth color:
+      .mockReturnValueOnce(0.123) // h
+      .mockReturnValueOnce(0.23456) // s
+      .mockReturnValueOnce(0.999) // l
+      .mockReturnValueOnce(0.987); // a
+    const colorRGBA1 = getRandomColorRGBA({ randomizeAlpha: true });
+    expect(colorRGBA1).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    const colorRGBA2 = getRandomColorRGBA({ randomizeAlpha: true });
+    expect(colorRGBA2).toEqual({ r: 201, g: 217, b: 140, a: 0.2 });
+    const colorRGBA3 = getRandomColorRGBA({ randomizeAlpha: true });
+    expect(colorRGBA3).toEqual({ r: 107, g: 93, b: 71, a: 0.556 });
+    const colorRGBA4 = getRandomColorRGBA({ randomizeAlpha: true });
+    expect(colorRGBA4).toEqual({ r: 255, g: 255, b: 255, a: 0.987 });
+    spy.mockRestore();
+  });
 
   it.each([
     [0.1236, 0.124],
@@ -63,7 +87,7 @@ describe('getRandomColorRGBA', () => {
   it.each([0.1, 0.5, 0.9])('limits hue to specified base color (%f)', (randomValue) => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
     const coloredAnchors = Object.values(BaseColorName).filter(
-      (name) => ![BaseColorName.BLACK, BaseColorName.GRAY, BaseColorName.WHITE].includes(name),
+      (name) => ![BaseColorName.BLACK, BaseColorName.GRAY, BaseColorName.WHITE].includes(name)
     );
     coloredAnchors.forEach((name) => {
       const colorRGBA = getRandomColorRGBA({ anchorColor: name });
@@ -107,10 +131,10 @@ describe('getRandomColorRGBA', () => {
         expect(expectedL).toBeLessThanOrEqual(max);
       });
       spy.mockRestore();
-    },
+    }
   );
 
-  it.each([0.1, 0.5, 0.9])(
+  it.each([0.0001, 0.1, 0.23452346, 0.5, 0.6734253, 0.9, 0.9999])(
     'generates palette-friendly colors when requested (%f)',
     (randomValue) => {
       const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
@@ -120,23 +144,26 @@ describe('getRandomColorRGBA', () => {
       expect(colorHSLA.l).toBeGreaterThanOrEqual(25);
       expect(colorHSLA.l).toBeLessThanOrEqual(75);
       spy.mockRestore();
-    },
+    }
   );
 
-  it.each([0.1, 0.5, 0.9])('combines hue and palette options (%f)', (randomValue) => {
-    const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
-    const colorRGBA = getRandomColorRGBA({
-      anchorColor: BaseColorName.BLUE,
-      paletteSuitable: true,
-    });
-    const { name } = new Color(colorRGBA).getName();
-    expect(name).toBe(BaseColorName.BLUE);
-    const colorHSLA = toHSLA(colorRGBA);
-    expect(colorHSLA.s).toBeGreaterThanOrEqual(40);
-    expect(colorHSLA.l).toBeGreaterThanOrEqual(25);
-    expect(colorHSLA.l).toBeLessThanOrEqual(75);
-    spy.mockRestore();
-  });
+  it.each([0.0001, 0.1, 0.23452346, 0.5, 0.6734253, 0.9, 0.9999])(
+    'combines hue and palette options (%f)',
+    (randomValue) => {
+      const spy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
+      const colorRGBA = getRandomColorRGBA({
+        anchorColor: BaseColorName.BLUE,
+        paletteSuitable: true,
+      });
+      const { name } = new Color(colorRGBA).getName();
+      expect(name).toBe(BaseColorName.BLUE);
+      const colorHSLA = toHSLA(colorRGBA);
+      expect(colorHSLA.s).toBeGreaterThanOrEqual(40);
+      expect(colorHSLA.l).toBeGreaterThanOrEqual(25);
+      expect(colorHSLA.l).toBeLessThanOrEqual(75);
+      spy.mockRestore();
+    }
+  );
 
   it('produces maximum component values when Math.random is near one', () => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(0.999999);


### PR DESCRIPTION
## Summary
- mock Math.random with diverse values to hit edge cases
- test anchored hues and grayscale branches with deterministic expectations
- verify alpha randomization and rounding across multiple inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34efca4f0832a8c75962d74718d45