### PR TITLE
refactor: simplify error messages

### DIFF
--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -68,7 +68,7 @@ describe('mixColors', () => {
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
     expect(() => mixColors([red])).toThrow(
-      '[mixColors] at least two colors are required for mixing'
+      'at least two colors are required for mixing'
     );
   });
 
@@ -159,7 +159,7 @@ describe('averageColors', () => {
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
     expect(() => averageColors([red])).toThrow(
-      '[averageColors] at least two colors are required for averaging'
+      'at least two colors are required for averaging'
     );
   });
 

--- a/src/color/__test__/formats.test.ts
+++ b/src/color/__test__/formats.test.ts
@@ -427,10 +427,10 @@ describe('getColorFormatType', () => {
 
   it('throws on unknown formats', () => {
     expect(() => getColorFormatType('abc' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => getColorFormatType({} as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
   });
 });

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -865,7 +865,7 @@ describe('getHarmonyColors', () => {
 
   it('throws for unknown harmony type', () => {
     expect(() => getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony)).toThrow(
-      '[getHarmonyColors] unknown color harmony: unknown'
+      'unknown color harmony: unknown'
     );
   });
 });

--- a/src/color/__test__/validations.test.ts
+++ b/src/color/__test__/validations.test.ts
@@ -3,9 +3,9 @@ import { validateColorOrThrow } from '../validations';
 describe('validateColorOrThrow nullish cases', () => {
   it('throws on undefined or null', () => {
     expect(() => validateColorOrThrow(undefined)).toThrow(
-      '[validateColorOrThrow] color is undefined'
+      'color is undefined'
     );
-    expect(() => validateColorOrThrow(null)).toThrow('[validateColorOrThrow] color is null');
+    expect(() => validateColorOrThrow(null)).toThrow('color is null');
   });
 });
 
@@ -18,25 +18,25 @@ describe('validateColorOrThrow HEX format', () => {
 
   it('rejects invalid hex strings', () => {
     expect(() => validateColorOrThrow('#ggg' as any)).toThrow(
-      /\[validateColorOrThrow\] invalid hex color/
+      /invalid hex color/
     );
     expect(() => validateColorOrThrow('#gggggg' as any)).toThrow(
-      /\[validateColorOrThrow\] invalid hex color/
+      /invalid hex color/
     );
   });
 
   it('throws on hex strings with invalid length', () => {
     expect(() => validateColorOrThrow('#' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow('#12345' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow('#1234567' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow('#123456789' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
   });
 });
@@ -49,13 +49,13 @@ describe('validateColorOrThrow HEX8 format', () => {
 
   it('rejects invalid hex8 strings', () => {
     expect(() => validateColorOrThrow('#gggggggg' as any)).toThrow(
-      /\[validateColorOrThrow\] invalid hex color/
+      /invalid hex color/
     );
     expect(() => validateColorOrThrow('#1234567g' as any)).toThrow(
-      /\[validateColorOrThrow\] invalid hex color/
+      /invalid hex color/
     );
     expect(() => validateColorOrThrow('#1234567' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
   });
 });
@@ -69,31 +69,31 @@ describe('validateColorOrThrow RGB format', () => {
 
   it('rejects out of range or non-number values', () => {
     expect(() => validateColorOrThrow({ r: -1, g: 0, b: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: -1, b: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 0, b: -1 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 256, g: 0, b: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 256, b: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 0, b: 256 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: NaN, g: 0, b: 0 } as any)).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: Infinity, b: 0 } as any)).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
     expect(() => validateColorOrThrow({ r: '255' as any, g: 0, b: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGB color/
+      /invalid RGB color/
     );
   });
 });
@@ -107,19 +107,19 @@ describe('validateColorOrThrow RGBA format', () => {
 
   it('rejects invalid RGBA objects', () => {
     expect(() => validateColorOrThrow({ r: 256, g: 0, b: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGBA color/
+      /invalid RGBA color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 0, b: 0, a: -0.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGBA color/
+      /invalid RGBA color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 0, b: 0, a: 1.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid RGBA color/
+      /invalid RGBA color/
     );
     expect(() => validateColorOrThrow({ r: 0, g: 0, b: 0, a: '0.5' as any })).toThrow(
-      /\[validateColorOrThrow\] invalid RGBA color/
+      /invalid RGBA color/
     );
     expect(() => validateColorOrThrow({ r: NaN, g: 0, b: 0, a: 0.5 } as any)).toThrow(
-      /\[validateColorOrThrow\] invalid RGBA color/
+      /invalid RGBA color/
     );
   });
 });
@@ -133,25 +133,25 @@ describe('validateColorOrThrow HSL format', () => {
 
   it('rejects invalid HSL objects', () => {
     expect(() => validateColorOrThrow({ h: -1, s: 0, l: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: 361, s: 0, l: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: -1, l: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 101, l: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: -1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: 101 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
     expect(() => validateColorOrThrow({ h: '0' as any, s: 0, l: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSL color/
+      /invalid HSL color/
     );
   });
 });
@@ -164,31 +164,31 @@ describe('validateColorOrThrow HSLA format', () => {
 
   it('rejects invalid HSLA objects', () => {
     expect(() => validateColorOrThrow({ h: -1, s: 0, l: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 361, s: 0, l: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: -1, l: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 101, l: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: -1, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: 101, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: 0, a: -0.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: 0, a: 1.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, l: 0, a: '0.5' as any })).toThrow(
-      /\[validateColorOrThrow\] invalid HSLA color/
+      /invalid HSLA color/
     );
   });
 });
@@ -202,25 +202,25 @@ describe('validateColorOrThrow HSV format', () => {
 
   it('rejects invalid HSV objects', () => {
     expect(() => validateColorOrThrow({ h: -1, s: 0, v: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: 361, s: 0, v: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: -1, v: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 101, v: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: -1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: 101 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
     expect(() => validateColorOrThrow({ h: '0' as any, s: 0, v: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSV color/
+      /invalid HSV color/
     );
   });
 });
@@ -233,31 +233,31 @@ describe('validateColorOrThrow HSVA format', () => {
 
   it('rejects invalid HSVA objects', () => {
     expect(() => validateColorOrThrow({ h: -1, s: 0, v: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 361, s: 0, v: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: -1, v: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 101, v: 0, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: -1, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: 101, a: 0.5 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: 0, a: -0.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: 0, a: 1.1 })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
     expect(() => validateColorOrThrow({ h: 0, s: 0, v: 0, a: '0.5' as any })).toThrow(
-      /\[validateColorOrThrow\] invalid HSVA color/
+      /invalid HSVA color/
     );
   });
 });
@@ -271,19 +271,19 @@ describe('validateColorOrThrow CMYK format', () => {
 
   it('rejects invalid CMYK objects', () => {
     expect(() => validateColorOrThrow({ c: -1, m: 0, y: 0, k: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid CMYK color/
+      /invalid CMYK color/
     );
     expect(() => validateColorOrThrow({ c: 0, m: 101, y: 0, k: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid CMYK color/
+      /invalid CMYK color/
     );
     expect(() => validateColorOrThrow({ c: 0, m: 0, y: -1, k: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid CMYK color/
+      /invalid CMYK color/
     );
     expect(() => validateColorOrThrow({ c: 0, m: 0, y: 0, k: 101 })).toThrow(
-      /\[validateColorOrThrow\] invalid CMYK color/
+      /invalid CMYK color/
     );
     expect(() => validateColorOrThrow({ c: '0' as any, m: 0, y: 0, k: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid CMYK color/
+      /invalid CMYK color/
     );
   });
 });
@@ -297,19 +297,19 @@ describe('validateColorOrThrow LCH format', () => {
 
   it('rejects invalid LCH objects', () => {
     expect(() => validateColorOrThrow({ l: 101, c: 0, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid LCH color/
+      /invalid LCH color/
     );
     expect(() => validateColorOrThrow({ l: 50, c: -1, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid LCH color/
+      /invalid LCH color/
     );
     expect(() => validateColorOrThrow({ l: 50, c: 0, h: -1 })).toThrow(
-      /\[validateColorOrThrow\] invalid LCH color/
+      /invalid LCH color/
     );
     expect(() => validateColorOrThrow({ l: 50, c: 0, h: 361 })).toThrow(
-      /\[validateColorOrThrow\] invalid LCH color/
+      /invalid LCH color/
     );
     expect(() => validateColorOrThrow({ l: '50' as any, c: 0, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid LCH color/
+      /invalid LCH color/
     );
   });
 });
@@ -323,19 +323,19 @@ describe('validateColorOrThrow OKLCH format', () => {
 
   it('rejects invalid OKLCH objects', () => {
     expect(() => validateColorOrThrow({ l: -0.1, c: 0, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid OKLCH color/
+      /invalid OKLCH color/
     );
     expect(() => validateColorOrThrow({ l: 0, c: -0.1, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid OKLCH color/
+      /invalid OKLCH color/
     );
     expect(() => validateColorOrThrow({ l: 0, c: '0' as any, h: 0 })).toThrow(
-      /\[validateColorOrThrow\] invalid OKLCH color/
+      /invalid OKLCH color/
     );
     expect(() => validateColorOrThrow({ l: 0, c: 0, h: -1 })).toThrow(
-      /\[validateColorOrThrow\] invalid OKLCH color/
+      /invalid OKLCH color/
     );
     expect(() => validateColorOrThrow({ l: 0, c: 0, h: 361 })).toThrow(
-      /\[validateColorOrThrow\] invalid OKLCH color/
+      /invalid OKLCH color/
     );
   });
 });
@@ -343,19 +343,19 @@ describe('validateColorOrThrow OKLCH format', () => {
 describe('validateColorOrThrow unknown format', () => {
   it('throws on unknown input', () => {
     expect(() => validateColorOrThrow({} as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow({ foo: 'bar' } as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow({ r: 0 } as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow([] as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
     expect(() => validateColorOrThrow('not-a-color' as any)).toThrow(
-      /\[getColorFormatType\] unknown color format/
+      /unknown color format/
     );
   });
 });

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -153,7 +153,7 @@ function mixColorsAdditive(
 
 export function mixColors(colors: Color[], options: MixColorsOptions = {}): Color {
   if (colors.length < 2) {
-    throw new Error('[mixColors] at least two colors are required for mixing');
+    throw new Error('at least two colors are required for mixing');
   }
   const { type = MixType.ADDITIVE, space = MixSpace.RGB } = options;
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
@@ -253,7 +253,7 @@ export interface AverageColorsOptions {
 
 export function averageColors(colors: Color[], options: AverageColorsOptions = {}): Color {
   if (colors.length < 2) {
-    throw new Error('[averageColors] at least two colors are required for averaging');
+    throw new Error('at least two colors are required for averaging');
   }
   const { space = MixSpace.RGB } = options;
   const { normalizedWeights } = getWeights(colors.length, options.weights);

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -425,7 +425,7 @@ export function toRGB(color: ColorFormat): ColorRGB {
     case ColorFormatType.OKLCH:
       return oklchToRGB(value);
     default:
-      throw new Error(`[toRGB] unknown color format: ${formatType}`);
+      throw new Error(`unknown color format: ${formatType}`);
   }
 }
 
@@ -455,7 +455,7 @@ export function toRGBA(color: ColorFormat): ColorRGBA {
     case ColorFormatType.OKLCH:
       return oklchToRGBA(value);
     default:
-      throw new Error(`[toRGBA] unknown color format: ${formatType}`);
+      throw new Error(`unknown color format: ${formatType}`);
   }
 }
 
@@ -486,7 +486,7 @@ export function toHex(color: ColorFormat): ColorHex {
     case ColorFormatType.OKLCH:
       return rgbToHex(oklchToRGB(value));
     default:
-      throw new Error(`[toHex] unknown color format: ${formatType}`);
+      throw new Error(`unknown color format: ${formatType}`);
   }
 }
 
@@ -517,7 +517,7 @@ export function toHex8(color: ColorFormat): ColorHex {
     case ColorFormatType.OKLCH:
       return rgbToHex8(oklchToRGB(value));
     default:
-      throw new Error(`[toHex8] unknown color format: ${formatType}`);
+      throw new Error(`unknown color format: ${formatType}`);
   }
 }
 

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -105,7 +105,7 @@ function getHexColorFormatType(color: ColorHex): ColorFormatTypeAndValue {
       return { formatType: ColorFormatType.HEX8, value: colorLowerCase as ColorHex };
     }
   }
-  throw new Error(`[getColorFormatType] unknown color format: "${JSON.stringify(color)}"`);
+  throw new Error(`unknown color format: "${JSON.stringify(color)}"`);
 }
 
 export function getColorFormatType(color: ColorFormat): ColorFormatTypeAndValue {
@@ -145,7 +145,7 @@ export function getColorFormatType(color: ColorFormat): ColorFormatTypeAndValue 
       : { formatType: ColorFormatType.RGB, value: color };
   }
 
-  throw new Error(`[getColorFormatType] unknown color format: "${JSON.stringify(color)}"`);
+  throw new Error(`unknown color format: "${JSON.stringify(color)}"`);
 }
 
 function getDecimalString(value: number, digits = 3): number {

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -147,6 +147,6 @@ export function getHarmonyColors(
     case ColorHarmony.MONOCHROMATIC:
       return getMonochromaticHarmonyColors(color);
     default:
-      throw new Error(`[getHarmonyColors] unknown color harmony: ${harmony}`);
+      throw new Error(`unknown color harmony: ${harmony}`);
   }
 }

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -37,7 +37,7 @@ export function getColorRGBAFromInput(color?: ColorFormat | Color | string | nul
       return parsedColor.toRGBA();
     }
 
-    throw new Error(`[getColorRGBAFromInput] unknown color name or format: "${color}"`);
+    throw new Error(`unknown color name or format: "${color}"`);
   }
 
   return color ? toRGBA(color) : getRandomColorRGBA();

--- a/src/color/validations.ts
+++ b/src/color/validations.ts
@@ -102,10 +102,10 @@ function isValidOKLCHColor(color: ColorOKLCH): boolean {
 
 export function validateColorOrThrow(color?: ColorFormat | null): void {
   if (color === undefined) {
-    throw new Error('[validateColorOrThrow] color is undefined');
+    throw new Error('color is undefined');
   }
   if (color === null) {
-    throw new Error('[validateColorOrThrow] color is null');
+    throw new Error('color is null');
   }
 
   const { formatType, value } = getColorFormatType(color);
@@ -113,55 +113,55 @@ export function validateColorOrThrow(color?: ColorFormat | null): void {
     case ColorFormatType.HEX:
     case ColorFormatType.HEX8:
       if (!isValidHexColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid hex color: "${value}"`);
+        throw new Error(`invalid hex color: "${value}"`);
       }
       break;
     case ColorFormatType.RGB:
       if (!isValidRGBColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid RGB color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid RGB color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.RGBA:
       if (!isValidRGBAColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid RGBA color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid RGBA color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.HSL:
       if (!isValidHSLColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid HSL color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid HSL color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.HSLA:
       if (!isValidHSLAColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid HSLA color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid HSLA color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.HSV:
       if (!isValidHSVColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid HSV color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid HSV color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.HSVA:
       if (!isValidHSVAColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid HSVA color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid HSVA color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.CMYK:
       if (!isValidCMYKColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid CMYK color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid CMYK color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.LCH:
       if (!isValidLCHColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid LCH color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid LCH color: "${JSON.stringify(value)}"`);
       }
       break;
     case ColorFormatType.OKLCH:
       if (!isValidOKLCHColor(value)) {
-        throw new Error(`[validateColorOrThrow] invalid OKLCH color: "${JSON.stringify(value)}"`);
+        throw new Error(`invalid OKLCH color: "${JSON.stringify(value)}"`);
       }
       break;
     default:
-      throw new Error(`[validateColorOrThrow] unknown color format: "${formatType}"`);
+      throw new Error(`unknown color format: "${formatType}"`);
   }
 }


### PR DESCRIPTION
## Summary
- remove function name tags from thrown errors
- update tests for new error messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab930177f4832a84432f5f5ecd5534