### PR TITLE
test: cover named color parsing

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -52,6 +52,11 @@ describe('Color constructor and conversion tests', () => {
     checkAllConversions(color, 1, HEX8_OPAQUE);
   });
 
+  it('correctly initializes from color name input', () => {
+    const color = new Color('red');
+    checkAllConversions(color, 1, HEX8_OPAQUE);
+  });
+
   it('correctly initializes from and converts short hex input', () => {
     const shortHex: ColorHex = '#fff';
     const color = new Color(shortHex);

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -196,4 +196,13 @@ describe('getColorRGBAFromInput', () => {
       a: 1,
     });
   });
+
+  it('parses named colors with or without spaces', () => {
+    expect(new Color(getColorRGBAFromInput('lightblue')).toHex()).toBe('#add8e6');
+    expect(new Color(getColorRGBAFromInput('light blue')).toHex()).toBe('#add8e6');
+  });
+
+  it('throws on unknown color names', () => {
+    expect(() => getColorRGBAFromInput('notacolor')).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- verify `getColorRGBAFromInput` resolves color names and rejects unknown ones
- ensure `Color` constructor handles named color input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa2ab247f4832abc433fd2317f6f14