### PR TITLE
Add readability exports and tests

### DIFF
--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -1,5 +1,11 @@
 import { Color } from '../color';
-import { getAPCAReadabilityScore, getWCAGContrastRatio } from '../readability';
+import {
+  getAPCAReadabilityScore,
+  getWCAGContrastRatio,
+  isTextReadable,
+  TextReadabilityConformanceLevel,
+  TextReadabilityTextSizeOptions,
+} from '../readability';
 
 describe('getWCAGContrastRatio', () => {
   it('red dark on #000000 alpha 1', () => {
@@ -1379,6 +1385,124 @@ describe('getWCAGContrastRatio', () => {
     const c2 = new Color('#888888');
     expect(getWCAGContrastRatio(c1, c2)).toBeCloseTo(1.26, 2);
     expect(getWCAGContrastRatio(c2, c1)).toBeCloseTo(1.26, 2);
+  });
+});
+
+describe('isTextReadable', () => {
+  it('#444444 vs #bbbbbb AA small', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(isTextReadable(c1, c2)).toBe(true);
+    expect(isTextReadable(c2, c1)).toBe(true);
+  });
+
+  it('#555555 vs #aaaaaa AA small', () => {
+    const c1 = new Color('#555555');
+    const c2 = new Color('#aaaaaa');
+    expect(isTextReadable(c1, c2)).toBe(false);
+    expect(isTextReadable(c2, c1)).toBe(false);
+  });
+
+  it('#555555 vs #aaaaaa AA large', () => {
+    const c1 = new Color('#555555');
+    const c2 = new Color('#aaaaaa');
+    expect(
+      isTextReadable(c1, c2, { size: TextReadabilityTextSizeOptions.LARGE })
+    ).toBe(true);
+    expect(
+      isTextReadable(c2, c1, { size: TextReadabilityTextSizeOptions.LARGE })
+    ).toBe(true);
+  });
+
+  it('#666666 vs #999999 AA large', () => {
+    const c1 = new Color('#666666');
+    const c2 = new Color('#999999');
+    expect(
+      isTextReadable(c1, c2, { size: TextReadabilityTextSizeOptions.LARGE })
+    ).toBe(false);
+    expect(
+      isTextReadable(c2, c1, { size: TextReadabilityTextSizeOptions.LARGE })
+    ).toBe(false);
+  });
+
+  it('#333333 vs #cccccc AAA small', () => {
+    const c1 = new Color('#333333');
+    const c2 = new Color('#cccccc');
+    expect(
+      isTextReadable(c1, c2, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(true);
+    expect(
+      isTextReadable(c2, c1, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(true);
+  });
+
+  it('#444444 vs #bbbbbb AAA small', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(
+      isTextReadable(c1, c2, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(false);
+    expect(
+      isTextReadable(c2, c1, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(false);
+  });
+
+  it('#444444 vs #bbbbbb AAA large', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(
+      isTextReadable(c1, c2, {
+        level: TextReadabilityConformanceLevel.AAA,
+        size: TextReadabilityTextSizeOptions.LARGE,
+      })
+    ).toBe(true);
+    expect(
+      isTextReadable(c2, c1, {
+        level: TextReadabilityConformanceLevel.AAA,
+        size: TextReadabilityTextSizeOptions.LARGE,
+      })
+    ).toBe(true);
+  });
+
+  it('#555555 vs #aaaaaa AAA large', () => {
+    const c1 = new Color('#555555');
+    const c2 = new Color('#aaaaaa');
+    expect(
+      isTextReadable(c1, c2, {
+        level: TextReadabilityConformanceLevel.AAA,
+        size: TextReadabilityTextSizeOptions.LARGE,
+      })
+    ).toBe(false);
+    expect(
+      isTextReadable(c2, c1, {
+        level: TextReadabilityConformanceLevel.AAA,
+        size: TextReadabilityTextSizeOptions.LARGE,
+      })
+    ).toBe(false);
+  });
+
+  it('red dark 0.5 alpha on #ffffff', () => {
+    const fg = new Color({ r: 153, g: 0, b: 0, a: 0.5 });
+    const bg = new Color('#ffffff');
+    expect(isTextReadable(fg, bg)).toBe(false);
+    expect(
+      isTextReadable(fg, bg, { size: TextReadabilityTextSizeOptions.LARGE })
+    ).toBe(true);
+  });
+});
+
+describe('Color.isReadable', () => {
+  it('checks readability for colors', () => {
+    const c1 = new Color('#444444');
+    const c2 = new Color('#bbbbbb');
+    expect(c1.isReadable(c2)).toBe(true);
+    expect(c2.isReadable(c1)).toBe(true);
+    expect(
+      c1.isReadable(c2, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(false);
+    expect(
+      c2.isReadable(c1, { level: TextReadabilityConformanceLevel.AAA })
+    ).toBe(false);
   });
 });
 

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -65,7 +65,12 @@ import {
 } from './manipulations';
 import { ColorLightnessModifier, ColorNameAndLightness, getBaseColorName } from './names';
 import { getRandomColorRGBA, RandomColorOptions } from './random';
-import { getAPCAReadabilityScore, getWCAGContrastRatio } from './readability';
+import {
+  getAPCAReadabilityScore,
+  getWCAGContrastRatio,
+  isTextReadable,
+  TextReadabilityOptions,
+} from './readability';
 import { ColorSwatch, getColorSwatch } from './swatch';
 import {
   ColorTemperatureAndLabel,
@@ -646,6 +651,26 @@ export class Color {
    */
   getReadabilityScore(backgroundColor: Color): number {
     return getAPCAReadabilityScore(this, backgroundColor);
+  }
+
+  /**
+   * Determine if this color meets WCAG contrast guidelines against a background color.
+   *
+   * @param backgroundColor The background {@link Color} to compare against.
+   * @param options Optional {@link TextReadabilityOptions} for conformance level and text size.
+   * @returns `true` if the contrast ratio meets the specified requirements.
+   *
+   * @example
+   * ```ts
+   * new Color('#000000').isReadable(new Color('#ffffff')); // true
+   * new Color('#777777').isReadable(new Color('#888888')); // false
+   * ```
+   */
+  isReadable(
+    backgroundColor: Color,
+    options?: TextReadabilityOptions
+  ): boolean {
+    return isTextReadable(this, backgroundColor, options);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,11 @@ import {
 import { ColorHarmony } from './color/harmonies';
 import { BaseColorName, ColorLightnessModifier, ColorNameAndLightness } from './color/names';
 import { RandomColorOptions } from './color/random';
+import {
+  TextReadabilityConformanceLevel,
+  TextReadabilityOptions,
+  TextReadabilityTextSizeOptions,
+} from './color/readability';
 import { ColorSwatch } from './color/swatch';
 import {
   ColorTemperatureAndLabel,
@@ -63,4 +68,7 @@ export {
   MixSpace,
   MixType,
   RandomColorOptions,
+  TextReadabilityConformanceLevel,
+  TextReadabilityOptions,
+  TextReadabilityTextSizeOptions,
 };


### PR DESCRIPTION
## Summary
- add comprehensive tests for `isTextReadable` covering WCAG levels, text sizes, and alpha blending
- export `TextReadabilityConformanceLevel`, `TextReadabilityTextSizeOptions`, and `TextReadabilityOptions`
- expose `Color.isReadable()` method

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaff5976a8832a894a9d8d96abc8f7