### PR TITLE
feat: validate alpha input

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -251,6 +251,15 @@ describe('Color.setAlpha', () => {
     expect(color.toRGBA()).toEqual({ ...BASE_RGB, a: 0 });
   });
 
+  it('defaults to full opacity for non-finite alpha values', () => {
+    const invalidValues = [undefined, NaN, 'foo'];
+    for (const value of invalidValues) {
+      const color = new Color({ ...BASE_RGB, a: 0 });
+      color.setAlpha(value as unknown as number);
+      expect(color.getAlpha()).toBe(1);
+    }
+  });
+
   it('is chainable', () => {
     const color = new Color(BASE_RGB).setAlpha(0.25);
     expect(color.toRGBA()).toEqual({ ...BASE_RGB, a: 0.25 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -279,10 +279,10 @@ export class Color {
   /**
    * Set the alpha channel of the color.
    *
-   * @param alpha - New alpha value between `0` and `1`.
+   * @param alpha - New alpha value between `0` and `1`; defaults to `1` when the input is not a finite number.
    */
   setAlpha(alpha: number): Color {
-    this.color.a = +clampValue(alpha, 0, 1).toFixed(3);
+    this.color.a = Number.isFinite(alpha) ? +clampValue(alpha, 0, 1).toFixed(3) : 1;
     return this;
   }
 


### PR DESCRIPTION
## Summary
- default alpha to 1 when input is not a finite number
- test `setAlpha` against undefined, NaN and non-numeric inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b61d0a18832a93b28a6a69b9bb44