### PR TITLE
feat: add off-white detection

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -494,6 +494,14 @@ describe('Color.isDark sanity check', () => {
   });
 });
 
+describe('Color.isOffWhite sanity check', () => {
+  it('identifies off-white and non-off-white colors', () => {
+    expect(new Color('#ffffff').isOffWhite()).toBe(true);
+    expect(new Color('#f0f0f0').isOffWhite()).toBe(true);
+    expect(new Color('#dddddd').isOffWhite()).toBe(false);
+  });
+});
+
 describe('Color.getName', () => {
   it('returns the base color name and lightness modifier', () => {
     const red = new Color(BASE_HEX);

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,6 +1,6 @@
 import { Color } from '../color';
 import type { ColorHex } from '../formats';
-import { isColorDark } from '../utils';
+import { isColorDark, isColorOffWhite } from '../utils';
 
 describe('isColorDark', () => {
   const cases: Array<[ColorHex, boolean]> = [
@@ -141,5 +141,47 @@ describe('isColorDark', () => {
 
   it.each(cases)('classifies %s correctly', (hex, expected) => {
     expect(isColorDark(new Color(hex))).toBe(expected);
+  });
+});
+
+describe('isColorOffWhite', () => {
+  const cases: Array<[ColorHex, boolean]> = [
+    // Off-white color cases:
+    ['#ffffff', true],
+    ['#fefefe', true],
+    ['#fdfdfd', true],
+    ['#fcfcfc', true],
+    ['#fafafa', true],
+    ['#f5f5f5', true],
+    ['#f0f0f0', true],
+    ['#fffafa', true],
+    ['#fffaf0', true],
+    ['#f0fff0', true],
+    ['#f0ffff', true],
+    ['#f0f8ff', true],
+    ['#fff5ee', true],
+    ['#f8f8ff', true],
+    ['#fffff0', true],
+
+    // Not off-white color cases:
+    ['#eeeeee', false],
+    ['#dddddd', false],
+    ['#cccccc', false],
+    ['#fff0dd', false],
+    ['#ffff00', false],
+    ['#ff0000', false],
+    ['#00ff00', false],
+    ['#0000ff', false],
+    ['#f5deb3', false],
+    ['#e0ffff', false],
+    ['#dcdcdc', false],
+    ['#f0e68c', false],
+    ['#fffacd', false],
+    ['#ffebcd', false],
+    ['#808080', false],
+  ];
+
+  it.each(cases)('classifies %s correctly', (hex, expected) => {
+    expect(isColorOffWhite(new Color(hex))).toBe(expected);
   });
 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -67,7 +67,7 @@ import { ColorLightnessModifier, ColorNameAndLightness, getBaseColorName } from 
 import { getRandomColorRGBA, RandomColorOptions } from './random';
 import { getAPCAReadabilityScore, getWCAGContrastRatio } from './readability';
 import { ColorSwatch, getColorSwatch } from './swatch';
-import { getColorRGBAFromInput, isColorDark } from './utils';
+import { getColorRGBAFromInput, isColorDark, isColorOffWhite } from './utils';
 
 /**
  * The base omni-color object.
@@ -583,6 +583,20 @@ export class Color {
    */
   isDark(): boolean {
     return isColorDark(this);
+  }
+
+  /**
+   * Determine if the color is pure white or a very light off-white.
+   *
+   * @example
+   * ```ts
+   * new Color('#ffffff').isOffWhite(); // true
+   * new Color('#f0f0f0').isOffWhite(); // true
+   * new Color('#cccccc').isOffWhite(); // false
+   * ```
+   */
+  isOffWhite(): boolean {
+    return isColorOffWhite(this);
   }
 
   /**

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -48,3 +48,11 @@ export function isColorDark(color: Color): boolean {
   }
   return brightness < 128;
 }
+
+export function isColorOffWhite(color: Color): boolean {
+  const { r, g, b } = color.toRGB();
+  const brightness = (299 * r + 587 * g + 114 * b) / 1000;
+  const maxChannel = Math.max(r, g, b);
+  const minChannel = Math.min(r, g, b);
+  return brightness >= 240 && maxChannel - minChannel <= 30;
+}


### PR DESCRIPTION
## Summary
- add utility to check if a color is off-white
- expose `Color.isOffWhite()` for quick checks
- test off-white detection on Color and utility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b5559fc8832abe9d193a56db5b7e