### PR TITLE
Add color() parsing and color string output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ _`constructor`_
 - <ins>Returns</ins> a new [`Color`](#types-color) instance of the specified color input.
 - <ins>Inputs</ins>:
   - `color` (optional) - an existing [`Color`](#types-color), any valid [`ColorFormat`](#types-color-format), a named CSS color, or any parsable color format (e.g. `"rgb(0,255,255)"`) including partial or exact matches of a [`ColorTemperatureLabel`](#types-color-temperature-label).
+    - Supports modern CSS Color 4/5 syntax including `hwb()`, `lab()`, `lch()`, `oklch()`, and `color()` for the `srgb`, `display-p3`, and `rec2020` color spaces.
     - No input or passing in `null`/`undefined` generates a random color.
     - **Invalid inputs throw an exception.**
 
@@ -393,6 +394,21 @@ new Color('#00b7eb').toOKLCH(); // { l: 0.727148, c: 0.140767, h: 227.27 }
 
 ```ts
 new Color('#00b7eb').toOKLCHString(); // 'oklch(0.727148 0.140767 227.27)'
+```
+
+#### `toColorString(options?: ColorStringOptions): string`
+
+- <ins>Returns</ins> a CSS `"color(space r g b / a)"` string in the requested color space.
+- <ins>Inputs</ins>:
+  - `options` (optional) - `ColorStringOptions`:
+    - `space` (optional) - target color space for the `color()` string: [`ColorSpace`](#types-color-space). Defaults to `"SRGB"`.
+
+```ts
+new Color('#ff000080').toColorString(); // 'color(srgb 1 0 0 / 0.5)'
+new Color('#ff000080').toColorString({ space: 'DISPLAY-P3' });
+// 'color(display-p3 0.917488 0.200287 0.138561 / 0.5)'
+new Color('#336699').toColorString({ space: 'rec2020' });
+// 'color(rec2020 0.250128 0.336705 0.537794)'
 ```
 
 ### Color Manipulations
@@ -905,6 +921,7 @@ bestSwatchBackground.toHex(); // '#301308'
   - <span id="types-color-oklab">`ColorOKLAB`</span> - OKLAB color space with lightness and color-opponent dimensions. `{ l: number; a: number; b: number }` where `l` is a number between 0 and 1 (lightness), and `a` and `b` are numbers typically between -0.4 and 0.4 (color-opponent dimensions).
   - <span id="types-color-lch">`ColorLCH`</span> - CIELCh color space with lightness, chroma, and hue. `{ l: number; c: number; h: number }` where `l` is a number between 0 and 100 (lightness), `c` is a number representing chroma (typically 0–150+), and `h` is a number between 0 and 360 (hue in degrees).
   - <span id="types-color-oklch">`ColorOKLCH`</span> - OKLCH color space with lightness, chroma, and hue. `{ l: number; c: number; h: number }` where `l` is a number between 0 and 1 (lightness), `c` is a number representing chroma (typically 0–0.4), and `h` is a number between 0 and 360 (hue in degrees).
+- <span id="types-color-space">`ColorSpace`</span> - supported color spaces for `color()` output: `"SRGB" | "DISPLAY-P3" | "REC2020"`.
 - <span id="types-color-temperature-label">`ColorTemperatureLabel`</span> - color temperature options: `"Candlelight" | "Incandescent lamp" | "Halogen lamp" | "Fluorescent lamp" | "Daylight" | "Cloudy sky" | "Shade" | "Blue sky"`
 - <span id="types-base-color-swatch">`BaseColorSwatch`</span> - a swatch representing shades of the same color from 100 to 900 `{ 100: number; 200 number; ... 900: number }` where `100` is the lightest shade and `900` is the darkest shade.
 - <span id="types-extended-color-swatch">`ExtendedColorSwatch`</span> - same as a [`ColorSwatch`](#types-color-swatch) but includes half-shades at 50, 100, 150, ..., 950. It is a superset of [`ColorSwatch`](#types-color-swatch).

--- a/demo/src/components/ColorInfoCard.tsx
+++ b/demo/src/components/ColorInfoCard.tsx
@@ -129,7 +129,7 @@ export function ColorInfoCard({ color, extended }: Props) {
         </div>
       </div>
       {extended && (
-        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 items-start">
           <InfoBox color={color} colorStrings={[color.toHex(), color.toHex8()]} title="HEX" />
           <InfoBox
             color={color}
@@ -148,6 +148,15 @@ export function ColorInfoCard({ color, extended }: Props) {
           <InfoBox color={color} colorStrings={[color.toOKLCHString()]} title="OKLCH" />
           <InfoBox color={color} colorStrings={[color.toHWBString()]} title="HWB" />
           <InfoBox color={color} colorStrings={[color.toHWBAString()]} title="HWBA" />
+          <InfoBox
+            color={color}
+            colorStrings={[
+              color.toColorString({ space: 'SRGB' }),
+              color.toColorString({ space: 'DISPLAY-P3' }),
+              color.toColorString({ space: 'REC2020' }),
+            ]}
+            title="color()"
+          />
         </div>
       )}
     </Card>

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -282,6 +282,13 @@ describe('Color.toXString methods', () => {
     expect(color.toLCHString()).toBe('lch(53.233% 104.576 40)');
     expect(color.toOKLABString()).toBe('oklab(0.627955 0.224863 0.125846)');
     expect(color.toOKLCHString()).toBe('oklch(0.627955 0.257683 29.234)');
+    expect(color.toColorString()).toBe('color(srgb 1 0 0 / 0.5)');
+    expect(color.toColorString({ space: 'display-p3' })).toBe(
+      'color(display-p3 0.917488 0.200287 0.138561 / 0.5)'
+    );
+    expect(color.toColorString({ space: 'REC2020' })).toBe(
+      'color(rec2020 0.791977 0.230976 0.073761 / 0.5)'
+    );
   });
 });
 

--- a/src/color/__test__/colorSpaces.test.ts
+++ b/src/color/__test__/colorSpaces.test.ts
@@ -1,0 +1,86 @@
+import type { CaseInsensitive } from '../../utils';
+import {
+  convertColorSpaceValuesToRGB,
+  convertRGBToColorSpaceValues,
+  parseColorSpace,
+  resolveColorSpace,
+} from '../colorSpaces';
+
+describe('parseColorSpace', () => {
+  it('parses supported spaces case-insensitively', () => {
+    expect(parseColorSpace('srgb')).toBe('SRGB');
+    expect(parseColorSpace('Display-P3')).toBe('DISPLAY-P3');
+    expect(parseColorSpace('REC2020')).toBe('REC2020');
+  });
+
+  it('returns null for unsupported spaces', () => {
+    expect(parseColorSpace('foo')).toBeNull();
+    expect(parseColorSpace('')).toBeNull();
+  });
+});
+
+describe('resolveColorSpace', () => {
+  it('defaults to SRGB when no value is provided', () => {
+    expect(resolveColorSpace()).toBe('SRGB');
+  });
+
+  it('normalizes supported inputs', () => {
+    expect(resolveColorSpace('display-p3')).toBe('DISPLAY-P3');
+    expect(resolveColorSpace(' rec2020 ' as unknown as CaseInsensitive<'REC2020'>)).toBe('REC2020');
+  });
+
+  it('falls back to SRGB for unsupported values', () => {
+    expect(resolveColorSpace('unknown' as unknown as CaseInsensitive<'SRGB'>)).toBe('SRGB');
+  });
+});
+
+describe('convertColorSpaceValuesToRGB', () => {
+  it('converts sRGB inputs directly', () => {
+    expect(convertColorSpaceValuesToRGB({ r: 1, g: 0, b: 0 }, 'SRGB')).toEqual({
+      r: 255,
+      g: 0,
+      b: 0,
+    });
+  });
+
+  it('converts Display-P3 values to RGB', () => {
+    expect(convertColorSpaceValuesToRGB({ r: 0.5, g: 0.2, b: 0.1 }, 'DISPLAY-P3')).toEqual({
+      r: 138,
+      g: 44,
+      b: 13,
+    });
+  });
+
+  it('converts Rec.2020 values to RGB', () => {
+    expect(convertColorSpaceValuesToRGB({ r: 0.25, g: 0.5, b: 0.75 }, 'REC2020')).toEqual({
+      r: 0,
+      g: 144,
+      b: 204,
+    });
+  });
+});
+
+describe('convertRGBToColorSpaceValues', () => {
+  it('converts RGB to sRGB-normalized values', () => {
+    const srgb = convertRGBToColorSpaceValues({ r: 255, g: 0, b: 0 }, 'SRGB');
+    expect(srgb.r).toBeCloseTo(1, 12);
+    expect(srgb.g).toBeCloseTo(0, 12);
+    expect(srgb.b).toBeCloseTo(0, 12);
+  });
+
+  it('converts RGB to Display-P3 and back to RGB', () => {
+    const rgb = { r: 51, g: 102, b: 153 };
+    const displayP3 = convertRGBToColorSpaceValues(rgb, 'DISPLAY-P3');
+    expect(displayP3.r).toBeCloseTo(0.249851, 6);
+    expect(displayP3.g).toBeCloseTo(0.39524, 6);
+    expect(displayP3.b).toBeCloseTo(0.584034, 6);
+    expect(convertColorSpaceValuesToRGB(displayP3, 'DISPLAY-P3')).toEqual(rgb);
+  });
+
+  it('converts RGB to Rec.2020 values', () => {
+    const rec2020 = convertRGBToColorSpaceValues({ r: 51, g: 102, b: 153 }, 'REC2020');
+    expect(rec2020.r).toBeCloseTo(0.250128, 6);
+    expect(rec2020.g).toBeCloseTo(0.336705, 6);
+    expect(rec2020.b).toBeCloseTo(0.537794, 6);
+  });
+});

--- a/src/color/__test__/formats.test.ts
+++ b/src/color/__test__/formats.test.ts
@@ -1,6 +1,7 @@
 import { Color } from '../color';
 import {
   cmykToString,
+  colorToString,
   getColorFormatType,
   hslaToString,
   hslToString,
@@ -202,6 +203,22 @@ describe('hslaToString', () => {
   it('rounds hsla components to three decimals', () => {
     expect(hslaToString({ h: 123.4567, s: 50.5555, l: 10.1234, a: 0.98765 })).toBe(
       'hsl(123.457 50.556% 10.123% / 0.988)'
+    );
+  });
+});
+
+describe('colorToString', () => {
+  it('generates color() strings in different spaces', () => {
+    const opaque = new Color('#336699');
+    const translucent = new Color('#336699cc');
+
+    expect(colorToString(opaque.toRGBA())).toBe('color(srgb 0.2 0.4 0.6)');
+    expect(colorToString(translucent.toRGBA())).toBe('color(srgb 0.2 0.4 0.6 / 0.8)');
+    expect(colorToString(translucent.toRGBA(), { space: 'display-p3' })).toBe(
+      'color(display-p3 0.249851 0.39524 0.584034 / 0.8)'
+    );
+    expect(colorToString(opaque.toRGBA(), { space: 'rec2020' })).toBe(
+      'color(rec2020 0.250128 0.336705 0.537794)'
     );
   });
 });

--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -67,6 +67,21 @@ describe('parseCSSColorFormatString', () => {
     });
   });
 
+  it('parses color() inputs', () => {
+    expect(parseCSSColorFormatString('color(srgb 1 0 0)')?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('color(srgb 100% 0% 0% / 25%)')?.toHex8()).toBe('#ff000040');
+    expect(parseCSSColorFormatString('color(srgb, 1, 1, 1, 50%)')?.toHex8()).toBe('#ffffff80');
+    expect(parseCSSColorFormatString('color(display-p3 0 100% 0 / 75%)')?.toHex8()).toBe(
+      '#00ff00bf'
+    );
+    expect(parseCSSColorFormatString('color(display-p3, 50%, 20%, 10% / 0.5)')?.toHex8()).toBe(
+      '#8a2c0d80'
+    );
+    expect(parseCSSColorFormatString('color(rec2020 25% 50% 75%)')?.toHex()).toBe('#0090cc');
+    expect(parseCSSColorFormatString('color(rec2020 0 0.5 1 / 0.25)')?.toHex8()).toBe('#0092ff40');
+    expect(parseCSSColorFormatString('color(REC2020 0% 0% 0% / 100%)')?.toHex()).toBe('#000000');
+  });
+
   it('parses HSL inputs', () => {
     expect(parseCSSColorFormatString('hsl(0, 0%, 0%)')?.toHex()).toBe('#000000');
     expect(parseCSSColorFormatString('hsl(0, 0%, 100%)')?.toHex()).toBe('#ffffff');
@@ -211,5 +226,7 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('oklch(-0.1 0 0)')).toBeNull();
     expect(parseCSSColorFormatString('hwb(0 0%)')).toBeNull();
     expect(parseCSSColorFormatString('foo(1,2,3)')).toBeNull();
+    expect(parseCSSColorFormatString('color(foo 1 0 0)')).toBeNull();
+    expect(parseCSSColorFormatString('color(display-p3 1 0)')).toBeNull();
   });
 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -29,7 +29,7 @@ import {
   toOKLCH,
   toRGB,
 } from './conversions';
-import { type DeltaEOptions,getDeltaE } from './deltaE';
+import { type DeltaEOptions, getDeltaE } from './deltaE';
 import {
   cmykToString,
   type ColorCMYK,
@@ -58,7 +58,7 @@ import {
   rgbaToString,
   rgbToString,
 } from './formats';
-import { type ColorGradientOptions,createColorGradient } from './gradients';
+import { type ColorGradientOptions, createColorGradient } from './gradients';
 import {
   type ColorHarmony,
   type ColorHarmonyOptions,
@@ -81,7 +81,7 @@ import {
   saturateColor,
   spinColorHue,
 } from './manipulations';
-import { type ColorNameAndLightness,getBaseColorName } from './names';
+import { type ColorNameAndLightness, getBaseColorName } from './names';
 import { getRandomColorRGBA, type RandomColorOptions } from './random';
 import {
   getAPCAReadabilityScore,

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,8 +1,18 @@
-import type { ColorPalette, GenerateColorPaletteOptions } from '../palette/palette';
-import { generateColorPaletteFromBaseColor } from '../palette/palette';
+import {
+  type ColorPalette,
+  generateColorPaletteFromBaseColor,
+  type GenerateColorPaletteOptions,
+} from '../palette/palette';
 import { type CaseInsensitive, clampValue } from '../utils';
-import type { AverageColorsOptions, BlendColorsOptions, MixColorsOptions } from './combinations';
-import { averageColors, blendColors, mixColors } from './combinations';
+import type { ColorStringOptions } from './colorSpaces';
+import {
+  averageColors,
+  type AverageColorsOptions,
+  blendColors,
+  type BlendColorsOptions,
+  mixColors,
+  type MixColorsOptions,
+} from './combinations';
 import {
   toCMYK,
   toHex,
@@ -19,26 +29,24 @@ import {
   toOKLCH,
   toRGB,
 } from './conversions';
-import type { DeltaEOptions } from './deltaE';
-import { getDeltaE } from './deltaE';
-import type {
-  ColorCMYK,
-  ColorHex,
-  ColorHSL,
-  ColorHSLA,
-  ColorHSV,
-  ColorHSVA,
-  ColorHWB,
-  ColorHWBA,
-  ColorLAB,
-  ColorLCH,
-  ColorOKLAB,
-  ColorOKLCH,
-  ColorRGB,
-  ColorRGBA,
-} from './formats';
+import { type DeltaEOptions,getDeltaE } from './deltaE';
 import {
   cmykToString,
+  type ColorCMYK,
+  type ColorHex,
+  type ColorHSL,
+  type ColorHSLA,
+  type ColorHSV,
+  type ColorHSVA,
+  type ColorHWB,
+  type ColorHWBA,
+  type ColorLAB,
+  type ColorLCH,
+  type ColorOKLAB,
+  type ColorOKLCH,
+  type ColorRGB,
+  type ColorRGBA,
+  colorToString,
   hslaToString,
   hslToString,
   hwbaToString,
@@ -50,10 +58,10 @@ import {
   rgbaToString,
   rgbToString,
 } from './formats';
-import type { ColorGradientOptions } from './gradients';
-import { createColorGradient } from './gradients';
-import type { ColorHarmony, ColorHarmonyOptions } from './harmonies';
+import { type ColorGradientOptions,createColorGradient } from './gradients';
 import {
+  type ColorHarmony,
+  type ColorHarmonyOptions,
   getAnalogousHarmonyColors,
   getComplementaryColors,
   getHarmonyColors,
@@ -63,24 +71,18 @@ import {
   getTetradicHarmonyColors,
   getTriadicHarmonyColors,
 } from './harmonies';
-import type { ColorBrightnessOptions, ColorSaturationOptions } from './manipulations';
 import {
   brightenColor,
+  type ColorBrightnessOptions,
+  type ColorSaturationOptions,
   colorToGrayscale,
   darkenColor,
   desaturateColor,
   saturateColor,
   spinColorHue,
 } from './manipulations';
-import type { ColorNameAndLightness } from './names';
-import { getBaseColorName } from './names';
-import type { RandomColorOptions } from './random';
-import { getRandomColorRGBA } from './random';
-import type {
-  ReadabilityComparisonOptions,
-  TextReadabilityOptions,
-  TextReadabilityReport,
-} from './readability';
+import { type ColorNameAndLightness,getBaseColorName } from './names';
+import { getRandomColorRGBA, type RandomColorOptions } from './random';
 import {
   getAPCAReadabilityScore,
   getBestBackgroundColorForText,
@@ -88,27 +90,33 @@ import {
   getTextReadabilityReport,
   getWCAGContrastRatio,
   isTextReadable,
+  type ReadabilityComparisonOptions,
+  type TextReadabilityOptions,
+  type TextReadabilityReport,
 } from './readability';
-import type { ColorSwatch, ColorSwatchOptions, ExtendedColorSwatch } from './swatch';
-import { getColorSwatch } from './swatch';
-import type {
-  ColorTemperatureAndLabel,
-  ColorTemperatureLabel,
-  ColorTemperatureStringFormatOptions,
-} from './temperature';
 import {
+  type ColorSwatch,
+  type ColorSwatchOptions,
+  type ExtendedColorSwatch,
+  getColorSwatch,
+} from './swatch';
+import {
+  type ColorTemperatureAndLabel,
+  type ColorTemperatureLabel,
+  type ColorTemperatureStringFormatOptions,
   getColorFromTemperature,
   getColorFromTemperatureLabel,
   getColorTemperature,
   getColorTemperatureString,
 } from './temperature';
-import type { IsColorDarkOptions, ValidColorInputFormat } from './utils';
 import {
   areColorsEqual,
   getColorList,
   getColorRGBAFromInput,
   isColorDark,
+  type IsColorDarkOptions,
   isColorOffWhite,
+  type ValidColorInputFormat,
 } from './utils';
 
 /**
@@ -413,6 +421,13 @@ export class Color {
    */
   toOKLCHString(): string {
     return oklchToString(this.toOKLCH());
+  }
+
+  /**
+   * Get the color as a CSS `color()` string in the chosen color space (`srgb`, `display-p3`, or `rec2020`).
+   */
+  toColorString(options?: ColorStringOptions): string {
+    return colorToString(this.toRGBA(), options);
   }
 
   /**

--- a/src/color/colorSpaces.ts
+++ b/src/color/colorSpaces.ts
@@ -1,0 +1,160 @@
+import { type CaseInsensitive, clampValue } from '../utils';
+import type { ColorRGB } from './formats';
+import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
+
+export type ColorSpace = 'SRGB' | 'DISPLAY-P3' | 'REC2020';
+
+export interface ColorSpaceValues {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface ColorStringOptions {
+  space?: CaseInsensitive<ColorSpace>;
+}
+
+const SRGB_TO_XYZ_MATRIX: readonly number[][] = [
+  [0.41239079926595934, 0.357584339383878, 0.1804807884018343],
+  [0.21263900587151027, 0.715168678767756, 0.07219231536073371],
+  [0.01933081871559185, 0.11919477979462598, 0.9505321522496607],
+];
+
+const XYZ_TO_SRGB_MATRIX: readonly number[][] = [
+  [3.240969941904521, -1.537383177570093, -0.498610760293],
+  [-0.96924363628087, 1.87596750150772, 0.041555057407175],
+  [0.055630079696993, -0.20397695888897, 1.056971514242878],
+];
+
+const DISPLAY_P3_TO_XYZ_MATRIX: readonly number[][] = [
+  [0.4865709486482162, 0.26566769316909306, 0.1982172852343625],
+  [0.2289745640697488, 0.6917385218365064, 0.079286914093745],
+  [0, 0.04511338185890264, 1.043944368900976],
+];
+
+const XYZ_TO_DISPLAY_P3_MATRIX: readonly number[][] = [
+  [2.493496911941425, -0.9313836179191239, -0.40271078445071684],
+  [-0.8294889695615747, 1.7626640603183463, 0.023624685841943577],
+  [0.03584583024378447, -0.07617238926804182, 0.9568845240076872],
+];
+
+const REC2020_TO_XYZ_MATRIX: readonly number[][] = [
+  [0.6369580483012914, 0.14461690358620832, 0.1688809751641721],
+  [0.2627002120112671, 0.6779980715188708, 0.05930171646986196],
+  [0, 0.028072693049087428, 1.060985057710791],
+];
+
+const XYZ_TO_REC2020_MATRIX: readonly number[][] = [
+  [1.716651187971268, -0.355670783776392, -0.25336628137366],
+  [-0.666684351832489, 1.616481236634939, 0.0157685458139111],
+  [0.0176398574453108, -0.0427706132578085, 0.942103121235474],
+];
+
+const REC2020_ALPHA = 1.09929682680944;
+const REC2020_BETA = 0.018053968510807;
+const REC2020_GAMMA = 0.45;
+
+function multiply3x3(matrix: readonly number[][], vector: readonly number[]): [number, number, number] {
+  const [x, y, z] = vector;
+  return [
+    matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z,
+    matrix[1][0] * x + matrix[1][1] * y + matrix[1][2] * z,
+    matrix[2][0] * x + matrix[2][1] * y + matrix[2][2] * z,
+  ];
+}
+
+function decodeRec2020Channel(encoded: number): number {
+  const value = clampValue(encoded, 0, 1);
+  if (value < 4.5 * REC2020_BETA) {
+    return value / 4.5;
+  }
+  return ((value + (REC2020_ALPHA - 1)) / REC2020_ALPHA) ** (1 / REC2020_GAMMA);
+}
+
+function encodeRec2020Channel(linear: number): number {
+  const value = clampValue(linear, 0, 1);
+  if (value < REC2020_BETA) {
+    return value * 4.5;
+  }
+  return REC2020_ALPHA * value ** REC2020_GAMMA - (REC2020_ALPHA - 1);
+}
+
+function decodeColorSpaceChannel(value: number, space: ColorSpace): number {
+  if (space === 'REC2020') {
+    return decodeRec2020Channel(value);
+  }
+  return srgbChannelToLinear(value * 255, 'SRGB');
+}
+
+function encodeColorSpaceChannel(value: number, space: ColorSpace): number {
+  if (space === 'REC2020') {
+    return clampValue(encodeRec2020Channel(value), 0, 1);
+  }
+  return clampValue(linearChannelToSrgb(value, 'SRGB') / 255, 0, 1);
+}
+
+function getSpaceToXYZMatrix(space: ColorSpace): readonly number[][] {
+  if (space === 'DISPLAY-P3') {
+    return DISPLAY_P3_TO_XYZ_MATRIX;
+  }
+  if (space === 'REC2020') {
+    return REC2020_TO_XYZ_MATRIX;
+  }
+  return SRGB_TO_XYZ_MATRIX;
+}
+
+function getXYZToSpaceMatrix(space: ColorSpace): readonly number[][] {
+  if (space === 'DISPLAY-P3') {
+    return XYZ_TO_DISPLAY_P3_MATRIX;
+  }
+  if (space === 'REC2020') {
+    return XYZ_TO_REC2020_MATRIX;
+  }
+  return XYZ_TO_SRGB_MATRIX;
+}
+
+export function parseColorSpace(space: string): ColorSpace | null {
+  const normalized = space.trim().toUpperCase();
+  if (normalized === 'SRGB' || normalized === 'DISPLAY-P3' || normalized === 'REC2020') {
+    return normalized as ColorSpace;
+  }
+  return null;
+}
+
+export function resolveColorSpace(space?: CaseInsensitive<ColorSpace>): ColorSpace {
+  return parseColorSpace(space ?? 'SRGB') ?? 'SRGB';
+}
+
+export function convertColorSpaceValuesToRGB(values: ColorSpaceValues, space: ColorSpace): ColorRGB {
+  const linear = [
+    decodeColorSpaceChannel(values.r, space),
+    decodeColorSpaceChannel(values.g, space),
+    decodeColorSpaceChannel(values.b, space),
+  ] as const;
+
+  const srgbLinear =
+    space === 'SRGB' ? linear : multiply3x3(XYZ_TO_SRGB_MATRIX, multiply3x3(getSpaceToXYZMatrix(space), linear));
+
+  return {
+    r: Math.round(clampValue(linearChannelToSrgb(srgbLinear[0], 'SRGB'), 0, 255)),
+    g: Math.round(clampValue(linearChannelToSrgb(srgbLinear[1], 'SRGB'), 0, 255)),
+    b: Math.round(clampValue(linearChannelToSrgb(srgbLinear[2], 'SRGB'), 0, 255)),
+  };
+}
+
+export function convertRGBToColorSpaceValues(rgb: ColorRGB, space: ColorSpace): ColorSpaceValues {
+  const srgbLinear = [
+    srgbChannelToLinear(rgb.r, 'SRGB'),
+    srgbChannelToLinear(rgb.g, 'SRGB'),
+    srgbChannelToLinear(rgb.b, 'SRGB'),
+  ] as const;
+
+  const targetLinear =
+    space === 'SRGB' ? srgbLinear : multiply3x3(getXYZToSpaceMatrix(space), multiply3x3(SRGB_TO_XYZ_MATRIX, srgbLinear));
+
+  return {
+    r: encodeColorSpaceChannel(targetLinear[0], space),
+    g: encodeColorSpaceChannel(targetLinear[1], space),
+    b: encodeColorSpaceChannel(targetLinear[2], space),
+  };
+}

--- a/src/color/colorSpaces.ts
+++ b/src/color/colorSpaces.ts
@@ -54,7 +54,10 @@ const REC2020_ALPHA = 1.09929682680944;
 const REC2020_BETA = 0.018053968510807;
 const REC2020_GAMMA = 0.45;
 
-function multiply3x3(matrix: readonly number[][], vector: readonly number[]): [number, number, number] {
+function multiply3x3(
+  matrix: readonly number[][],
+  vector: readonly number[]
+): [number, number, number] {
   const [x, y, z] = vector;
   return [
     matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z,
@@ -125,7 +128,10 @@ export function resolveColorSpace(space?: CaseInsensitive<ColorSpace>): ColorSpa
   return parseColorSpace(space ?? 'SRGB') ?? 'SRGB';
 }
 
-export function convertColorSpaceValuesToRGB(values: ColorSpaceValues, space: ColorSpace): ColorRGB {
+export function convertColorSpaceValuesToRGB(
+  values: ColorSpaceValues,
+  space: ColorSpace
+): ColorRGB {
   const linear = [
     decodeColorSpaceChannel(values.r, space),
     decodeColorSpaceChannel(values.g, space),
@@ -133,7 +139,9 @@ export function convertColorSpaceValuesToRGB(values: ColorSpaceValues, space: Co
   ] as const;
 
   const srgbLinear =
-    space === 'SRGB' ? linear : multiply3x3(XYZ_TO_SRGB_MATRIX, multiply3x3(getSpaceToXYZMatrix(space), linear));
+    space === 'SRGB'
+      ? linear
+      : multiply3x3(XYZ_TO_SRGB_MATRIX, multiply3x3(getSpaceToXYZMatrix(space), linear));
 
   return {
     r: Math.round(clampValue(linearChannelToSrgb(srgbLinear[0], 'SRGB'), 0, 255)),
@@ -150,7 +158,9 @@ export function convertRGBToColorSpaceValues(rgb: ColorRGB, space: ColorSpace): 
   ] as const;
 
   const targetLinear =
-    space === 'SRGB' ? srgbLinear : multiply3x3(getXYZToSpaceMatrix(space), multiply3x3(SRGB_TO_XYZ_MATRIX, srgbLinear));
+    space === 'SRGB'
+      ? srgbLinear
+      : multiply3x3(getXYZToSpaceMatrix(space), multiply3x3(SRGB_TO_XYZ_MATRIX, srgbLinear));
 
   return {
     r: encodeColorSpaceChannel(targetLinear[0], space),

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -1,4 +1,6 @@
 import type { CaseInsensitive } from '../utils';
+import type { ColorStringOptions } from './colorSpaces';
+import { convertRGBToColorSpaceValues, resolveColorSpace } from './colorSpaces';
 
 export type ColorHex = `#${string}`;
 
@@ -239,6 +241,24 @@ export function getColorFormatType(color: ColorFormat): ColorFormatTypeAndValue 
 
 function getDecimalString(value: number, digits = 3): number {
   return +value.toFixed(digits);
+}
+
+function formatColorFunctionChannel(value: number): number {
+  return getDecimalString(value, 6);
+}
+
+export function colorToString(color: ColorRGBA, options?: ColorStringOptions): string {
+  const space = resolveColorSpace(options?.space);
+  const values = convertRGBToColorSpaceValues(color, space);
+  const base = `${formatColorFunctionChannel(values.r)} ${formatColorFunctionChannel(
+    values.g
+  )} ${formatColorFunctionChannel(values.b)}`;
+
+  if (color.a !== undefined && color.a < 1) {
+    return `color(${space.toLowerCase()} ${base} / ${getDecimalString(color.a)})`;
+  }
+
+  return `color(${space.toLowerCase()} ${base})`;
 }
 
 export function rgbToString({ r, g, b }: ColorRGB): string {

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -1,6 +1,10 @@
 import { clampValue } from '../utils';
 import { Color } from './color';
-import { type ColorSpaceValues, convertColorSpaceValuesToRGB, parseColorSpace } from './colorSpaces';
+import {
+  type ColorSpaceValues,
+  convertColorSpaceValuesToRGB,
+  parseColorSpace,
+} from './colorSpaces';
 import type { ColorFormat } from './formats';
 
 const MATCH_RGB_STRING_REGEX = /^rgb\((.+)\)$/;
@@ -120,7 +124,10 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
       return null;
     }
 
-    const channelSection = params.slice(separatorIndex).trim().replace(/^[,\s]+/, '');
+    const channelSection = params
+      .slice(separatorIndex)
+      .trim()
+      .replace(/^[,\s]+/, '');
     const colorParams = splitColorFunctionParams(channelSection, {
       expectedChannels: 3,
       allowAlpha: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { Color } from './color/color';
+import type { ColorSpace, ColorStringOptions } from './color/colorSpaces';
 import type { BlendMode, BlendSpace, MixSpace, MixType } from './color/combinations';
 import { AverageColorsOptions, BlendColorsOptions, MixColorsOptions } from './color/combinations';
 import type { CIE94Options, CIEDE2000Options, DeltaEMethod, DeltaEOptions } from './color/deltaE';
-import type { ColorFormat } from './color/formats';
 import {
   ColorCMYK,
+  type ColorFormat,
   ColorHex,
   ColorHSL,
   ColorHSLA,
@@ -87,6 +88,8 @@ export {
   ColorRGBA,
   ColorSaturationOptions,
   type ColorSaturationSpace,
+  type ColorSpace,
+  type ColorStringOptions,
   ColorSwatch,
   ColorSwatchOptions,
   ColorTemperatureAndLabel,


### PR DESCRIPTION
## Summary
- add parsing support for CSS color() inputs in srgb, display-p3, and rec2020 spaces with alpha handling
- add Color.toColorString plus formatting utilities and exports for color() output options
- refine documentation and add dedicated color space conversion tests to cover edge cases and type exports

## Testing
- npm test
- npm run lint
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695421550744832a8aa002a93e87f2cc)