### PR TITLE
feat: harmonize neutrals with base color

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ import { ColorHarmony } from './color/harmonies';
 import { BaseColorName, ColorLightnessModifier, ColorNameAndLightness } from './color/names';
 import { RandomColorOptions } from './color/random';
 import { ColorSwatch } from './color/swatch';
-import { ColorPalette, SemanticColorHarmonizationOptions } from './palette/palette';
+import {
+  ColorPalette,
+  NeutralColorHarmonizationOptions,
+  SemanticColorHarmonizationOptions,
+} from './palette/palette';
 
 export {
   BaseColorName,
@@ -37,6 +41,7 @@ export {
   ColorRGB,
   ColorRGBA,
   ColorSwatch,
+  NeutralColorHarmonizationOptions,
   RandomColorOptions,
   SemanticColorHarmonizationOptions,
 };

--- a/src/palette/__test__/palette.test.ts
+++ b/src/palette/__test__/palette.test.ts
@@ -1,5 +1,20 @@
+import { Color } from '../../color/color';
+import { generateColorPaletteFromBaseColor } from '../palette';
+
 describe('generateColorPaletteFromBaseColor()', () => {
-  it('is a placeholder', () => {
-    // TODO: implement
+  it('harmonizes neutrals with the base color', () => {
+    const baseColor = new Color('red');
+    const palette = generateColorPaletteFromBaseColor(baseColor);
+
+    const baseOKLCH = baseColor.toOKLCH();
+    const neutralOKLCH = palette.neutrals[500].toOKLCH();
+    expect(neutralOKLCH.c).toBeCloseTo(0, 5);
+    expect(neutralOKLCH.l).toBeCloseTo(baseOKLCH.l, 2);
+
+    const tintedOKLCH = palette.tintedNeutrals[500].toOKLCH();
+    expect(tintedOKLCH.c).toBeGreaterThan(0);
+    expect(tintedOKLCH.c).toBeLessThan(baseOKLCH.c);
+    expect(Math.abs(tintedOKLCH.h - baseOKLCH.h)).toBeLessThan(5);
   });
 });
+


### PR DESCRIPTION
## Summary
- adapt neutral swatches to base color with new harmonizeNeutrals and harmonizeTintedNeutrals helpers
- expose NeutralColorHarmonizationOptions and include tinted neutrals in palettes
- test palette generation to verify neutral behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a46b6dcf4c832abd20671960562955