### PR TITLE
Add color temperature utilities

### DIFF
--- a/src/color/__test__/temperature.test.ts
+++ b/src/color/__test__/temperature.test.ts
@@ -35,4 +35,3 @@ describe('color temperature utilities', () => {
     expect(result.label).toBe(ColorTemperatureLabel.DAYLIGHT);
   });
 });
-


### PR DESCRIPTION
## Summary
- add utilities to compute and convert color temperatures
- support human-readable color temperature labels
- test color temperature helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ac75e864832abdb6870a2d496a0f