### PR TITLE
fix: prevent negative color temperatures

### DIFF
--- a/src/color/temperature.ts
+++ b/src/color/temperature.ts
@@ -71,7 +71,13 @@ export function getColorTemperature(color: Color): ColorTemperatureAndLabel {
     const chromaY = y / sum;
     // McCamy's approximation formula to calculate correlated color temperature (CCT):
     const n = (chromaX - 0.332) / (0.1858 - chromaY); // 0.332, 0.1858 are reference points on the chromaticity diagram
-    temperature = Math.round(449 * n * n * n + 3525 * n * n + 6823.3 * n + 5520.33);
+    const cct = 449 * n * n * n + 3525 * n * n + 6823.3 * n + 5520.33;
+    // McCamy's polynomial can yield negative or invalid values for colours far from the
+    // Planckian locus. Clamp the result to `0` in those cases to avoid returning
+    // nonsensical negative temperatures.
+    if (Number.isFinite(cct)) {
+      temperature = Math.max(0, Math.round(cct));
+    }
   }
 
   return { temperature, label: getLabelForTemperature(temperature) };


### PR DESCRIPTION
## Summary
- clamp CCT calculation to avoid negative Kelvin values
- adjust and expand color temperature tests including number formatting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa19d4ab08832a9e79883761e70997