### PR TITLE
test: verify random color pathways

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -13,7 +13,16 @@ import type {
 } from '../formats';
 import { ColorHarmony } from '../harmonies';
 import { BaseColorName, ColorLightnessModifier } from '../names';
+import { getRandomColorRGBA } from '../random';
 import { ColorTemperatureLabel } from '../temperature';
+
+jest.mock('../random', () => {
+  const actual = jest.requireActual('../random');
+  return {
+    ...actual,
+    getRandomColorRGBA: jest.fn(actual.getRandomColorRGBA),
+  };
+});
 
 const BASE_HEX: ColorHex = '#ff0000';
 const BASE_RGB: ColorRGB = { r: 255, g: 0, b: 0 };
@@ -159,6 +168,46 @@ describe('Color.random', () => {
     expect(randomizedAlpha.getAlpha()).toBe(0.5);
 
     spy.mockRestore();
+  });
+});
+
+describe('Random color pathways', () => {
+  const mockColor = { r: 10, g: 20, b: 30, a: 0.4 };
+  const randomSpy = getRandomColorRGBA as jest.Mock;
+  const actualRandom = (jest.requireActual('../random') as typeof import('../random')).getRandomColorRGBA;
+
+  beforeEach(() => {
+    randomSpy.mockImplementation(actualRandom);
+    randomSpy.mockClear();
+  });
+
+  afterEach(() => {
+    randomSpy.mockImplementation(actualRandom);
+    randomSpy.mockClear();
+  });
+
+  it('uses getRandomColorRGBA when constructed without arguments', () => {
+    randomSpy.mockReturnValue(mockColor);
+    const color = new Color();
+    expect(randomSpy).toHaveBeenCalledTimes(1);
+    expect(color.toRGB()).toEqual({ r: 10, g: 20, b: 30 });
+    expect(color.getAlpha()).toBe(0.4);
+  });
+
+  it('uses getRandomColorRGBA when constructed with null', () => {
+    randomSpy.mockReturnValue(mockColor);
+    const color = new Color(null);
+    expect(randomSpy).toHaveBeenCalledTimes(1);
+    expect(color.toRGB()).toEqual({ r: 10, g: 20, b: 30 });
+    expect(color.getAlpha()).toBe(0.4);
+  });
+
+  it('Color.random uses getRandomColorRGBA', () => {
+    randomSpy.mockReturnValue(mockColor);
+    const color = Color.random();
+    expect(randomSpy).toHaveBeenCalledTimes(1);
+    expect(color.toRGB()).toEqual({ r: 10, g: 20, b: 30 });
+    expect(color.getAlpha()).toBe(0.4);
   });
 });
 


### PR DESCRIPTION
## Summary
- mock `getRandomColorRGBA` in `color.test.ts`
- test that `new Color()`, `new Color(null)`, and `Color.random()` use the mocked RNG and return expected RGBA values
- sort test imports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa2ad52a44832ab763f754afb2a0c0