### PR TITLE
Default zero-sum weights to equal values in mixColors

### DIFF
--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -50,6 +50,13 @@ describe('mixColors', () => {
       '[mixColors] at least two colors are required for mixing'
     );
   });
+
+  it('defaults weights to 1 when provided weights sum to 0', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const result = mixColors([red, blue], { weights: [1, -1] });
+    expect(result.toHex()).toBe('#ff00ff');
+  });
 });
 
 describe('averageColors', () => {

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -33,16 +33,17 @@ function getWeights(
   count: number,
   inputRawWeights?: number[]
 ): { weights: number[]; sumOfWeights: number; normalizedWeights: number[] } {
-  const weights =
+  let weights =
     inputRawWeights && inputRawWeights.length === count
       ? inputRawWeights
       : new Array<number>(count).fill(1);
-  const sumOfWeights = weights.reduce((sum, w) => sum + w, 0);
+  let sumOfWeights = weights.reduce((sum, w) => sum + w, 0);
   if (sumOfWeights === 0) {
-    // This is a sort of undefined behavior case, so just return what we can
-    return { weights, sumOfWeights, normalizedWeights: weights };
+    weights = new Array<number>(count).fill(1);
+    sumOfWeights = count;
   }
-  return { weights, sumOfWeights, normalizedWeights: weights.map((w) => w / sumOfWeights) };
+  const normalizedWeights = weights.map((w) => w / sumOfWeights);
+  return { weights, sumOfWeights, normalizedWeights };
 }
 
 function mixColorsSubtractive(colors: Color[], normalizedWeights: number[]): Color {
@@ -152,7 +153,6 @@ export function mixColors(colors: Color[], options: MixColorsOptions = {}): Colo
   }
   const { type = MixType.ADDITIVE, space = MixSpace.RGB } = options;
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
-
   if (type === MixType.SUBTRACTIVE) {
     return mixColorsSubtractive(colors, normalizedWeights);
   }

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -30,17 +30,17 @@ export interface MixColorsOptions {
 }
 
 function getWeights(
-  count: number,
+  numColors: number,
   inputRawWeights?: number[]
 ): { weights: number[]; sumOfWeights: number; normalizedWeights: number[] } {
   let weights =
-    inputRawWeights && inputRawWeights.length === count
+    inputRawWeights && inputRawWeights.length === numColors
       ? inputRawWeights
-      : new Array<number>(count).fill(1);
+      : new Array<number>(numColors).fill(1);
   let sumOfWeights = weights.reduce((sum, w) => sum + w, 0);
   if (sumOfWeights === 0) {
-    weights = new Array<number>(count).fill(1);
-    sumOfWeights = count;
+    weights = new Array<number>(numColors).fill(1);
+    sumOfWeights = numColors;
   }
   const normalizedWeights = weights.map((w) => w / sumOfWeights);
   return { weights, sumOfWeights, normalizedWeights };
@@ -153,6 +153,7 @@ export function mixColors(colors: Color[], options: MixColorsOptions = {}): Colo
   }
   const { type = MixType.ADDITIVE, space = MixSpace.RGB } = options;
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
+
   if (type === MixType.SUBTRACTIVE) {
     return mixColorsSubtractive(colors, normalizedWeights);
   }


### PR DESCRIPTION
## Summary
- default to equal weights when provided weights sum to 0
- test fallback to default weights in mixColors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b629aa88832a953e6fefbf9b2481