### PR TITLE
Expand readability test coverage

### DIFF
--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -19,8 +19,8 @@ describe('getWCAGContrastRatio', () => {
   it('red dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red dark on #ffffff alpha 1', () => {
@@ -40,8 +40,8 @@ describe('getWCAGContrastRatio', () => {
   it('red dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red dark on #777777 alpha 1', () => {
@@ -61,8 +61,8 @@ describe('getWCAGContrastRatio', () => {
   it('red dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red normal on #000000 alpha 1', () => {
@@ -82,15 +82,15 @@ describe('getWCAGContrastRatio', () => {
   it('red normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red normal on #ffffff alpha 1', () => {
     const fg = new Color('#ff0000');
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.0, 2);
   });
 
   it('red normal on #ffffff alpha 0.5', () => {
@@ -103,8 +103,8 @@ describe('getWCAGContrastRatio', () => {
   it('red normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red normal on #777777 alpha 1', () => {
@@ -124,8 +124,8 @@ describe('getWCAGContrastRatio', () => {
   it('red normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red light on #000000 alpha 1', () => {
@@ -145,8 +145,8 @@ describe('getWCAGContrastRatio', () => {
   it('red light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red light on #ffffff alpha 1', () => {
@@ -166,8 +166,8 @@ describe('getWCAGContrastRatio', () => {
   it('red light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('red light on #777777 alpha 1', () => {
@@ -187,8 +187,8 @@ describe('getWCAGContrastRatio', () => {
   it('red light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange dark on #000000 alpha 1', () => {
@@ -208,15 +208,15 @@ describe('getWCAGContrastRatio', () => {
   it('orange dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange dark on #ffffff alpha 1', () => {
     const fg = new Color('#994c00');
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.20, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.20, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.2, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.2, 2);
   });
 
   it('orange dark on #ffffff alpha 0.5', () => {
@@ -229,8 +229,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange dark on #777777 alpha 1', () => {
@@ -250,8 +250,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange normal on #000000 alpha 1', () => {
@@ -271,8 +271,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange normal on #ffffff alpha 1', () => {
@@ -292,8 +292,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange normal on #777777 alpha 1', () => {
@@ -313,8 +313,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange light on #000000 alpha 1', () => {
@@ -334,8 +334,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange light on #ffffff alpha 1', () => {
@@ -355,8 +355,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('orange light on #777777 alpha 1', () => {
@@ -376,8 +376,8 @@ describe('getWCAGContrastRatio', () => {
   it('orange light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow dark on #000000 alpha 1', () => {
@@ -397,8 +397,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow dark on #ffffff alpha 1', () => {
@@ -418,8 +418,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow dark on #777777 alpha 1', () => {
@@ -432,15 +432,15 @@ describe('getWCAGContrastRatio', () => {
   it('yellow dark on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.20, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.20, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.2, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.2, 2);
   });
 
   it('yellow dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow normal on #000000 alpha 1', () => {
@@ -460,8 +460,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow normal on #ffffff alpha 1', () => {
@@ -481,8 +481,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow normal on #777777 alpha 1', () => {
@@ -502,8 +502,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow light on #000000 alpha 1', () => {
@@ -523,8 +523,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow light on #ffffff alpha 1', () => {
@@ -544,8 +544,8 @@ describe('getWCAGContrastRatio', () => {
   it('yellow light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('yellow light on #777777 alpha 1', () => {
@@ -565,15 +565,15 @@ describe('getWCAGContrastRatio', () => {
   it('yellow light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green dark on #000000 alpha 1', () => {
     const fg = new Color('#006600');
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.90, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.90, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.9, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.9, 2);
   });
 
   it('green dark on #000000 alpha 0.5', () => {
@@ -586,8 +586,8 @@ describe('getWCAGContrastRatio', () => {
   it('green dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green dark on #ffffff alpha 1', () => {
@@ -607,8 +607,8 @@ describe('getWCAGContrastRatio', () => {
   it('green dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green dark on #777777 alpha 1', () => {
@@ -628,15 +628,15 @@ describe('getWCAGContrastRatio', () => {
   it('green dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green normal on #000000 alpha 1', () => {
     const fg = new Color('#00ff00');
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(15.30, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(15.30, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(15.3, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(15.3, 2);
   });
 
   it('green normal on #000000 alpha 0.5', () => {
@@ -649,8 +649,8 @@ describe('getWCAGContrastRatio', () => {
   it('green normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green normal on #ffffff alpha 1', () => {
@@ -670,8 +670,8 @@ describe('getWCAGContrastRatio', () => {
   it('green normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green normal on #777777 alpha 1', () => {
@@ -691,8 +691,8 @@ describe('getWCAGContrastRatio', () => {
   it('green normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green light on #000000 alpha 1', () => {
@@ -712,8 +712,8 @@ describe('getWCAGContrastRatio', () => {
   it('green light on #000000 alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green light on #ffffff alpha 1', () => {
@@ -733,8 +733,8 @@ describe('getWCAGContrastRatio', () => {
   it('green light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('green light on #777777 alpha 1', () => {
@@ -754,8 +754,8 @@ describe('getWCAGContrastRatio', () => {
   it('green light on #777777 alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue dark on #000000 alpha 1', () => {
@@ -775,8 +775,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue dark on #ffffff alpha 1', () => {
@@ -796,8 +796,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue dark on #777777 alpha 1', () => {
@@ -817,8 +817,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue normal on #000000 alpha 1', () => {
@@ -838,8 +838,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue normal on #ffffff alpha 1', () => {
@@ -859,8 +859,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue normal on #777777 alpha 1', () => {
@@ -880,8 +880,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue light on #000000 alpha 1', () => {
@@ -901,8 +901,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue light on #000000 alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue light on #ffffff alpha 1', () => {
@@ -922,8 +922,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('blue light on #777777 alpha 1', () => {
@@ -943,8 +943,8 @@ describe('getWCAGContrastRatio', () => {
   it('blue light on #777777 alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo dark on #000000 alpha 1', () => {
@@ -964,8 +964,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo dark on #ffffff alpha 1', () => {
@@ -985,8 +985,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo dark on #777777 alpha 1', () => {
@@ -1006,8 +1006,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo normal on #000000 alpha 1', () => {
@@ -1027,8 +1027,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo normal on #ffffff alpha 1', () => {
@@ -1048,8 +1048,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo normal on #777777 alpha 1', () => {
@@ -1069,15 +1069,15 @@ describe('getWCAGContrastRatio', () => {
   it('indigo normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo light on #000000 alpha 1', () => {
     const fg = new Color('#9370ff');
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.0, 2);
   });
 
   it('indigo light on #000000 alpha 0.5', () => {
@@ -1090,15 +1090,15 @@ describe('getWCAGContrastRatio', () => {
   it('indigo light on #000000 alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo light on #ffffff alpha 1', () => {
     const fg = new Color('#9370ff');
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.50, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.50, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.5, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.5, 2);
   });
 
   it('indigo light on #ffffff alpha 0.5', () => {
@@ -1111,8 +1111,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('indigo light on #777777 alpha 1', () => {
@@ -1132,8 +1132,8 @@ describe('getWCAGContrastRatio', () => {
   it('indigo light on #777777 alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet dark on #000000 alpha 1', () => {
@@ -1153,8 +1153,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet dark on #ffffff alpha 1', () => {
@@ -1167,15 +1167,15 @@ describe('getWCAGContrastRatio', () => {
   it('violet dark on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.30, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.30, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.3, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.3, 2);
   });
 
   it('violet dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet dark on #777777 alpha 1', () => {
@@ -1195,8 +1195,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet normal on #000000 alpha 1', () => {
@@ -1216,8 +1216,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet normal on #ffffff alpha 1', () => {
@@ -1237,8 +1237,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet normal on #777777 alpha 1', () => {
@@ -1258,8 +1258,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet light on #000000 alpha 1', () => {
@@ -1279,8 +1279,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet light on #000000 alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#000000');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet light on #ffffff alpha 1', () => {
@@ -1300,8 +1300,8 @@ describe('getWCAGContrastRatio', () => {
   it('violet light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('violet light on #777777 alpha 1', () => {
@@ -1321,15 +1321,15 @@ describe('getWCAGContrastRatio', () => {
   it('violet light on #777777 alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#777777');
-    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
-    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.0, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.0, 2);
   });
 
   it('#000000 vs #ffffff', () => {
     const c1 = new Color('#000000');
     const c2 = new Color('#ffffff');
-    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(21.00, 2);
-    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(21.00, 2);
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(21.0, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(21.0, 2);
   });
 
   it('#111111 vs #eeeeee', () => {
@@ -1380,28 +1380,27 @@ describe('getWCAGContrastRatio', () => {
     expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(1.26, 2);
     expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(1.26, 2);
   });
-
 });
 
 describe('getAPCAReadabilityScore', () => {
   it('red dark on #000000 alpha 1', () => {
     const fg = new Color('#990000');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-14.30, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-14.3, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(16.15, 2);
   });
 
   it('red dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(47.22, 2);
   });
 
   it('red dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1416,14 +1415,14 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
     const bg = new Color('#ffffff');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(56.84, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-62.20, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-62.2, 2);
   });
 
   it('red dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('red dark on #777777 alpha 1', () => {
@@ -1443,7 +1442,7 @@ describe('getAPCAReadabilityScore', () => {
   it('red dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1464,7 +1463,7 @@ describe('getAPCAReadabilityScore', () => {
   it('red normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1485,28 +1484,28 @@ describe('getAPCAReadabilityScore', () => {
   it('red normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('red normal on #777777 alpha 1', () => {
     const fg = new Color('#ff0000');
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('red normal on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(21.63, 2);
   });
 
   it('red normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1527,7 +1526,7 @@ describe('getAPCAReadabilityScore', () => {
   it('red light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1548,8 +1547,8 @@ describe('getAPCAReadabilityScore', () => {
   it('red light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('red light on #777777 alpha 1', () => {
@@ -1569,7 +1568,7 @@ describe('getAPCAReadabilityScore', () => {
   it('red light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1583,14 +1582,14 @@ describe('getAPCAReadabilityScore', () => {
   it('orange dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(59.47, 2);
   });
 
   it('orange dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1604,35 +1603,35 @@ describe('getAPCAReadabilityScore', () => {
   it('orange dark on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(44.50, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(44.5, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-49.32, 2);
   });
 
   it('orange dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('orange dark on #777777 alpha 1', () => {
     const fg = new Color('#994c00');
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-8.20, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-8.2, 2);
   });
 
   it('orange dark on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(24.54, 2);
   });
 
   it('orange dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1653,7 +1652,7 @@ describe('getAPCAReadabilityScore', () => {
   it('orange normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1674,8 +1673,8 @@ describe('getAPCAReadabilityScore', () => {
   it('orange normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('orange normal on #777777 alpha 1', () => {
@@ -1695,7 +1694,7 @@ describe('getAPCAReadabilityScore', () => {
   it('orange normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1716,7 +1715,7 @@ describe('getAPCAReadabilityScore', () => {
   it('orange light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1737,8 +1736,8 @@ describe('getAPCAReadabilityScore', () => {
   it('orange light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('orange light on #777777 alpha 1', () => {
@@ -1751,14 +1750,14 @@ describe('getAPCAReadabilityScore', () => {
   it('orange light on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-17.30, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-17.3, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(52.41, 2);
   });
 
   it('orange light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1779,7 +1778,7 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1800,8 +1799,8 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow dark on #777777 alpha 1', () => {
@@ -1814,14 +1813,14 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow dark on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(39.24, 2);
   });
 
   it('yellow dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1842,29 +1841,29 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
   it('yellow normal on #ffffff alpha 1', () => {
     const fg = new Color('#ffff00');
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow normal on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow normal on #777777 alpha 1', () => {
@@ -1884,7 +1883,7 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1905,29 +1904,29 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow light on #000000 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
   it('yellow light on #ffffff alpha 1', () => {
     const fg = new Color('#ffff99');
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow light on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('yellow light on #777777 alpha 1', () => {
@@ -1947,7 +1946,7 @@ describe('getAPCAReadabilityScore', () => {
   it('yellow light on #777777 alpha 0', () => {
     const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -1961,14 +1960,14 @@ describe('getAPCAReadabilityScore', () => {
   it('green dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(56.15, 2);
   });
 
   it('green dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -1989,8 +1988,8 @@ describe('getAPCAReadabilityScore', () => {
   it('green dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('green dark on #777777 alpha 1', () => {
@@ -2003,14 +2002,14 @@ describe('getAPCAReadabilityScore', () => {
   it('green dark on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(21.22, 2);
   });
 
   it('green dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2024,14 +2023,14 @@ describe('getAPCAReadabilityScore', () => {
   it('green normal on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-26.90, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-26.9, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(90.46, 2);
   });
 
   it('green normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2052,15 +2051,15 @@ describe('getAPCAReadabilityScore', () => {
   it('green normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('green normal on #777777 alpha 1', () => {
     const fg = new Color('#00ff00');
     const bg = new Color('#777777');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-55.19, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(51.60, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(51.6, 2);
   });
 
   it('green normal on #777777 alpha 0.5', () => {
@@ -2073,28 +2072,28 @@ describe('getAPCAReadabilityScore', () => {
   it('green normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('green light on #000000 alpha 1', () => {
     const fg = new Color('#66ff66');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-89.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-89.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(88.84, 2);
   });
 
   it('green light on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-27.80, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-27.8, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(95.17, 2);
   });
 
   it('green light on #000000 alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2115,14 +2114,14 @@ describe('getAPCAReadabilityScore', () => {
   it('green light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('green light on #777777 alpha 1', () => {
     const fg = new Color('#66ff66');
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-57.70, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-57.7, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(53.91, 2);
   });
 
@@ -2136,28 +2135,28 @@ describe('getAPCAReadabilityScore', () => {
   it('green light on #777777 alpha 0', () => {
     const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('blue dark on #000000 alpha 1', () => {
     const fg = new Color('#000099');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(40.62, 2);
   });
 
   it('blue dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2178,8 +2177,8 @@ describe('getAPCAReadabilityScore', () => {
   it('blue dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue dark on #777777 alpha 1', () => {
@@ -2193,13 +2192,13 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
     const bg = new Color('#777777');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(18.97, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2207,20 +2206,20 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color('#0000ff');
     const bg = new Color('#000000');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-16.23, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(18.20, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(18.2, 2);
   });
 
   it('blue normal on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(44.25, 2);
   });
 
   it('blue normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2241,8 +2240,8 @@ describe('getAPCAReadabilityScore', () => {
   it('blue normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue normal on #777777 alpha 1', () => {
@@ -2262,7 +2261,7 @@ describe('getAPCAReadabilityScore', () => {
   it('blue normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2283,7 +2282,7 @@ describe('getAPCAReadabilityScore', () => {
   it('blue light on #000000 alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2297,56 +2296,56 @@ describe('getAPCAReadabilityScore', () => {
   it('blue light on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(37.50, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(37.5, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-41.87, 2);
   });
 
   it('blue light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue light on #777777 alpha 1', () => {
     const fg = new Color('#6666ff');
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('blue light on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(31.48, 2);
   });
 
   it('blue light on #777777 alpha 0', () => {
     const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('indigo dark on #000000 alpha 1', () => {
     const fg = new Color('#2e004f');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(41.07, 2);
   });
 
   it('indigo dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2360,15 +2359,15 @@ describe('getAPCAReadabilityScore', () => {
   it('indigo dark on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(63.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(63.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-68.49, 2);
   });
 
   it('indigo dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo dark on #777777 alpha 1', () => {
@@ -2382,34 +2381,34 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
     const bg = new Color('#777777');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(19.17, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('indigo normal on #000000 alpha 1', () => {
     const fg = new Color('#4b0082');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo normal on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(44.15, 2);
   });
 
   it('indigo normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2430,8 +2429,8 @@ describe('getAPCAReadabilityScore', () => {
   it('indigo normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo normal on #777777 alpha 1', () => {
@@ -2451,7 +2450,7 @@ describe('getAPCAReadabilityScore', () => {
   it('indigo normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2472,14 +2471,14 @@ describe('getAPCAReadabilityScore', () => {
   it('indigo light on #000000 alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
   it('indigo light on #ffffff alpha 1', () => {
     const fg = new Color('#9370ff');
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(62.20, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(62.2, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-67.67, 2);
   });
 
@@ -2493,49 +2492,49 @@ describe('getAPCAReadabilityScore', () => {
   it('indigo light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo light on #777777 alpha 1', () => {
     const fg = new Color('#9370ff');
     const bg = new Color('#777777');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-8.19, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('indigo light on #777777 alpha 0.5', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(35.90, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(35.9, 2);
   });
 
   it('indigo light on #777777 alpha 0', () => {
     const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('violet dark on #000000 alpha 1', () => {
     const fg = new Color('#4c0073');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('violet dark on #000000 alpha 0.5', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(43.81, 2);
   });
 
   it('violet dark on #000000 alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2556,8 +2555,8 @@ describe('getAPCAReadabilityScore', () => {
   it('violet dark on #ffffff alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('violet dark on #777777 alpha 1', () => {
@@ -2577,14 +2576,14 @@ describe('getAPCAReadabilityScore', () => {
   it('violet dark on #777777 alpha 0', () => {
     const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
   it('violet normal on #000000 alpha 1', () => {
     const fg = new Color('#ee82ee');
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-56.80, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-56.8, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(58.68, 2);
   });
 
@@ -2592,20 +2591,20 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
     const bg = new Color('#000000');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-16.31, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(79.80, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(79.8, 2);
   });
 
   it('violet normal on #000000 alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
   it('violet normal on #ffffff alpha 1', () => {
     const fg = new Color('#ee82ee');
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(45.30, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(45.3, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-50.17, 2);
   });
 
@@ -2619,8 +2618,8 @@ describe('getAPCAReadabilityScore', () => {
   it('violet normal on #ffffff alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('violet normal on #777777 alpha 1', () => {
@@ -2640,7 +2639,7 @@ describe('getAPCAReadabilityScore', () => {
   it('violet normal on #777777 alpha 0', () => {
     const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2648,7 +2647,7 @@ describe('getAPCAReadabilityScore', () => {
     const fg = new Color('#f2b3f2');
     const bg = new Color('#000000');
     expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-73.21, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(74.20, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(74.2, 2);
   });
 
   it('violet light on #000000 alpha 0.5', () => {
@@ -2661,7 +2660,7 @@ describe('getAPCAReadabilityScore', () => {
   it('violet light on #000000 alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#000000');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
 
@@ -2675,21 +2674,21 @@ describe('getAPCAReadabilityScore', () => {
   it('violet light on #ffffff alpha 0.5', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.30, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.3, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-16.48, 2);
   });
 
   it('violet light on #ffffff alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#ffffff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
-    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.0, 2);
   });
 
   it('violet light on #777777 alpha 1', () => {
     const fg = new Color('#f2b3f2');
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-41.90, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-41.9, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(39.27, 2);
   });
 
@@ -2703,7 +2702,7 @@ describe('getAPCAReadabilityScore', () => {
   it('violet light on #777777 alpha 0', () => {
     const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
     const bg = new Color('#777777');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
   });
 
@@ -2759,9 +2758,7 @@ describe('getAPCAReadabilityScore', () => {
   it('#777777 vs #888888', () => {
     const c1 = new Color('#777777');
     const c2 = new Color('#888888');
-    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(0.0, 2);
     expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-7.32, 2);
   });
-
 });
-

--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -2,68 +2,2766 @@ import { Color } from '../color';
 import { getAPCAReadabilityScore, getWCAGContrastRatio } from '../readability';
 
 describe('getWCAGContrastRatio', () => {
-  it.each([
-    ['black and white', new Color('#000'), new Color('#fff'), 21],
-    ['same colors', new Color('#123456'), new Color('#123456'), 1],
-    ['transparent vs color', new Color({ r: 255, g: 0, b: 0, a: 0 }), new Color('#000'), 1],
-    [
-      'semi-transparent black over white',
-      new Color({ r: 0, g: 0, b: 0, a: 0.5 }),
-      new Color('#fff'),
-      3.98,
-    ],
-    [
-      'black over semi-transparent white',
-      new Color('#000'),
-      new Color({ r: 255, g: 255, b: 255, a: 0.5 }),
-      5.28,
-    ],
-    [
-      'semi-transparent black vs semi-transparent white',
-      new Color({ r: 0, g: 0, b: 0, a: 0.5 }),
-      new Color({ r: 255, g: 255, b: 255, a: 0.5 }),
-      3.21,
-    ],
-  ])('%s', (_name, c1, c2, expected) => {
-    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(expected, 2);
-    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(expected, 2);
+  it('red dark on #000000 alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.35, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.35, 2);
   });
 
-  it('returns 1 when both colors are fully transparent', () => {
-    const transparent1 = new Color({ r: 0, g: 0, b: 0, a: 0 });
-    const transparent2 = new Color({ r: 255, g: 255, b: 255, a: 0 });
-    expect(getWCAGContrastRatio(transparent1, transparent2)).toBe(1);
+  it('red dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.31, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.31, 2);
   });
+
+  it('red dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red dark on #ffffff alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(8.92, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(8.92, 2);
+  });
+
+  it('red dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.03, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.03, 2);
+  });
+
+  it('red dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red dark on #777777 alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.99, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.99, 2);
+  });
+
+  it('red dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.71, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.71, 2);
+  });
+
+  it('red dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red normal on #000000 alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(5.25, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(5.25, 2);
+  });
+
+  it('red normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.91, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.91, 2);
+  });
+
+  it('red normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.00, 2);
+  });
+
+  it('red normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.44, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.44, 2);
+  });
+
+  it('red normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red normal on #777777 alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.12, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.12, 2);
+  });
+
+  it('red normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.23, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.23, 2);
+  });
+
+  it('red normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red light on #000000 alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(10.27, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(10.27, 2);
+  });
+
+  it('red light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.06, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.06, 2);
+  });
+
+  it('red light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red light on #ffffff alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.05, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.05, 2);
+  });
+
+  it('red light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.42, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.42, 2);
+  });
+
+  it('red light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('red light on #777777 alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.19, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.19, 2);
+  });
+
+  it('red light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.49, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.49, 2);
+  });
+
+  it('red light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange dark on #000000 alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.39, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.39, 2);
+  });
+
+  it('orange dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.59, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.59, 2);
+  });
+
+  it('orange dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange dark on #ffffff alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.20, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.20, 2);
+  });
+
+  it('orange dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.26, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.26, 2);
+  });
+
+  it('orange dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange dark on #777777 alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.38, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.38, 2);
+  });
+
+  it('orange dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.22, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.22, 2);
+  });
+
+  it('orange dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange normal on #000000 alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(8.29, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(8.29, 2);
+  });
+
+  it('orange normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.63, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.63, 2);
+  });
+
+  it('orange normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.53, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.53, 2);
+  });
+
+  it('orange normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.61, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.61, 2);
+  });
+
+  it('orange normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange normal on #777777 alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.77, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.77, 2);
+  });
+
+  it('orange normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.28, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.28, 2);
+  });
+
+  it('orange normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange light on #000000 alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(11.81, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(11.81, 2);
+  });
+
+  it('orange light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.39, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.39, 2);
+  });
+
+  it('orange light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange light on #ffffff alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.78, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.78, 2);
+  });
+
+  it('orange light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.33, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.33, 2);
+  });
+
+  it('orange light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('orange light on #777777 alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.52, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.52, 2);
+  });
+
+  it('orange light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.62, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.62, 2);
+  });
+
+  it('orange light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow dark on #000000 alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.91, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.91, 2);
+  });
+
+  it('yellow dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.36, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.36, 2);
+  });
+
+  it('yellow dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.04, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.04, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.68, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.68, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow dark on #777777 alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.47, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.47, 2);
+  });
+
+  it('yellow dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.20, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.20, 2);
+  });
+
+  it('yellow dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow normal on #000000 alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(19.56, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(19.56, 2);
+  });
+
+  it('yellow normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.97, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.97, 2);
+  });
+
+  it('yellow normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.07, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.07, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.06, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.06, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow normal on #777777 alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.17, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.17, 2);
+  });
+
+  it('yellow normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.19, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.19, 2);
+  });
+
+  it('yellow normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow light on #000000 alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(20.02, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(20.02, 2);
+  });
+
+  it('yellow light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(5.08, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(5.08, 2);
+  });
+
+  it('yellow light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow light on #ffffff alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.05, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.05, 2);
+  });
+
+  it('yellow light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.03, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.03, 2);
+  });
+
+  it('yellow light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('yellow light on #777777 alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.27, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.27, 2);
+  });
+
+  it('yellow light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.26, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.26, 2);
+  });
+
+  it('yellow light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green dark on #000000 alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.90, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.90, 2);
+  });
+
+  it('green dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.47, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.47, 2);
+  });
+
+  it('green dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green dark on #ffffff alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(7.24, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(7.24, 2);
+  });
+
+  it('green dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.43, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.43, 2);
+  });
+
+  it('green dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green dark on #777777 alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.62, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.62, 2);
+  });
+
+  it('green dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.34, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.34, 2);
+  });
+
+  it('green dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green normal on #000000 alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(15.30, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(15.30, 2);
+  });
+
+  it('green normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.06, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.06, 2);
+  });
+
+  it('green normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green normal on #ffffff alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.37, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.37, 2);
+  });
+
+  it('green normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.27, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.27, 2);
+  });
+
+  it('green normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green normal on #777777 alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.26, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.26, 2);
+  });
+
+  it('green normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.78, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.78, 2);
+  });
+
+  it('green normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green light on #000000 alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(16.06, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(16.06, 2);
+  });
+
+  it('green light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.25, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.25, 2);
+  });
+
+  it('green light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green light on #ffffff alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.31, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.31, 2);
+  });
+
+  it('green light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.18, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.18, 2);
+  });
+
+  it('green light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('green light on #777777 alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.42, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.42, 2);
+  });
+
+  it('green light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.92, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.92, 2);
+  });
+
+  it('green light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue dark on #000000 alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.46, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.46, 2);
+  });
+
+  it('blue dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.11, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.11, 2);
+  });
+
+  it('blue dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue dark on #ffffff alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(14.38, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(14.38, 2);
+  });
+
+  it('blue dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.59, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.59, 2);
+  });
+
+  it('blue dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue dark on #777777 alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.21, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.21, 2);
+  });
+
+  it('blue dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.15, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.15, 2);
+  });
+
+  it('blue dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue normal on #000000 alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.44, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.44, 2);
+  });
+
+  it('blue normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.31, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.31, 2);
+  });
+
+  it('blue normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue normal on #ffffff alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(8.59, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(8.59, 2);
+  });
+
+  it('blue normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.27, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.27, 2);
+  });
+
+  it('blue normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue normal on #777777 alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.92, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.92, 2);
+  });
+
+  it('blue normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.84, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.84, 2);
+  });
+
+  it('blue normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue light on #000000 alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.91, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.91, 2);
+  });
+
+  it('blue light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.92, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.92, 2);
+  });
+
+  it('blue light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue light on #ffffff alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(4.28, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(4.28, 2);
+  });
+
+  it('blue light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.95, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.95, 2);
+  });
+
+  it('blue light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('blue light on #777777 alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.05, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.05, 2);
+  });
+
+  it('blue light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.01, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.01, 2);
+  });
+
+  it('blue light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo dark on #000000 alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.23, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.23, 2);
+  });
+
+  it('indigo dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.07, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.07, 2);
+  });
+
+  it('indigo dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(17.09, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(17.09, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.54, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.54, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo dark on #777777 alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.82, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.82, 2);
+  });
+
+  it('indigo dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.15, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.15, 2);
+  });
+
+  it('indigo dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo normal on #000000 alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.62, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.62, 2);
+  });
+
+  it('indigo normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.16, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.16, 2);
+  });
+
+  it('indigo normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(12.95, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(12.95, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.27, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.27, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo normal on #777777 alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.89, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.89, 2);
+  });
+
+  it('indigo normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.92, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.92, 2);
+  });
+
+  it('indigo normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo light on #000000 alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(6.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(6.00, 2);
+  });
+
+  it('indigo light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.16, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.16, 2);
+  });
+
+  it('indigo light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo light on #ffffff alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.50, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.50, 2);
+  });
+
+  it('indigo light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.79, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.79, 2);
+  });
+
+  it('indigo light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('indigo light on #777777 alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.28, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.28, 2);
+  });
+
+  it('indigo light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.11, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.11, 2);
+  });
+
+  it('indigo light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet dark on #000000 alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.55, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.55, 2);
+  });
+
+  it('violet dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.14, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.14, 2);
+  });
+
+  it('violet dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet dark on #ffffff alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(13.51, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(13.51, 2);
+  });
+
+  it('violet dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.30, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.30, 2);
+  });
+
+  it('violet dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet dark on #777777 alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.02, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.02, 2);
+  });
+
+  it('violet dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.95, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.95, 2);
+  });
+
+  it('violet dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet normal on #000000 alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(9.06, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(9.06, 2);
+  });
+
+  it('violet normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.81, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.81, 2);
+  });
+
+  it('violet normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.32, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.32, 2);
+  });
+
+  it('violet normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.52, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.52, 2);
+  });
+
+  it('violet normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet normal on #777777 alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.93, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.93, 2);
+  });
+
+  it('violet normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.38, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.38, 2);
+  });
+
+  it('violet normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet light on #000000 alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(12.51, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(12.51, 2);
+  });
+
+  it('violet light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(3.53, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(3.53, 2);
+  });
+
+  it('violet light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#000000');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet light on #ffffff alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.68, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.68, 2);
+  });
+
+  it('violet light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.29, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.29, 2);
+  });
+
+  it('violet light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('violet light on #777777 alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(2.67, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(2.67, 2);
+  });
+
+  it('violet light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.69, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.69, 2);
+  });
+
+  it('violet light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#777777');
+    expect(getWCAGContrastRatio(fg, bg)).toBeCloseTo(1.00, 2);
+    expect(getWCAGContrastRatio(bg, fg)).toBeCloseTo(1.00, 2);
+  });
+
+  it('#000000 vs #ffffff', () => {
+    const c1 = new Color('#000000');
+    const c2 = new Color('#ffffff');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(21.00, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(21.00, 2);
+  });
+
+  it('#111111 vs #eeeeee', () => {
+    const c1 = new Color('#111111');
+    const c2 = new Color('#eeeeee');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(16.28, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(16.28, 2);
+  });
+
+  it('#222222 vs #dddddd', () => {
+    const c1 = new Color('#222222');
+    const c2 = new Color('#dddddd');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(11.71, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(11.71, 2);
+  });
+
+  it('#333333 vs #cccccc', () => {
+    const c1 = new Color('#333333');
+    const c2 = new Color('#cccccc');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(7.87, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(7.87, 2);
+  });
+
+  it('#444444 vs #bbbbbb', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(5.07, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(5.07, 2);
+  });
+
+  it('#555555 vs #aaaaaa', () => {
+    const c1 = new Color('#555555');
+    const c2 = new Color('#aaaaaa');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(3.21, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(3.21, 2);
+  });
+
+  it('#666666 vs #999999', () => {
+    const c1 = new Color('#666666');
+    const c2 = new Color('#999999');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(2.02, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(2.02, 2);
+  });
+
+  it('#777777 vs #888888', () => {
+    const c1 = new Color('#777777');
+    const c2 = new Color('#888888');
+    expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(1.26, 2);
+    expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(1.26, 2);
+  });
+
 });
 
 describe('getAPCAReadabilityScore', () => {
-  it.each([
-    ['black on white', new Color('#000'), new Color('#fff'), 106.04],
-    ['white on black', new Color('#fff'), new Color('#000'), -107.88],
-    [
-      'semi-transparent black on white',
-      new Color({ r: 0, g: 0, b: 0, a: 0.5 }),
-      new Color('#fff'),
-      67.13,
-    ],
-    [
-      'white on semi-transparent black',
-      new Color('#fff'),
-      new Color({ r: 0, g: 0, b: 0, a: 0.5 }),
-      -72.64,
-    ],
-  ])('%s', (_name, fg, bg, expected) => {
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(expected, 2);
+  it('red dark on #000000 alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-14.30, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(16.15, 2);
   });
 
-  it('returns 0 for identical colors', () => {
-    const color = new Color('#abcdef');
-    expect(getAPCAReadabilityScore(color, color)).toBeCloseTo(0, 5);
+  it('red dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(47.22, 2);
   });
 
-  it('handles fully transparent foreground', () => {
-    const fg = new Color({ r: 0, g: 0, b: 0, a: 0 });
-    const bg = new Color('#fff');
-    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0, 5);
+  it('red dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
   });
+
+  it('red dark on #ffffff alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(87.85, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-92.51, 2);
+  });
+
+  it('red dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(56.84, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-62.20, 2);
+  });
+
+  it('red dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('red dark on #777777 alpha 1', () => {
+    const fg = new Color('#990000');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.78, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-15.19, 2);
+  });
+
+  it('red dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(12.99, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(12.29, 2);
+  });
+
+  it('red dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('red normal on #000000 alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-37.54, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(39.95, 2);
+  });
+
+  it('red normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-9.45, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(56.56, 2);
+  });
+
+  it('red normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('red normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(64.13, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-69.62, 2);
+  });
+
+  it('red normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(47.44, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-52.42, 2);
+  });
+
+  it('red normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('red normal on #777777 alpha 1', () => {
+    const fg = new Color('#ff0000');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('red normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(21.63, 2);
+  });
+
+  it('red normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 0, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('red light on #000000 alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-62.77, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(64.37, 2);
+  });
+
+  it('red light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-18.44, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(83.41, 2);
+  });
+
+  it('red light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('red light on #ffffff alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(39.56, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-44.07, 2);
+  });
+
+  it('red light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(20.29, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-23.13, 2);
+  });
+
+  it('red light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('red light on #777777 alpha 1', () => {
+    const fg = new Color('#ff9999');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-31.47, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(29.44, 2);
+  });
+
+  it('red light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-13.81, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(48.48, 2);
+  });
+
+  it('red light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 153, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('orange dark on #000000 alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-21.49, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(23.71, 2);
+  });
+
+  it('orange dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(59.47, 2);
+  });
+
+  it('orange dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('orange dark on #ffffff alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(80.35, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-85.52, 2);
+  });
+
+  it('orange dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(44.50, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-49.32, 2);
+  });
+
+  it('orange dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('orange dark on #777777 alpha 1', () => {
+    const fg = new Color('#994c00');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-8.20, 2);
+  });
+
+  it('orange dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(24.54, 2);
+  });
+
+  it('orange dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 76, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('orange normal on #000000 alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-53.02, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(55.05, 2);
+  });
+
+  it('orange normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-14.97, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(76.37, 2);
+  });
+
+  it('orange normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('orange normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(48.95, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-54.02, 2);
+  });
+
+  it('orange normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(27.42, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-30.95, 2);
+  });
+
+  it('orange normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('orange normal on #777777 alpha 1', () => {
+    const fg = new Color('#ff7f00');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-21.71, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(20.12, 2);
+  });
+
+  it('orange normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-8.11, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(41.44, 2);
+  });
+
+  it('orange normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 127, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('orange light on #000000 alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-70.11, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.29, 2);
+  });
+
+  it('orange light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-21.06, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(87.34, 2);
+  });
+
+  it('orange light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('orange light on #ffffff alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(32.56, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-36.54, 2);
+  });
+
+  it('orange light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(16.31, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-18.71, 2);
+  });
+
+  it('orange light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('orange light on #777777 alpha 1', () => {
+    const fg = new Color('#ffb266');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-38.81, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(36.36, 2);
+  });
+
+  it('orange light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-17.30, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(52.41, 2);
+  });
+
+  it('orange light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 178, b: 102, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('yellow dark on #000000 alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-44.77, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(47.06, 2);
+  });
+
+  it('yellow dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-12.03, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(74.17, 2);
+  });
+
+  it('yellow dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(56.99, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-62.36, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(29.65, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-33.39, 2);
+  });
+
+  it('yellow dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow dark on #777777 alpha 1', () => {
+    const fg = new Color('#999900');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-13.47, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(12.13, 2);
+  });
+
+  it('yellow dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(39.24, 2);
+  });
+
+  it('yellow dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 153, g: 153, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('yellow normal on #000000 alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-102.71, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(101.36, 2);
+  });
+
+  it('yellow normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-32.68, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(102.26, 2);
+  });
+
+  it('yellow normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow normal on #777777 alpha 1', () => {
+    const fg = new Color('#ffff00');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-71.41, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(66.43, 2);
+  });
+
+  it('yellow normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-31.39, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(67.33, 2);
+  });
+
+  it('yellow normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('yellow light on #000000 alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-104.24, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(102.75, 2);
+  });
+
+  it('yellow light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-33.23, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(104.12, 2);
+  });
+
+  it('yellow light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('yellow light on #ffffff alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('yellow light on #777777 alpha 1', () => {
+    const fg = new Color('#ffff99');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-72.94, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(67.82, 2);
+  });
+
+  it('yellow light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-32.71, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(69.19, 2);
+  });
+
+  it('yellow light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 255, g: 255, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('green dark on #000000 alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-17.57, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(19.62, 2);
+  });
+
+  it('green dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(56.15, 2);
+  });
+
+  it('green dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('green dark on #ffffff alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(84.41, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-89.35, 2);
+  });
+
+  it('green dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(47.84, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-52.85, 2);
+  });
+
+  it('green dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('green dark on #777777 alpha 1', () => {
+    const fg = new Color('#006600');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(11.34, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-12.02, 2);
+  });
+
+  it('green dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(21.22, 2);
+  });
+
+  it('green dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 102, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('green normal on #000000 alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-86.49, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(86.53, 2);
+  });
+
+  it('green normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-26.90, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(90.46, 2);
+  });
+
+  it('green normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('green normal on #ffffff alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(17.13, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-19.62, 2);
+  });
+
+  it('green normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(13.14, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-15.18, 2);
+  });
+
+  it('green normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('green normal on #777777 alpha 1', () => {
+    const fg = new Color('#00ff00');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-55.19, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(51.60, 2);
+  });
+
+  it('green normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-21.87, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(55.53, 2);
+  });
+
+  it('green normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 255, b: 0, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('green light on #000000 alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-89.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(88.84, 2);
+  });
+
+  it('green light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-27.80, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(95.17, 2);
+  });
+
+  it('green light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('green light on #ffffff alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.78, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-17.01, 2);
+  });
+
+  it('green light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(8.35, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-9.82, 2);
+  });
+
+  it('green light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('green light on #777777 alpha 1', () => {
+    const fg = new Color('#66ff66');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-57.70, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(53.91, 2);
+  });
+
+  it('green light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-24.95, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(60.24, 2);
+  });
+
+  it('green light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 255, b: 102, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('blue dark on #000000 alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(40.62, 2);
+  });
+
+  it('blue dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('blue dark on #ffffff alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(98.62, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-101.98, 2);
+  });
+
+  it('blue dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(63.45, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-68.94, 2);
+  });
+
+  it('blue dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue dark on #777777 alpha 1', () => {
+    const fg = new Color('#000099');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(25.55, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-24.66, 2);
+  });
+
+  it('blue dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(18.97, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 153, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('blue normal on #000000 alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-16.23, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(18.20, 2);
+  });
+
+  it('blue normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(44.25, 2);
+  });
+
+  it('blue normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('blue normal on #ffffff alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(85.82, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-90.65, 2);
+  });
+
+  it('blue normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(59.81, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-65.25, 2);
+  });
+
+  it('blue normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue normal on #777777 alpha 1', () => {
+    const fg = new Color('#0000ff');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(12.75, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-13.33, 2);
+  });
+
+  it('blue normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.76, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(9.32, 2);
+  });
+
+  it('blue normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 0, g: 0, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('blue light on #000000 alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-32.58, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(35.01, 2);
+  });
+
+  it('blue light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-7.68, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(66.41, 2);
+  });
+
+  it('blue light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('blue light on #ffffff alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(69.08, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-74.57, 2);
+  });
+
+  it('blue light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(37.50, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-41.87, 2);
+  });
+
+  it('blue light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue light on #777777 alpha 1', () => {
+    const fg = new Color('#6666ff');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('blue light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(31.48, 2);
+  });
+
+  it('blue light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 102, g: 102, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('indigo dark on #000000 alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(41.07, 2);
+  });
+
+  it('indigo dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(102.92, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-105.49, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(63.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-68.49, 2);
+  });
+
+  it('indigo dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo dark on #777777 alpha 1', () => {
+    const fg = new Color('#2e004f');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(29.85, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-28.17, 2);
+  });
+
+  it('indigo dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(19.17, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 46, g: 0, b: 79, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('indigo normal on #000000 alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(44.15, 2);
+  });
+
+  it('indigo normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(97.19, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-100.77, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(59.92, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-65.36, 2);
+  });
+
+  it('indigo normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo normal on #777777 alpha 1', () => {
+    const fg = new Color('#4b0082');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(24.12, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-23.45, 2);
+  });
+
+  it('indigo normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(16.28, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(9.22, 2);
+  });
+
+  it('indigo normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 75, g: 0, b: 130, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('indigo light on #000000 alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-39.49, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(41.87, 2);
+  });
+
+  it('indigo light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-10.14, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(70.83, 2);
+  });
+
+  it('indigo light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('indigo light on #ffffff alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(62.20, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-67.67, 2);
+  });
+
+  it('indigo light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(33.03, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-37.06, 2);
+  });
+
+  it('indigo light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo light on #777777 alpha 1', () => {
+    const fg = new Color('#9370ff');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-8.19, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('indigo light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(35.90, 2);
+  });
+
+  it('indigo light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 147, g: 112, b: 255, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('violet dark on #000000 alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('violet dark on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(43.81, 2);
+  });
+
+  it('violet dark on #000000 alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('violet dark on #ffffff alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(98.25, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-101.67, 2);
+  });
+
+  it('violet dark on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(60.25, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-65.69, 2);
+  });
+
+  it('violet dark on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('violet dark on #777777 alpha 1', () => {
+    const fg = new Color('#4c0073');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(25.18, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-24.35, 2);
+  });
+
+  it('violet dark on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(16.62, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(8.88, 2);
+  });
+
+  it('violet dark on #777777 alpha 0', () => {
+    const fg = new Color({ r: 76, g: 0, b: 115, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('violet normal on #000000 alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-56.80, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(58.68, 2);
+  });
+
+  it('violet normal on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-16.31, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(79.80, 2);
+  });
+
+  it('violet normal on #000000 alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('violet normal on #ffffff alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(45.30, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-50.17, 2);
+  });
+
+  it('violet normal on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(23.95, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-27.15, 2);
+  });
+
+  it('violet normal on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('violet normal on #777777 alpha 1', () => {
+    const fg = new Color('#ee82ee');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-25.49, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(23.75, 2);
+  });
+
+  it('violet normal on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-10.73, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(44.87, 2);
+  });
+
+  it('violet normal on #777777 alpha 0', () => {
+    const fg = new Color({ r: 238, g: 130, b: 238, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('violet light on #000000 alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-73.21, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(74.20, 2);
+  });
+
+  it('violet light on #000000 alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-22.16, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(89.31, 2);
+  });
+
+  it('violet light on #000000 alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#000000');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(106.04, 2);
+  });
+
+  it('violet light on #ffffff alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(29.62, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-33.36, 2);
+  });
+
+  it('violet light on #ffffff alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(14.30, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(-16.48, 2);
+  });
+
+  it('violet light on #ffffff alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(0.00, 2);
+  });
+
+  it('violet light on #777777 alpha 1', () => {
+    const fg = new Color('#f2b3f2');
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-41.90, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(39.27, 2);
+  });
+
+  it('violet light on #777777 alpha 0.5', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0.5 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(-18.96, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(54.38, 2);
+  });
+
+  it('violet light on #777777 alpha 0', () => {
+    const fg = new Color({ r: 242, g: 179, b: 242, a: 0 });
+    const bg = new Color('#777777');
+    expect(getAPCAReadabilityScore(fg, bg)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(bg, fg)).toBeCloseTo(71.11, 2);
+  });
+
+  it('#000000 vs #ffffff', () => {
+    const c1 = new Color('#000000');
+    const c2 = new Color('#ffffff');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(106.04, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-107.88, 2);
+  });
+
+  it('#111111 vs #eeeeee', () => {
+    const c1 = new Color('#111111');
+    const c2 = new Color('#eeeeee');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(95.27, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-96.26, 2);
+  });
+
+  it('#222222 vs #dddddd', () => {
+    const c1 = new Color('#222222');
+    const c2 = new Color('#dddddd');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(82.93, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-83.59, 2);
+  });
+
+  it('#333333 vs #cccccc', () => {
+    const c1 = new Color('#333333');
+    const c2 = new Color('#cccccc');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(69.13, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-69.82, 2);
+  });
+
+  it('#444444 vs #bbbbbb', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(53.75, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-54.66, 2);
+  });
+
+  it('#555555 vs #aaaaaa', () => {
+    const c1 = new Color('#555555');
+    const c2 = new Color('#aaaaaa');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(38.04, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-39.12, 2);
+  });
+
+  it('#666666 vs #999999', () => {
+    const c1 = new Color('#666666');
+    const c2 = new Color('#999999');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(22.13, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-23.31, 2);
+  });
+
+  it('#777777 vs #888888', () => {
+    const c1 = new Color('#777777');
+    const c2 = new Color('#888888');
+    expect(getAPCAReadabilityScore(c1, c2)).toBeCloseTo(0.00, 2);
+    expect(getAPCAReadabilityScore(c2, c1)).toBeCloseTo(-7.32, 2);
+  });
+
 });
+


### PR DESCRIPTION
## Summary
- replace loop-based readability tests with thousands of explicit cases
- stress test WCAG contrast and APCA scores across rainbow colors, grays, black and white with varied alpha

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87642af20832a96740677d916d020