### PR TITLE
Add color equality util and method

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -640,3 +640,21 @@ describe('Color.clone', () => {
     expect(cloned).not.toBe(color);
   });
 });
+
+describe('Color.equals', () => {
+  it('compares colors for equality', () => {
+    const color = new Color('#123456');
+    const same = new Color('rgb(18, 52, 86)');
+    const different = new Color('#654321');
+    expect(color.equals(same)).toBe(true);
+    expect(color.equals(different)).toBe(false);
+  });
+
+  it('accounts for small rounding differences', () => {
+    const base = new Color('rgba(10, 20, 30, 0.333)');
+    const rounded = new Color('rgba(11, 20, 30, 0.333)');
+    const tooFar = new Color('rgba(12, 20, 30, 0.333)');
+    expect(base.equals(rounded)).toBe(true);
+    expect(base.equals(tooFar)).toBe(false);
+  });
+});

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,19 +1,12 @@
 import { Color } from '../color';
 import { ColorTemperatureLabel, getColorFromTemperatureLabel } from '../temperature';
-import {
-  areColorsEqual,
-  getColorRGBAFromInput,
-  isColorDark,
-  isColorOffWhite,
-} from '../utils';
+import { areColorsEqual, getColorRGBAFromInput, isColorDark, isColorOffWhite } from '../utils';
 
 describe('areColorsEqual', () => {
   it('identifies identical colors across formats', () => {
     expect(areColorsEqual(new Color('#ff0000'), new Color('#ff0000'))).toBe(true);
     expect(areColorsEqual(new Color('#ffffff'), new Color('white'))).toBe(true);
-    expect(
-      areColorsEqual(new Color('rgb(0, 0, 255)'), new Color('#0000ff'))
-    ).toBe(true);
+    expect(areColorsEqual(new Color('rgb(0, 0, 255)'), new Color('#0000ff'))).toBe(true);
   });
 
   it('allows small rounding differences', () => {

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,6 +1,48 @@
 import { Color } from '../color';
 import { ColorTemperatureLabel, getColorFromTemperatureLabel } from '../temperature';
-import { getColorRGBAFromInput, isColorDark, isColorOffWhite } from '../utils';
+import {
+  areColorsEqual,
+  getColorRGBAFromInput,
+  isColorDark,
+  isColorOffWhite,
+} from '../utils';
+
+describe('areColorsEqual', () => {
+  it('identifies identical colors across formats', () => {
+    expect(areColorsEqual(new Color('#ff0000'), new Color('#ff0000'))).toBe(true);
+    expect(areColorsEqual(new Color('#ffffff'), new Color('white'))).toBe(true);
+    expect(
+      areColorsEqual(new Color('rgb(0, 0, 255)'), new Color('#0000ff'))
+    ).toBe(true);
+  });
+
+  it('allows small rounding differences', () => {
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(1, 0, 0, 0.333)'))
+    ).toBe(true);
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(0, 1, 0, 0.333)'))
+    ).toBe(true);
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(0, 0, 1, 0.333)'))
+    ).toBe(true);
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(0, 0, 0, 0.334)'))
+    ).toBe(true);
+
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(2, 0, 0, 0.333)'))
+    ).toBe(false);
+    expect(
+      areColorsEqual(new Color('rgba(0, 0, 0, 0.333)'), new Color('rgba(0, 0, 0, 0.335)'))
+    ).toBe(false);
+  });
+
+  it('returns false for different colors', () => {
+    expect(areColorsEqual(new Color('#ff0000'), new Color('#00ff00'))).toBe(false);
+    expect(areColorsEqual(new Color('#000000'), new Color('#0000ff'))).toBe(false);
+  });
+});
 
 describe('isColorDark', () => {
   it('classifies colors correctly', () => {

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -81,12 +81,7 @@ import {
   getColorTemperature,
   getColorTemperatureString,
 } from './temperature';
-import {
-  areColorsEqual,
-  getColorRGBAFromInput,
-  isColorDark,
-  isColorOffWhite,
-} from './utils';
+import { areColorsEqual, getColorRGBAFromInput, isColorDark, isColorOffWhite } from './utils';
 
 /**
  * The base omni-color object.
@@ -609,9 +604,7 @@ export class Color {
   }
 
   /**
-   * Determine if this color is equal to another color.
-   *
-   * Uses {@link areColorsEqual} to allow for minor rounding differences.
+   * Determine if this color is equal to another color. Allows for minor rounding differences.
    *
    * @param other The other {@link Color} to compare against.
    * @returns `true` if the colors are equal within rounding tolerance.

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -81,7 +81,12 @@ import {
   getColorTemperature,
   getColorTemperatureString,
 } from './temperature';
-import { getColorRGBAFromInput, isColorDark, isColorOffWhite } from './utils';
+import {
+  areColorsEqual,
+  getColorRGBAFromInput,
+  isColorDark,
+  isColorOffWhite,
+} from './utils';
 
 /**
  * The base omni-color object.
@@ -601,6 +606,24 @@ export class Color {
     options?: GenerateColorPaletteOptions
   ): ColorPalette {
     return generateColorPaletteFromBaseColor(this, harmony, options);
+  }
+
+  /**
+   * Determine if this color is equal to another color.
+   *
+   * Uses {@link areColorsEqual} to allow for minor rounding differences.
+   *
+   * @param other The other {@link Color} to compare against.
+   * @returns `true` if the colors are equal within rounding tolerance.
+   *
+   * @example
+   * ```ts
+   * new Color('#ff0000').equals(new Color('rgb(255, 0, 0)')); // true
+   * new Color('#ff0000').equals(new Color('#00ff00')); // false
+   * ```
+   */
+  equals(other: Color): boolean {
+    return areColorsEqual(this, other);
   }
 
   /**

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -103,3 +103,18 @@ export function isColorOffWhite(color: Color): boolean {
   const minChannel = Math.min(r, g, b);
   return brightness >= 240 && maxChannel - minChannel <= 30;
 }
+
+const RGB_CHANNEL_EPSILON = 1; // allow off‑by‑one rounding differences
+const ALPHA_EPSILON = 0.0015; // alpha values are rounded to three decimals and may have floating‑point error
+
+export function areColorsEqual(color1: Color, color2: Color): boolean {
+  const c1 = color1.toRGBA();
+  const c2 = color2.toRGBA();
+
+  return (
+    Math.abs(c1.r - c2.r) <= RGB_CHANNEL_EPSILON &&
+    Math.abs(c1.g - c2.g) <= RGB_CHANNEL_EPSILON &&
+    Math.abs(c1.b - c2.b) <= RGB_CHANNEL_EPSILON &&
+    Math.abs((c1.a ?? 1) - (c2.a ?? 1)) <= ALPHA_EPSILON
+  );
+}


### PR DESCRIPTION
## Summary
- add `areColorsEqual` helper to compare two colors with small tolerance
- expose `Color.equals` method that wraps the helper
- test color equality logic across formats and rounding cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab03ea6910832a87c3fc569f6ad5a8