### PR TITLE
feat: add color combination utilities

### DIFF
--- a/demo/src/AppHeader.tsx
+++ b/demo/src/AppHeader.tsx
@@ -4,7 +4,8 @@ export function AppHeader() {
       <h1 className="mb-6">omni-color</h1>
       <h3 className="mb-4">A fast, powerful, and lightweight color library for TypeScript</h3>
       <h6 className="font-mono">
-        conversions &middot; manipulations &middot; harmonies &middot; color palettes
+        conversions &middot; manipulations &middot; combinations &middot; harmonies &middot; color
+        palettes
       </h6>
     </div>
   );

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -37,6 +37,10 @@ button:active {
   color: #a4acff;
 }
 
+select:hover {
+  cursor: pointer;
+}
+
 body {
   margin: 0;
   display: flex;

--- a/demo/src/playground/ColorCombinationDemo.tsx
+++ b/demo/src/playground/ColorCombinationDemo.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+import { Color } from '../../../dist';
+import { ColorBox } from '../components/ColorBox';
+
+interface Props {
+  color: Color;
+}
+
+export function ColorCombinationDemo({ color }: Props) {
+  const { red, green, blue } = useMemo(() => {
+    return { red: new Color('red'), green: new Color('green'), blue: new Color('blue') };
+  }, []);
+
+  return (
+    <div className="w-full flex flex-row justify-center">
+      <table className="table-auto">
+        <thead>
+          <tr>
+            <th />
+            <th className="pb-1 font-normal">Original</th>
+            <th className="pb-1 font-normal">+ Red</th>
+            <th className="pb-1 font-normal">+ Green</th>
+            <th className="pb-1 font-normal">+ Blue</th>
+            <th className="pb-1 font-normal">+ RGB</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="pb-2 pr-2 text-right">Mix</td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.mix([red])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.mix([green])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.mix([blue])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.mix([red, green, blue])} />
+            </td>
+          </tr>
+          <tr>
+            <td className="pb-2 pr-2 text-right">Blend</td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.blend(red)} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.blend(green)} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.blend(blue)} />
+            </td>
+            <td className="pb-2 px-2">N / A</td>
+          </tr>
+          <tr>
+            <td className="pb-2 pr-2 text-right">Average</td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.average([red])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.average([green])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.average([blue])} />
+            </td>
+            <td className="pb-2 px-2">
+              <ColorBox color={color.average([red, green, blue])} />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/demo/src/playground/Playground.tsx
+++ b/demo/src/playground/Playground.tsx
@@ -7,6 +7,7 @@ import { VSpace } from '../components/VSpace';
 import { ColorHarmonyDemo } from './ColorHarmonyDemo';
 import { ColorSwatch } from './ColorSwatch';
 import { ColorPaletteDemo } from './palette/ColorPaletteDemo';
+import { ColorCombinationDemo } from './ColorCombinationDemo';
 
 const COLOR_SEARCH_PARAM_KEY = 'color' as const;
 
@@ -55,6 +56,9 @@ export function Playground() {
       <VSpace height={24} />
       <h5 className="mb-3">Manipulations</h5>
       <ColorManipulationDemo color={color} />
+      <VSpace height={24} />
+      <h5 className="mb-3">Combinations</h5>
+      <ColorCombinationDemo color={color} />
       <VSpace height={24} />
       <h5 className="mb-3">Harmonies</h5>
       <ColorHarmonyDemo color={color} />

--- a/demo/src/playground/Playground.tsx
+++ b/demo/src/playground/Playground.tsx
@@ -7,7 +7,7 @@ import { VSpace } from '../components/VSpace';
 import { ColorHarmonyDemo } from './ColorHarmonyDemo';
 import { ColorSwatch } from './ColorSwatch';
 import { ColorPaletteDemo } from './palette/ColorPaletteDemo';
-import { ColorCombinationDemo } from './ColorCombinationDemo';
+import { ColorCombinationDemo } from './combinations/ColorCombinationDemo';
 
 const COLOR_SEARCH_PARAM_KEY = 'color' as const;
 

--- a/demo/src/playground/combinations/AverageColorsOptionInputs.tsx
+++ b/demo/src/playground/combinations/AverageColorsOptionInputs.tsx
@@ -1,0 +1,26 @@
+import { MixSpace, type AverageColorsOptions } from '../../../../dist';
+
+interface Props {
+  mixOptions: AverageColorsOptions;
+  onOptionsChanged: (options: AverageColorsOptions) => void;
+}
+
+export function AverageColorsOptionInputs({ mixOptions, onOptionsChanged }: Props) {
+  return (
+    <div className="flex flex-row gap-2">
+      <label>
+        Mix space:
+        <select
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          value={mixOptions.space}
+          onChange={(e) => onOptionsChanged({ ...mixOptions, space: e.target.value as MixSpace })}
+        >
+          <option value={MixSpace.RGB}>RGB</option>
+          <option value={MixSpace.HSL}>HSL</option>
+          <option value={MixSpace.LCH}>LCH</option>
+          <option value={MixSpace.OKLCH}>OKLCH</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/demo/src/playground/combinations/BlendColorsOptionInputs.tsx
+++ b/demo/src/playground/combinations/BlendColorsOptionInputs.tsx
@@ -1,0 +1,52 @@
+import { BlendMode, BlendSpace, type BlendColorsOptions } from '../../../../dist';
+
+interface Props {
+  blendOptions: BlendColorsOptions;
+  onOptionsChanged: (options: BlendColorsOptions) => void;
+}
+
+export function BlendColorsOptionInputs({ blendOptions, onOptionsChanged }: Props) {
+  return (
+    <div className="flex flex-row gap-2">
+      <label>
+        Blend mode:
+        <select
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          value={blendOptions.mode}
+          onChange={(e) => onOptionsChanged({ ...blendOptions, mode: e.target.value as BlendMode })}
+        >
+          <option value={BlendMode.NORMAL}>Normal</option>
+          <option value={BlendMode.MULTIPLY}>Multiply</option>
+          <option value={BlendMode.SCREEN}>Screen</option>
+          <option value={BlendMode.OVERLAY}>Overlay</option>
+        </select>
+      </label>
+      &middot;
+      <label>
+        Blend space:
+        <select
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          value={blendOptions.space}
+          onChange={(e) =>
+            onOptionsChanged({ ...blendOptions, space: e.target.value as BlendSpace })
+          }
+        >
+          <option value={BlendSpace.RGB}>RGB</option>
+          <option value={BlendSpace.HSL}>HSL</option>
+        </select>
+      </label>
+      <label>
+        Blend ratio:
+        <input
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          max={1}
+          min={0}
+          step={0.01}
+          type="number"
+          value={blendOptions.ratio}
+          onChange={(e) => onOptionsChanged({ ...blendOptions, ratio: Number(e.target.value) })}
+        />
+      </label>
+    </div>
+  );
+}

--- a/demo/src/playground/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/playground/combinations/ColorCombinationDemo.tsx
@@ -5,12 +5,14 @@ import {
   Color,
   MixSpace,
   MixType,
+  type AverageColorsOptions,
   type BlendColorsOptions,
   type MixColorsOptions,
 } from '../../../../dist';
 import { ColorBox } from '../../components/ColorBox';
 import { MixColorsOptionInputs } from './MixColorsOptionInputs';
 import { BlendColorsOptionInputs } from './BlendColorsOptionInputs';
+import { AverageColorsOptionInputs } from './AverageColorsOptionInputs';
 
 interface Props {
   color: Color;
@@ -26,6 +28,10 @@ export function ColorCombinationDemo({ color }: Props) {
     mode: BlendMode.NORMAL,
     space: BlendSpace.RGB,
     ratio: 0.5,
+  });
+
+  const [averageOptions, setAverageOptions] = useState<AverageColorsOptions>({
+    space: MixSpace.RGB,
   });
 
   const { red, green, blue } = useMemo(() => {
@@ -96,18 +102,23 @@ export function ColorCombinationDemo({ color }: Props) {
               <ColorBox color={color} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.average([red])} />
+              <ColorBox color={color.average([red], averageOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.average([green])} />
+              <ColorBox color={color.average([green], averageOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.average([blue])} />
+              <ColorBox color={color.average([blue], averageOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.average([red, green, blue])} />
+              <ColorBox color={color.average([red, green, blue], averageOptions)} />
             </td>
-            <td className="pb-2 px-2">TODO - options</td>
+            <td className="pb-2 px-2">
+              <AverageColorsOptionInputs
+                mixOptions={averageOptions}
+                onOptionsChanged={setAverageOptions}
+              />
+            </td>
           </tr>
         </tbody>
       </table>

--- a/demo/src/playground/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/playground/combinations/ColorCombinationDemo.tsx
@@ -1,7 +1,16 @@
 import { useMemo, useState } from 'react';
-import { Color, MixSpace, MixType, type MixColorsOptions } from '../../../../dist';
+import {
+  BlendMode,
+  BlendSpace,
+  Color,
+  MixSpace,
+  MixType,
+  type BlendColorsOptions,
+  type MixColorsOptions,
+} from '../../../../dist';
 import { ColorBox } from '../../components/ColorBox';
 import { MixColorsOptionInputs } from './MixColorsOptionInputs';
+import { BlendColorsOptionInputs } from './BlendColorsOptionInputs';
 
 interface Props {
   color: Color;
@@ -11,6 +20,12 @@ export function ColorCombinationDemo({ color }: Props) {
   const [mixOptions, setMixOptions] = useState<MixColorsOptions>({
     space: MixSpace.RGB,
     type: MixType.ADDITIVE,
+  });
+
+  const [blendOptions, setBlendOptions] = useState<BlendColorsOptions>({
+    mode: BlendMode.NORMAL,
+    space: BlendSpace.RGB,
+    ratio: 0.5,
   });
 
   const { red, green, blue } = useMemo(() => {
@@ -59,16 +74,21 @@ export function ColorCombinationDemo({ color }: Props) {
               <ColorBox color={color} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.blend(red)} />
+              <ColorBox color={color.blend(red, blendOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.blend(green)} />
+              <ColorBox color={color.blend(green, blendOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.blend(blue)} />
+              <ColorBox color={color.blend(blue, blendOptions)} />
             </td>
             <td className="pb-2 px-2">N / A</td>
-            <td className="pb-2 px-2">TODO - options</td>
+            <td className="pb-2 px-2">
+              <BlendColorsOptionInputs
+                blendOptions={blendOptions}
+                onOptionsChanged={setBlendOptions}
+              />
+            </td>
           </tr>
           <tr>
             <td className="pb-2 pr-2 text-right">Average</td>

--- a/demo/src/playground/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/playground/combinations/ColorCombinationDemo.tsx
@@ -1,12 +1,18 @@
-import { useMemo } from 'react';
-import { Color } from '../../../dist';
-import { ColorBox } from '../components/ColorBox';
+import { useMemo, useState } from 'react';
+import { Color, MixSpace, MixType, type MixColorsOptions } from '../../../../dist';
+import { ColorBox } from '../../components/ColorBox';
+import { MixColorsOptionInputs } from './MixColorsOptionInputs';
 
 interface Props {
   color: Color;
 }
 
 export function ColorCombinationDemo({ color }: Props) {
+  const [mixOptions, setMixOptions] = useState<MixColorsOptions>({
+    space: MixSpace.RGB,
+    type: MixType.ADDITIVE,
+  });
+
   const { red, green, blue } = useMemo(() => {
     return { red: new Color('red'), green: new Color('green'), blue: new Color('blue') };
   }, []);
@@ -22,6 +28,7 @@ export function ColorCombinationDemo({ color }: Props) {
             <th className="pb-1 font-normal">+ Green</th>
             <th className="pb-1 font-normal">+ Blue</th>
             <th className="pb-1 font-normal">+ RGB</th>
+            <th className="pb-1 font-normal">Options</th>
           </tr>
         </thead>
         <tbody>
@@ -31,16 +38,19 @@ export function ColorCombinationDemo({ color }: Props) {
               <ColorBox color={color} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.mix([red])} />
+              <ColorBox color={color.mix([red], mixOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.mix([green])} />
+              <ColorBox color={color.mix([green], mixOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.mix([blue])} />
+              <ColorBox color={color.mix([blue], mixOptions)} />
             </td>
             <td className="pb-2 px-2">
-              <ColorBox color={color.mix([red, green, blue])} />
+              <ColorBox color={color.mix([red, green, blue], mixOptions)} />
+            </td>
+            <td className="pb-2 px-2">
+              <MixColorsOptionInputs mixOptions={mixOptions} onOptionsChanged={setMixOptions} />
             </td>
           </tr>
           <tr>
@@ -58,6 +68,7 @@ export function ColorCombinationDemo({ color }: Props) {
               <ColorBox color={color.blend(blue)} />
             </td>
             <td className="pb-2 px-2">N / A</td>
+            <td className="pb-2 px-2">TODO - options</td>
           </tr>
           <tr>
             <td className="pb-2 pr-2 text-right">Average</td>
@@ -76,6 +87,7 @@ export function ColorCombinationDemo({ color }: Props) {
             <td className="pb-2 px-2">
               <ColorBox color={color.average([red, green, blue])} />
             </td>
+            <td className="pb-2 px-2">TODO - options</td>
           </tr>
         </tbody>
       </table>

--- a/demo/src/playground/combinations/MixColorsOptionInputs.tsx
+++ b/demo/src/playground/combinations/MixColorsOptionInputs.tsx
@@ -1,0 +1,38 @@
+import { MixSpace, MixType, type MixColorsOptions } from '../../../../dist';
+
+interface Props {
+  mixOptions: MixColorsOptions;
+  onOptionsChanged: (options: MixColorsOptions) => void;
+}
+
+export function MixColorsOptionInputs({ mixOptions, onOptionsChanged }: Props) {
+  return (
+    <div className="flex flex-row gap-2">
+      <label>
+        Mix type:
+        <select
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          value={mixOptions.type}
+          onChange={(e) => onOptionsChanged({ ...mixOptions, type: e.target.value as MixType })}
+        >
+          <option value={MixType.ADDITIVE}>Additive</option>
+          <option value={MixType.SUBTRACTIVE}>Subtractive</option>
+        </select>
+      </label>
+      &middot;
+      <label>
+        Mix space:
+        <select
+          className="ml-2 px-2 py-0.5 border-1 border-gray-200 rounded-md shadow-md"
+          value={mixOptions.space}
+          onChange={(e) => onOptionsChanged({ ...mixOptions, space: e.target.value as MixSpace })}
+        >
+          <option value={MixSpace.RGB}>RGB</option>
+          <option value={MixSpace.HSL}>HSL</option>
+          <option value={MixSpace.LCH}>LCH</option>
+          <option value={MixSpace.OKLCH}>OKLCH</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -1,0 +1,130 @@
+import { Color } from '../color';
+import {
+  averageColors,
+  blendColors,
+  BlendMode,
+  BlendSpace,
+  mixColors,
+  MixSpace,
+  MixType,
+} from '../combinations';
+
+describe('mixColors', () => {
+  it('mixes colors additively in RGB space', () => {
+    const red = new Color('#ff0000');
+    const green = new Color('#00ff00');
+    const result = mixColors([red, green], {
+      type: MixType.ADDITIVE,
+      space: MixSpace.RGB,
+    });
+    expect(result.toHex()).toBe('#ffff00');
+  });
+
+  it('mixes colors subtractively in CMYK space', () => {
+    const cyan = new Color('#00ffff');
+    const yellow = new Color('#ffff00');
+    const result = mixColors([cyan, yellow], { type: MixType.SUBTRACTIVE });
+    expect(result.toHex()).toBe('#00ff00');
+  });
+
+  it('mixes colors in HSL space with weights', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = mixColors([red, blue], {
+      space: MixSpace.HSL,
+      weights: [1, 3],
+    });
+    expect(result.toHex()).toBe('#00ffff');
+  });
+
+  it('defaults to additive RGB mixing', () => {
+    const red = new Color('#ff0000');
+    const green = new Color('#00ff00');
+    const result = mixColors([red, green]);
+    expect(result.toHex()).toBe('#ffff00');
+  });
+
+  it('throws when fewer than two colors are provided', () => {
+    const red = new Color('#ff0000');
+    expect(() => mixColors([red])).toThrow('mixColors requires at least two colors');
+  });
+});
+
+describe('averageColors', () => {
+  it('averages colors in RGB space', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = averageColors([red, blue], { space: MixSpace.RGB });
+    expect(result.toHex()).toBe('#800080');
+  });
+
+  it('averages colors in HSL space with weights', () => {
+    const red = new Color('#ff0000');
+    const green = new Color('#00ff00');
+    const result = averageColors([red, green], {
+      space: MixSpace.HSL,
+      weights: [1, 2],
+    });
+    expect(result.toHex()).toBe('#aaff00');
+  });
+
+  it('defaults to RGB averaging', () => {
+    const red = new Color('#ff0000');
+    const green = new Color('#00ff00');
+    const result = averageColors([red, green]);
+    expect(result.toHex()).toBe('#808000');
+  });
+
+  it('throws when fewer than two colors are provided', () => {
+    const red = new Color('#ff0000');
+    expect(() => averageColors([red])).toThrow('averageColors requires at least two colors');
+  });
+});
+
+describe('blendColors', () => {
+  it('blends using multiply mode', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = blendColors(red, blue, { mode: BlendMode.MULTIPLY, ratio: 1 });
+    expect(result.toHex()).toBe('#000000');
+  });
+
+  it('blends using screen mode', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = blendColors(red, blue, { mode: BlendMode.SCREEN, ratio: 1 });
+    expect(result.toHex()).toBe('#ff00ff');
+  });
+
+  it('blends using overlay mode', () => {
+    const gray = new Color('#808080');
+    const white = new Color('#ffffff');
+    const result = blendColors(gray, white, { mode: BlendMode.OVERLAY, ratio: 1 });
+    expect(result.toHex()).toBe('#ffffff');
+  });
+
+  it('returns base color when ratio is 0', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = blendColors(red, blue, { ratio: 0 });
+    expect(result.toHex()).toBe('#ff0000');
+  });
+
+  it('returns blend color when ratio is 1 in normal mode', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = blendColors(red, blue, { mode: BlendMode.NORMAL, ratio: 1 });
+    expect(result.toHex()).toBe('#0000ff');
+  });
+
+  it('blends in HSL space', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = blendColors(red, blue, {
+      space: BlendSpace.HSL,
+      ratio: 0.5,
+    });
+    expect(result.toHex()).toBe('#00ff00');
+  });
+});
+

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -127,4 +127,3 @@ describe('blendColors', () => {
     expect(result.toHex()).toBe('#00ff00');
   });
 });
-

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -46,7 +46,9 @@ describe('mixColors', () => {
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => mixColors([red])).toThrow('mixColors requires at least two colors');
+    expect(() => mixColors([red])).toThrow(
+      '[mixColors] at least two colors are required for mixing'
+    );
   });
 });
 
@@ -77,7 +79,9 @@ describe('averageColors', () => {
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => averageColors([red])).toThrow('averageColors requires at least two colors');
+    expect(() => averageColors([red])).toThrow(
+      '[averageColors] at least two colors are required for averaging'
+    );
   });
 });
 

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -4,6 +4,7 @@ import {
   GenerateColorPaletteOptions,
 } from '../palette/palette';
 import { clampValue } from '../utils';
+import { averageColors, blendColors, mixColors } from './combinations';
 import {
   toCMYK,
   toHex,
@@ -355,6 +356,18 @@ export class Color {
    */
   grayscale(): Color {
     return colorToGrayscale(this);
+  }
+
+  mix(others: Color[]) {
+    return mixColors([this, ...others]);
+  }
+
+  blend(other: Color): Color {
+    return blendColors(this, other);
+  }
+
+  average(others: Color[]): Color {
+    return averageColors([this, ...others]);
   }
 
   /**

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -4,7 +4,13 @@ import {
   GenerateColorPaletteOptions,
 } from '../palette/palette';
 import { clampValue } from '../utils';
-import { averageColors, blendColors, mixColors, MixColorsOptions } from './combinations';
+import {
+  averageColors,
+  blendColors,
+  BlendColorsOptions,
+  mixColors,
+  MixColorsOptions,
+} from './combinations';
 import {
   toCMYK,
   toHex,
@@ -362,7 +368,7 @@ export class Color {
    * Mix this color with one or more other colors.
    *
    * @param others - Array of one or more other colors to mix with.
-   * @param options - optional {@link MixColorsOptions} mixing options and weights.
+   * @param options - Optional {@link MixColorsOptions} mixing options and weights.
    * @returns A new color that is the result of the mix.
    */
   mix(others: Color[], options?: MixColorsOptions): Color {
@@ -372,8 +378,15 @@ export class Color {
     return mixColors([this, ...others], options);
   }
 
-  blend(other: Color): Color {
-    return blendColors(this, other);
+  /**
+   * Blend this color with another color.
+   *
+   * @param other - The color to blend with.
+   * @param options - Optional {@link BlendColorsOptions} for blend mode, space, and ratio.
+   * @returns A new color that is the result of the blend.
+   */
+  blend(other: Color, options?: BlendColorsOptions): Color {
+    return blendColors(this, other, options);
   }
 
   average(others: Color[]): Color {

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -6,6 +6,7 @@ import {
 import { clampValue } from '../utils';
 import {
   averageColors,
+  AverageColorsOptions,
   blendColors,
   BlendColorsOptions,
   mixColors,
@@ -389,11 +390,18 @@ export class Color {
     return blendColors(this, other, options);
   }
 
-  average(others: Color[]): Color {
+  /**
+   * Average this color with one or more other colors by averaging their channels in the selected color space.
+   *
+   * @param others - Array of one or more other colors to average with.
+   * @param options - Optional {@link AverageColorsOptions} mix space and weights.
+   * @returns A new color that is the result of the averaging.
+   */
+  average(others: Color[], options?: AverageColorsOptions): Color {
     if (others.length === 0) {
       return this.clone();
     }
-    return averageColors([this, ...others]);
+    return averageColors([this, ...others], options);
   }
 
   /**

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -4,7 +4,7 @@ import {
   GenerateColorPaletteOptions,
 } from '../palette/palette';
 import { clampValue } from '../utils';
-import { averageColors, blendColors, mixColors } from './combinations';
+import { averageColors, blendColors, mixColors, MixColorsOptions } from './combinations';
 import {
   toCMYK,
   toHex,
@@ -358,8 +358,18 @@ export class Color {
     return colorToGrayscale(this);
   }
 
-  mix(others: Color[]) {
-    return mixColors([this, ...others]);
+  /**
+   * Mix this color with one or more other colors.
+   *
+   * @param others - Array of one or more other colors to mix with.
+   * @param options - optional {@link MixColorsOptions} mixing options and weights.
+   * @returns A new color that is the result of the mix.
+   */
+  mix(others: Color[], options?: MixColorsOptions): Color {
+    if (others.length === 0) {
+      return this.clone();
+    }
+    return mixColors([this, ...others], options);
   }
 
   blend(other: Color): Color {
@@ -367,6 +377,9 @@ export class Color {
   }
 
   average(others: Color[]): Color {
+    if (others.length === 0) {
+      return this.clone();
+    }
     return averageColors([this, ...others]);
   }
 

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -1,0 +1,294 @@
+import { clampValue } from '../utils';
+import { Color } from './color';
+import { toCMYK } from './conversions';
+import { ColorCMYK, ColorHSL, ColorLCH, ColorOKLCH, ColorRGBA } from './formats';
+
+export enum MixType {
+  ADDITIVE = 'ADDITIVE',
+  SUBTRACTIVE = 'SUBTRACTIVE',
+}
+
+export enum MixSpace {
+  RGB = 'RGB',
+  HSL = 'HSL',
+  LCH = 'LCH',
+  OKLCH = 'OKLCH',
+}
+
+export interface MixOptions {
+  type?: MixType;
+  space?: MixSpace;
+  weights?: number[];
+  /** Optional white point placeholder for future use */
+  whitePoint?: unknown;
+  /** Clamp the resulting color into gamut */
+  gamutMap?: 'clip';
+}
+
+function getWeights(count: number, weights?: number[]): number[] {
+  return weights && weights.length === count ? weights : Array(count).fill(1);
+}
+
+export function mixColors(colors: Color[], options: MixOptions = {}): Color {
+  if (colors.length < 2) {
+    throw new Error('mixColors requires at least two colors');
+  }
+  const { type = MixType.ADDITIVE, space = MixSpace.RGB, weights } = options;
+  const w = getWeights(colors.length, weights);
+
+  switch (type) {
+    case MixType.SUBTRACTIVE: {
+      const norm = w.map((v) => v / w.reduce((a, b) => a + b, 0));
+      let c = 1;
+      let m = 1;
+      let y = 1;
+      let k = 1;
+      colors.forEach((color, i) => {
+        const part = toCMYK(color.toRGBA());
+        const weight = norm[i];
+        c *= Math.pow(1 - part.c / 100, weight);
+        m *= Math.pow(1 - part.m / 100, weight);
+        y *= Math.pow(1 - part.y / 100, weight);
+        k *= Math.pow(1 - part.k / 100, weight);
+      });
+      const result: ColorCMYK = {
+        c: +(100 * (1 - c)).toFixed(2),
+        m: +(100 * (1 - m)).toFixed(2),
+        y: +(100 * (1 - y)).toFixed(2),
+        k: +(100 * (1 - k)).toFixed(2),
+      };
+      return new Color(result);
+    }
+    case MixType.ADDITIVE:
+    default:
+      break;
+  }
+
+  const total = w.reduce((a, b) => a + b, 0);
+  const norm = w.map((v) => v / total);
+
+  switch (space) {
+    case MixSpace.RGB:
+    default: {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      colors.forEach((color, i) => {
+        const val: ColorRGBA = color.toRGBA();
+        const weight = w[i];
+        r += val.r * weight;
+        g += val.g * weight;
+        b += val.b * weight;
+        a += (val.a ?? 1) * weight;
+      });
+      const result: ColorRGBA = {
+        r: Math.round(clampValue(r, 0, 255)),
+        g: Math.round(clampValue(g, 0, 255)),
+        b: Math.round(clampValue(b, 0, 255)),
+        a: +clampValue(a / total, 0, 1).toFixed(3),
+      };
+      return new Color(result);
+    }
+    case MixSpace.HSL: {
+      let h = 0;
+      let s = 0;
+      let l = 0;
+      colors.forEach((color, i) => {
+        const val: ColorHSL = color.toHSL();
+        const weight = norm[i];
+        h += val.h * weight;
+        s += val.s * weight;
+        l += val.l * weight;
+      });
+      const result: ColorHSL = {
+        h: Math.round(h) % 360,
+        s: Math.round(s),
+        l: Math.round(l),
+      };
+      return new Color(result);
+    }
+    case MixSpace.LCH: {
+      let l = 0;
+      let c = 0;
+      let h = 0;
+      colors.forEach((color, i) => {
+        const val: ColorLCH = color.toLCH();
+        const weight = norm[i];
+        l += val.l * weight;
+        c += val.c * weight;
+        h += val.h * weight;
+      });
+      const result: ColorLCH = { l, c, h };
+      return new Color(result);
+    }
+    case MixSpace.OKLCH: {
+      let l = 0;
+      let c = 0;
+      let h = 0;
+      colors.forEach((color, i) => {
+        const val: ColorOKLCH = color.toOKLCH();
+        const weight = norm[i];
+        l += val.l * weight;
+        c += val.c * weight;
+        h += val.h * weight;
+      });
+      const result: ColorOKLCH = { l, c, h };
+      return new Color(result);
+    }
+  }
+}
+
+export interface AverageOptions {
+  space?: MixSpace;
+  weights?: number[];
+}
+
+export function averageColors(colors: Color[], options: AverageOptions = {}): Color {
+  if (colors.length < 2) {
+    throw new Error('averageColors requires at least two colors');
+  }
+  const { space = MixSpace.RGB, weights } = options;
+  const w = getWeights(colors.length, weights);
+  const total = w.reduce((a, b) => a + b, 0);
+  const norm = w.map((v) => v / total);
+
+  switch (space) {
+    case MixSpace.RGB:
+    default: {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let a = 0;
+      colors.forEach((color, i) => {
+        const val: ColorRGBA = color.toRGBA();
+        const weight = norm[i];
+        r += val.r * weight;
+        g += val.g * weight;
+        b += val.b * weight;
+        a += (val.a ?? 1) * weight;
+      });
+      return new Color({
+        r: Math.round(r),
+        g: Math.round(g),
+        b: Math.round(b),
+        a: +a.toFixed(3),
+      });
+    }
+    case MixSpace.HSL: {
+      let h = 0;
+      let s = 0;
+      let l = 0;
+      colors.forEach((color, i) => {
+        const val: ColorHSL = color.toHSL();
+        const weight = norm[i];
+        h += val.h * weight;
+        s += val.s * weight;
+        l += val.l * weight;
+      });
+      return new Color({
+        h: Math.round(h) % 360,
+        s: Math.round(s),
+        l: Math.round(l),
+      });
+    }
+    case MixSpace.LCH: {
+      let l = 0;
+      let c = 0;
+      let h = 0;
+      colors.forEach((color, i) => {
+        const val: ColorLCH = color.toLCH();
+        const weight = norm[i];
+        l += val.l * weight;
+        c += val.c * weight;
+        h += val.h * weight;
+      });
+      return new Color({ l, c, h });
+    }
+    case MixSpace.OKLCH: {
+      let l = 0;
+      let c = 0;
+      let h = 0;
+      colors.forEach((color, i) => {
+        const val: ColorOKLCH = color.toOKLCH();
+        const weight = norm[i];
+        l += val.l * weight;
+        c += val.c * weight;
+        h += val.h * weight;
+      });
+      return new Color({ l, c, h });
+    }
+  }
+}
+
+export enum BlendMode {
+  NORMAL = 'NORMAL',
+  MULTIPLY = 'MULTIPLY',
+  SCREEN = 'SCREEN',
+  OVERLAY = 'OVERLAY',
+}
+
+export enum BlendSpace {
+  RGB = 'RGB',
+  HSL = 'HSL',
+}
+
+export interface BlendOptions {
+  mode?: BlendMode;
+  space?: BlendSpace;
+  ratio?: number; // 0..1 amount of blend color over base
+}
+
+function blendChannel(mode: BlendMode, base: number, blend: number): number {
+  switch (mode) {
+    case BlendMode.MULTIPLY:
+      return (base * blend) / 255;
+    case BlendMode.SCREEN:
+      return 255 - ((255 - base) * (255 - blend)) / 255;
+    case BlendMode.OVERLAY:
+      return base < 128
+        ? (2 * base * blend) / 255
+        : 255 - (2 * (255 - base) * (255 - blend)) / 255;
+    case BlendMode.NORMAL:
+    default:
+      return blend;
+  }
+}
+
+export function blendColors(
+  base: Color,
+  blend: Color,
+  options: BlendOptions = {}
+): Color {
+  const { mode = BlendMode.NORMAL, space = BlendSpace.RGB, ratio = 0.5 } = options;
+  const t = clampValue(ratio, 0, 1);
+  switch (space) {
+    case BlendSpace.HSL: {
+      const b = base.toHSL();
+      const a = blend.toHSL();
+      const result: ColorHSL = {
+        h: (1 - t) * b.h + t * a.h,
+        s: (1 - t) * b.s + t * a.s,
+        l: (1 - t) * b.l + t * a.l,
+      };
+      return new Color(result);
+    }
+    case BlendSpace.RGB:
+    default: {
+      const b = base.toRGBA();
+      const a = blend.toRGBA();
+      const r = (1 - t) * b.r + t * blendChannel(mode, b.r, a.r);
+      const g = (1 - t) * b.g + t * blendChannel(mode, b.g, a.g);
+      const bb = (1 - t) * b.b + t * blendChannel(mode, b.b, a.b);
+      const alpha = (1 - t) * (b.a ?? 1) + t * (a.a ?? 1);
+      const result: ColorRGBA = {
+        r: Math.round(clampValue(r, 0, 255)),
+        g: Math.round(clampValue(g, 0, 255)),
+        b: Math.round(clampValue(bb, 0, 255)),
+        a: +clampValue(alpha, 0, 1).toFixed(3),
+      };
+      return new Color(result);
+    }
+  }
+}
+

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -19,8 +19,8 @@ export interface MixColorsOptions {
   space?: MixSpace;
   type?: MixType;
   /**
-   * Array of non-normalized `weights` for how much each color is weighed during combination.
-   * Length of weights must match number of colors being combined.
+   * Array of non-normalized `weights` for how much each color is weighed during mixing.
+   * Length of weights must match number of colors being mixed.
    * @example
    * ```ts
    * { weights: [1, 1, 2] }
@@ -230,12 +230,21 @@ export function blendColors(base: Color, blend: Color, options: BlendColorsOptio
   return blendColorsInHSLSpace(base, blend, ratio);
 }
 
-export interface AverageOptions {
+export interface AverageColorsOptions {
   space?: MixSpace;
+  /**
+   * Array `weights` for how much each color is weighed during averaging.
+   * Length of weights must match number of colors being averaged.
+   * Weights will be normalized automatically if not already normalized.
+   * @example
+   * ```ts
+   * { weights: [0.25, 0.25, 0.5] }
+   * ```
+   */
   weights?: number[];
 }
 
-export function averageColors(colors: Color[], options: AverageOptions = {}): Color {
+export function averageColors(colors: Color[], options: AverageColorsOptions = {}): Color {
   if (colors.length < 2) {
     throw new Error('[averageColors] at least two colors are required for averaging');
   }

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -236,7 +236,7 @@ export enum BlendSpace {
 export interface BlendOptions {
   mode?: BlendMode;
   space?: BlendSpace;
-  ratio?: number; // 0..1 amount of blend color over base
+  ratio?: number; // amount of blend color over base (0 - 1)
 }
 
 function blendChannel(mode: BlendMode, base: number, blend: number): number {
@@ -246,20 +246,14 @@ function blendChannel(mode: BlendMode, base: number, blend: number): number {
     case BlendMode.SCREEN:
       return 255 - ((255 - base) * (255 - blend)) / 255;
     case BlendMode.OVERLAY:
-      return base < 128
-        ? (2 * base * blend) / 255
-        : 255 - (2 * (255 - base) * (255 - blend)) / 255;
+      return base < 128 ? (2 * base * blend) / 255 : 255 - (2 * (255 - base) * (255 - blend)) / 255;
     case BlendMode.NORMAL:
     default:
       return blend;
   }
 }
 
-export function blendColors(
-  base: Color,
-  blend: Color,
-  options: BlendOptions = {}
-): Color {
+export function blendColors(base: Color, blend: Color, options: BlendOptions = {}): Color {
   const { mode = BlendMode.NORMAL, space = BlendSpace.RGB, ratio = 0.5 } = options;
   const t = clampValue(ratio, 0, 1);
   switch (space) {
@@ -291,4 +285,3 @@ export function blendColors(
     }
   }
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Color } from './color/color';
 import {
+  AverageColorsOptions,
   BlendColorsOptions,
   BlendMode,
   BlendSpace,
@@ -27,6 +28,7 @@ import { ColorSwatch } from './color/swatch';
 import { ColorPalette, GenerateColorPaletteOptions } from './palette/palette';
 
 export {
+  AverageColorsOptions,
   BaseColorName,
   BlendColorsOptions,
   BlendMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { Color } from './color/color';
-import { MixColorsOptions, MixSpace, MixType } from './color/combinations';
+import {
+  BlendColorsOptions,
+  BlendMode,
+  BlendSpace,
+  MixColorsOptions,
+  MixSpace,
+  MixType,
+} from './color/combinations';
 import {
   ColorCMYK,
   ColorFormat,
@@ -21,6 +28,9 @@ import { ColorPalette, GenerateColorPaletteOptions } from './palette/palette';
 
 export {
   BaseColorName,
+  BlendColorsOptions,
+  BlendMode,
+  BlendSpace,
   Color,
   ColorCMYK,
   ColorFormat,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Color } from './color/color';
+import { MixColorsOptions, MixSpace, MixType } from './color/combinations';
 import {
   ColorCMYK,
   ColorFormat,
@@ -38,5 +39,8 @@ export {
   ColorRGBA,
   ColorSwatch,
   GenerateColorPaletteOptions,
+  MixColorsOptions,
+  MixSpace,
+  MixType,
   RandomColorOptions,
 };


### PR DESCRIPTION
## Summary
- refactor mixing, averaging, and blending helpers to use enums and explicit default cases
- round HSL results and enforce minimum color counts
- expand test coverage for edge cases and multiple color spaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46e6a1a04832a95dfeb84614386bb