### PR TITLE
feat: support short hex with alpha

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -88,6 +88,12 @@ describe('Color constructor and conversion tests', () => {
     expect(oklch.c).toBeCloseTo(0, 6);
   });
 
+  it('correctly initializes from and converts short hex with alpha input', () => {
+    const shortHex8: ColorHex = '#f008';
+    const color = new Color(shortHex8);
+    checkAllConversions(color, 0.533, '#ff000088');
+  });
+
   it('correctly initializes from and converts hex8 input', () => {
     const color = new Color(HEX8_SEMI_TRANSPARENT);
     checkAllConversions(color, 0.502, HEX8_SEMI_TRANSPARENT);

--- a/src/color/__test__/conversions.test.ts
+++ b/src/color/__test__/conversions.test.ts
@@ -20,6 +20,7 @@ describe('conversions', () => {
       expect(toRGB('#f00')).toEqual({ r: 255, g: 0, b: 0 });
       expect(toRGB('#ff0000ff')).toEqual({ r: 255, g: 0, b: 0 });
       expect(toRGB('#ff000080')).toEqual({ r: 255, g: 0, b: 0 });
+      expect(toRGB('#f008')).toEqual({ r: 255, g: 0, b: 0 });
       expect(toRGB({ r: 255, g: 0, b: 0 })).toEqual({ r: 255, g: 0, b: 0 });
       expect(toRGB({ r: 255, g: 0, b: 0, a: 0.5 })).toEqual({ r: 255, g: 0, b: 0 });
       expect(toRGB({ h: 0, s: 100, l: 50 })).toEqual({ r: 255, g: 0, b: 0 });
@@ -71,6 +72,12 @@ describe('conversions', () => {
       expect(fromHex8.b).toBe(0);
       expect(fromHex8.a).toBeCloseTo(0.502, 3);
 
+      const fromShortHex8 = toRGBA('#f008');
+      expect(fromShortHex8.r).toBe(255);
+      expect(fromShortHex8.g).toBe(0);
+      expect(fromShortHex8.b).toBe(0);
+      expect(fromShortHex8.a).toBeCloseTo(0.533, 3);
+
       const fromRGBA = toRGBA({ r: 255, g: 0, b: 0, a: 0.5 });
       expect(fromRGBA.r).toBe(255);
       expect(fromRGBA.g).toBe(0);
@@ -90,6 +97,11 @@ describe('conversions', () => {
       expect(fromHSVA.a).toBeCloseTo(0.5, 3);
     });
 
+    it('#RGBA converts to hex8 and back', () => {
+      const roundTrip = toHex8(toRGBA('#f008'));
+      expect(roundTrip).toBe('#ff000088');
+    });
+
     it('throws on invalid RGBA', () => {
       expect(() => toRGBA({ r: 256, g: 0, b: 0, a: 1 } as ColorRGBA)).toThrow();
     });
@@ -105,6 +117,7 @@ describe('conversions', () => {
       expect(toHex('#f00')).toBe('#ff0000');
       expect(toHex('#ff0000ff')).toBe('#ff0000');
       expect(toHex('#ff000080')).toBe('#ff0000');
+      expect(toHex('#f008')).toBe('#ff0000');
       expect(toHex({ r: 255, g: 0, b: 0 })).toBe('#ff0000');
       expect(toHex({ r: 255, g: 0, b: 0, a: 0.5 })).toBe('#ff0000');
       expect(toHex({ h: 0, s: 100, l: 50 })).toBe('#ff0000');
@@ -140,6 +153,7 @@ describe('conversions', () => {
 
     it('preserves alpha when converting', () => {
       expect(toHex8('#ff000080')).toBe('#ff000080');
+      expect(toHex8('#f008')).toBe('#ff000088');
       expect(toHex8({ r: 255, g: 0, b: 0, a: 0.5 })).toBe('#ff000080');
       expect(toHex8({ h: 0, s: 100, l: 50, a: 0.5 })).toBe('#ff000080');
       expect(toHex8({ h: 0, s: 100, v: 100, a: 0.5 })).toBe('#ff000080');

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -36,6 +36,11 @@ function hexOrHex8ToRGBA(hex: ColorHex): ColorRGBA {
     r = parseInt(raw[0] + raw[0], 16);
     g = parseInt(raw[1] + raw[1], 16);
     b = parseInt(raw[2] + raw[2], 16);
+  } else if (raw.length === 4) {
+    r = parseInt(raw[0] + raw[0], 16);
+    g = parseInt(raw[1] + raw[1], 16);
+    b = parseInt(raw[2] + raw[2], 16);
+    a = parseInt(raw[3] + raw[3], 16) / 255;
   } else {
     r = parseInt(raw.slice(0, 2), 16);
     g = parseInt(raw.slice(2, 4), 16);

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -84,6 +84,12 @@ function getHexColorFormatType(color: ColorHex): ColorFormatTypeAndValue {
           `#${colorLowerCase[1]}${colorLowerCase[1]}${colorLowerCase[2]}${colorLowerCase[2]}${colorLowerCase[3]}${colorLowerCase[3]}` as ColorHex,
       };
     }
+    if (colorLowerCase.length === 5) {
+      return {
+        formatType: 'HEX8',
+        value: `#${colorLowerCase[1]}${colorLowerCase[1]}${colorLowerCase[2]}${colorLowerCase[2]}${colorLowerCase[3]}${colorLowerCase[3]}${colorLowerCase[4]}${colorLowerCase[4]}` as ColorHex,
+      };
+    }
     if (colorLowerCase.length === 7) {
       return { formatType: 'HEX', value: colorLowerCase as ColorHex };
     }

--- a/src/color/validations.ts
+++ b/src/color/validations.ts
@@ -12,7 +12,7 @@ import type {
 } from './formats';
 import { getColorFormatType } from './formats';
 
-const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
 function isValidHexColor(color: string): boolean {
   return HEX_COLOR_REGEX.test(color);


### PR DESCRIPTION
## Summary
- support parsing of 4-digit #RGBA colors
- allow short hex with alpha in validations
- test #RGBA round-trips through conversions and Color class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a3d9e4b4832a96f454046def78fe