### PR TITLE
feat: add color readability metrics

### DIFF
--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -1,0 +1,50 @@
+import { Color } from '../color';
+import { getAPCAReadabilityScore, getContrastRatio } from '../readability';
+
+describe('getContrastRatio', () => {
+  it.each([
+    ['black and white', new Color('#000'), new Color('#fff'), 21],
+    ['same colors', new Color('#123456'), new Color('#123456'), 1],
+    ['transparent vs color', new Color({ r: 255, g: 0, b: 0, a: 0 }), new Color('#000'), 1],
+    ['semi-transparent black over white', new Color({ r: 0, g: 0, b: 0, a: 0.5 }), new Color('#fff'), 3.98],
+    ['black over semi-transparent white', new Color('#000'), new Color({ r: 255, g: 255, b: 255, a: 0.5 }), 5.28],
+    [
+      'semi-transparent black vs semi-transparent white',
+      new Color({ r: 0, g: 0, b: 0, a: 0.5 }),
+      new Color({ r: 255, g: 255, b: 255, a: 0.5 }),
+      3.21,
+    ],
+  ])('%s', (_name, c1, c2, expected) => {
+    expect(getContrastRatio(c1, c2)).toBeCloseTo(expected, 2);
+    expect(getContrastRatio(c2, c1)).toBeCloseTo(expected, 2);
+  });
+
+  it('returns 1 when both colors are fully transparent', () => {
+    const transparent1 = new Color({ r: 0, g: 0, b: 0, a: 0 });
+    const transparent2 = new Color({ r: 255, g: 255, b: 255, a: 0 });
+    expect(getContrastRatio(transparent1, transparent2)).toBe(1);
+  });
+});
+
+describe('getAPCAReadabilityScore', () => {
+  it.each([
+    ['black on white', new Color('#000'), new Color('#fff'), 106.04],
+    ['white on black', new Color('#fff'), new Color('#000'), -107.88],
+    ['semi-transparent black on white', new Color({ r: 0, g: 0, b: 0, a: 0.5 }), new Color('#fff'), 67.13],
+    ['white on semi-transparent black', new Color('#fff'), new Color({ r: 0, g: 0, b: 0, a: 0.5 }), -72.64],
+  ])('%s', (_name, fg, bg, expected) => {
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(expected, 2);
+  });
+
+  it('returns 0 for identical colors', () => {
+    const color = new Color('#abcdef');
+    expect(getAPCAReadabilityScore(color, color)).toBeCloseTo(0, 5);
+  });
+
+  it('handles fully transparent foreground', () => {
+    const fg = new Color({ r: 0, g: 0, b: 0, a: 0 });
+    const bg = new Color('#fff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0, 5);
+  });
+});
+

--- a/src/color/readability.ts
+++ b/src/color/readability.ts
@@ -1,0 +1,112 @@
+import { Color } from './color';
+import type { ColorRGBA } from './formats';
+
+function compositeRGBA(fg: ColorRGBA, bg: ColorRGBA): ColorRGBA {
+  const fgA = fg.a ?? 1;
+  const bgA = bg.a ?? 1;
+  const outA = fgA + bgA * (1 - fgA);
+  if (outA === 0) {
+    return { r: bg.r, g: bg.g, b: bg.b, a: 0 };
+  }
+  const r = (fg.r * fgA + bg.r * bgA * (1 - fgA)) / outA;
+  const g = (fg.g * fgA + bg.g * bgA * (1 - fgA)) / outA;
+  const b = (fg.b * fgA + bg.b * bgA * (1 - fgA)) / outA;
+  return { r, g, b, a: outA };
+}
+
+function relativeLuminance(rgb: ColorRGBA): number {
+  const toLinear = (channel: number): number => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const r = toLinear(rgb.r);
+  const g = toLinear(rgb.g);
+  const b = toLinear(rgb.b);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function getContrastRatio(color1: Color, color2: Color): number {
+  const c1 = color1.toRGBA();
+  const c2 = color2.toRGBA();
+  if ((c1.a ?? 1) === 0 && (c2.a ?? 1) === 0) {
+    return 1;
+  }
+  const c1Over2 = c1.a !== undefined && c1.a < 1 ? compositeRGBA(c1, c2) : c1;
+  const c2Over1 = c2.a !== undefined && c2.a < 1 ? compositeRGBA(c2, c1) : c2;
+  const l1 = relativeLuminance(c1Over2);
+  const l2 = relativeLuminance(c2Over1);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+  return +ratio.toFixed(2);
+}
+
+const SA98G = {
+  mainTRC: 2.4,
+  sRco: 0.2126729,
+  sGco: 0.7151522,
+  sBco: 0.0721750,
+  normBG: 0.56,
+  normTXT: 0.57,
+  revTXT: 0.62,
+  revBG: 0.65,
+  blkThrs: 0.022,
+  blkClmp: 1.414,
+  scaleBoW: 1.14,
+  scaleWoB: 1.14,
+  loBoWoffset: 0.027,
+  loWoBoffset: 0.027,
+  deltaYmin: 0.0005,
+  loClip: 0.1,
+};
+
+function sRGBtoY(rgb: ColorRGBA): number {
+  const exp = SA98G.mainTRC;
+  const lin = (c: number): number => Math.pow(c / 255, exp);
+  return SA98G.sRco * lin(rgb.r) + SA98G.sGco * lin(rgb.g) + SA98G.sBco * lin(rgb.b);
+}
+
+function APCAcontrast(txtY: number, bgY: number): number {
+  const icp = [0.0, 1.1];
+  if (
+    Number.isNaN(txtY) ||
+    Number.isNaN(bgY) ||
+    Math.min(txtY, bgY) < icp[0] ||
+    Math.max(txtY, bgY) > icp[1]
+  ) {
+    return 0;
+  }
+  txtY = txtY > SA98G.blkThrs ? txtY : txtY + Math.pow(SA98G.blkThrs - txtY, SA98G.blkClmp);
+  bgY = bgY > SA98G.blkThrs ? bgY : bgY + Math.pow(SA98G.blkThrs - bgY, SA98G.blkClmp);
+  if (Math.abs(bgY - txtY) < SA98G.deltaYmin) {
+    return 0;
+  }
+  let SAPC = 0;
+  let outputContrast = 0;
+  if (bgY > txtY) {
+    SAPC = (Math.pow(bgY, SA98G.normBG) - Math.pow(txtY, SA98G.normTXT)) * SA98G.scaleBoW;
+    outputContrast = SAPC < SA98G.loClip ? 0 : SAPC - SA98G.loBoWoffset;
+  } else {
+    SAPC = (Math.pow(bgY, SA98G.revBG) - Math.pow(txtY, SA98G.revTXT)) * SA98G.scaleWoB;
+    outputContrast = SAPC > -SA98G.loClip ? 0 : SAPC + SA98G.loWoBoffset;
+  }
+  return outputContrast * 100;
+}
+
+/**
+ * Calculate the APCA readability score (Lc value).
+ *
+ * Note: This is based on draft recommendations and is provided for advisory use only as WCAG 3 is not finalized.
+ */
+export function getAPCAReadabilityScore(foreground: Color, background: Color): number {
+  const fg = foreground.toRGBA();
+  const bg = background.toRGBA();
+
+  const bgOpaque = bg.a !== undefined && bg.a < 1 ? compositeRGBA(bg, { r: 255, g: 255, b: 255, a: 1 }) : bg;
+  const fgOpaque = fg.a !== undefined && fg.a < 1 ? compositeRGBA(fg, bgOpaque) : fg;
+
+  const txtY = sRGBtoY(fgOpaque);
+  const bgY = sRGBtoY(bgOpaque);
+  return APCAcontrast(txtY, bgY);
+}
+


### PR DESCRIPTION
## Summary
- add WCAG 2 contrast ratio calculator with alpha handling
- add draft APCA readability score implementation
- test extensive edge cases for new readability utilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a864693d8c832a9526f87fac31b6c9