### PR TITLE
Harden Color immutability and clone readability selection results

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -846,6 +846,7 @@ describe('Color.getMostReadableTextColor', () => {
 
     const result = background.getMostReadableTextColor([gray, charcoal, black]);
     expect(result.toHex()).toBe('#000000');
+    expect(result).not.toBe(black);
   });
 
   it('can evaluate candidates with APCA scoring', () => {
@@ -884,6 +885,7 @@ describe('Color.getMostReadableTextColor', () => {
     const basicSwatch = new Color('#21352e').getColorSwatch({ centerOn500: true });
     const resultBasic = background.getMostReadableTextColor(basicSwatch);
     expect(resultBasic.equals(basicSwatch[900])).toBe(true);
+    expect(resultBasic).not.toBe(basicSwatch[900]);
 
     const extendedSwatch = new Color('#0ea5e9ff').getColorSwatch({
       extended: true,
@@ -891,6 +893,7 @@ describe('Color.getMostReadableTextColor', () => {
     });
     const resultExtended = background.getMostReadableTextColor(extendedSwatch);
     expect(resultExtended.equals(extendedSwatch[950])).toBe(true);
+    expect(resultExtended).not.toBe(extendedSwatch[950]);
   });
 });
 
@@ -951,6 +954,7 @@ describe('Color.getBestBackgroundColor', () => {
 
     const result = textColor.getBestBackgroundColor([darkGray, slate, white]);
     expect(result.toHex()).toBe(white.toHex());
+    expect(result).not.toBe(white);
   });
 
   it('respects WCAG options when picking the closest match', () => {
@@ -1008,6 +1012,7 @@ describe('Color.getBestBackgroundColor', () => {
     const basicSwatch = new Color('#3e3623ff').getColorSwatch();
     const resultBasic = textColor.getBestBackgroundColor(basicSwatch);
     expect(resultBasic.equals(basicSwatch[100])).toBe(true);
+    expect(resultBasic).not.toBe(basicSwatch[100]);
 
     const extendedSwatch = new Color('#eab308').getColorSwatch({
       extended: true,
@@ -1015,6 +1020,7 @@ describe('Color.getBestBackgroundColor', () => {
     });
     const resultExtended = textColor.getBestBackgroundColor(extendedSwatch);
     expect(resultExtended.equals(extendedSwatch[50])).toBe(true);
+    expect(resultExtended).not.toBe(extendedSwatch[50]);
   });
 });
 
@@ -1069,6 +1075,36 @@ describe('Color.clone', () => {
     const cloned = color.clone();
     expect(cloned).toEqual(color);
     expect(cloned).not.toBe(color);
+  });
+});
+
+describe('Color immutability', () => {
+  it('returns defensive copies from toRGBA', () => {
+    const color = new Color('#336699');
+    const firstRGBA = color.toRGBA();
+    const secondRGBA = color.toRGBA();
+
+    expect(firstRGBA).toEqual(secondRGBA);
+    expect(firstRGBA).not.toBe(secondRGBA);
+
+    firstRGBA.r = 255;
+    firstRGBA.g = 255;
+    firstRGBA.b = 255;
+    firstRGBA.a = 0;
+
+    expect(color.toHex()).toBe('#336699');
+    expect(color.getAlpha()).toBe(1);
+  });
+
+  it('does not expose mutable internal state through runtime property access', () => {
+    const original = new Color('#123456');
+    const sameValueClone = new Color(original);
+
+    const runtimePrivateColor = Reflect.get(original as unknown as Record<string, unknown>, 'color');
+    expect(runtimePrivateColor).toBeUndefined();
+    expect(original.toHex()).toBe('#123456');
+    expect(sameValueClone.toHex()).toBe('#123456');
+    expect(sameValueClone).not.toBe(original);
   });
 });
 

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -137,7 +137,7 @@ import {
  * ```
  */
 export class Color {
-  private color: ColorRGBA;
+  readonly #color: Readonly<ColorRGBA>;
 
   /**
    * Create a new {@link Color} instance.
@@ -163,7 +163,7 @@ export class Color {
    */
   constructor(color?: ValidColorInputFormat | null) {
     // getColorRGBAFromInput always returns a fresh object
-    this.color = getColorRGBAFromInput(color);
+    this.#color = Object.freeze({ ...getColorRGBAFromInput(color) });
   }
 
   /**
@@ -236,7 +236,7 @@ export class Color {
    * ```
    */
   toHex(): ColorHex {
-    return toHex(this.color);
+    return toHex(this.#color);
   }
 
   /**
@@ -248,14 +248,14 @@ export class Color {
    * ```
    */
   toHex8(): ColorHex {
-    return toHex8(this.color);
+    return toHex8(this.#color);
   }
 
   /**
    * Get the color as a {@link ColorRGB} `{ r, g, b }` object.
    */
   toRGB(): ColorRGB {
-    return toRGB(this.color);
+    return toRGB(this.#color);
   }
 
   /**
@@ -269,7 +269,7 @@ export class Color {
    * Get the color as a {@link ColorRGBA} `{ r, g, b, a }` object.
    */
   toRGBA(): ColorRGBA {
-    return { ...this.color };
+    return { ...this.#color };
   }
 
   /**
@@ -284,7 +284,7 @@ export class Color {
    * and `l` are 0–100.
    */
   toHSL(): ColorHSL {
-    return toHSL(this.color);
+    return toHSL(this.#color);
   }
 
   /**
@@ -298,7 +298,7 @@ export class Color {
    * Get the color as a {@link ColorHSLA} `{ h, s, l, a }` object.
    */
   toHSLA(): ColorHSLA {
-    return toHSLA(this.color);
+    return toHSLA(this.#color);
   }
 
   /**
@@ -313,7 +313,7 @@ export class Color {
    * and `b` are 0–100.
    */
   toHWB(): ColorHWB {
-    return toHWB(this.color);
+    return toHWB(this.#color);
   }
 
   /**
@@ -327,7 +327,7 @@ export class Color {
    * Get the color as a {@link ColorHWBA} `{ h, w, b, a }` object.
    */
   toHWBA(): ColorHWBA {
-    return toHWBA(this.color);
+    return toHWBA(this.#color);
   }
 
   /**
@@ -342,14 +342,14 @@ export class Color {
    * and `v` are 0–100.
    */
   toHSV(): ColorHSV {
-    return toHSV(this.color);
+    return toHSV(this.#color);
   }
 
   /**
    * Get the color as a {@link ColorHSVA} `{ h, s, v, a }` object.
    */
   toHSVA(): ColorHSVA {
-    return toHSVA(this.color);
+    return toHSVA(this.#color);
   }
 
   /**
@@ -357,7 +357,7 @@ export class Color {
    * 0–100.
    */
   toCMYK(): ColorCMYK {
-    return toCMYK(this.color);
+    return toCMYK(this.#color);
   }
 
   /**
@@ -371,7 +371,7 @@ export class Color {
    * Get the color as a {@link ColorLAB} `{ l, a, b }` object.
    */
   toLAB(): ColorLAB {
-    return toLAB(this.color);
+    return toLAB(this.#color);
   }
 
   /**
@@ -385,7 +385,7 @@ export class Color {
    * Get the color as a {@link ColorLCH} (CIELCh) `{ l, c, h }` object.
    */
   toLCH(): ColorLCH {
-    return toLCH(this.color);
+    return toLCH(this.#color);
   }
 
   /**
@@ -399,7 +399,7 @@ export class Color {
    * Get the color as a {@link ColorOKLAB} `{ l, a, b }` object.
    */
   toOKLAB(): ColorOKLAB {
-    return toOKLAB(this.color);
+    return toOKLAB(this.#color);
   }
 
   /**
@@ -413,7 +413,7 @@ export class Color {
    * Get the color as a {@link ColorOKLCH} `{ l, c, h }` object.
    */
   toOKLCH(): ColorOKLCH {
-    return toOKLCH(this.color);
+    return toOKLCH(this.#color);
   }
 
   /**
@@ -434,7 +434,7 @@ export class Color {
    * Return the alpha channel of the color (0–1).
    */
   getAlpha(): number {
-    return this.color.a;
+    return this.#color.a;
   }
 
   /**
@@ -447,7 +447,7 @@ export class Color {
    */
   setAlpha(alpha: number): Color {
     return new Color({
-      ...this.color,
+      ...this.#color,
       a: Number.isFinite(alpha) ? +clampValue(alpha, 0, 1).toFixed(3) : 1,
     });
   }
@@ -976,7 +976,7 @@ export class Color {
     textColors: readonly ValidColorInputFormat[] | ColorSwatch,
     options?: ReadabilityComparisonOptions
   ): Color {
-    return getMostReadableTextColorForBackground(this, getColorList(textColors), options);
+    return getMostReadableTextColorForBackground(this, getColorList(textColors), options).clone();
   }
 
   /**
@@ -1010,7 +1010,7 @@ export class Color {
     backgroundColors: readonly ValidColorInputFormat[] | ColorSwatch,
     options?: ReadabilityComparisonOptions
   ): Color {
-    return getBestBackgroundColorForText(this, getColorList(backgroundColors), options);
+    return getBestBackgroundColorForText(this, getColorList(backgroundColors), options).clone();
   }
 
   /**
@@ -1068,6 +1068,6 @@ export class Color {
    * @returns A new {@link Color} instance with the same color value.
    */
   clone(): Color {
-    return new Color({ ...this.color });
+    return new Color({ ...this.#color });
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure `Color` instances cannot be mutated or have their internal state observed/modified at runtime, and guarantee every method that returns color data or picks a `Color` returns a fresh copy so two `Color` instances can never share mutable internal state.

### Description
- Replace the TypeScript-private `color` field with a JavaScript private field `#color` and store a frozen copy in the constructor via `this.#color = Object.freeze({ ...getColorRGBAFromInput(color) })` to prevent runtime access or mutation (file: `src/color/color.ts`).
- Update all `Color` methods to read from `#color` and continue returning defensive copies where appropriate (e.g. `toRGBA()` now returns `{ ...this.#color }`, `clone()` uses `{ ...this.#color }`).
- Change readability-selection APIs to return clones so callers never receive a reference to the original candidate instances by writing `getMostReadableTextColor(...).clone()` and `getBestBackgroundColor(...).clone()` (file: `src/color/color.ts`).
- Add tests asserting immutability and copy semantics, including defensive-copy behavior of `toRGBA()`, that readability selection results are equal-but-not-identical to candidates, and that runtime access to a `color` field is not possible (file: `src/color/__test__/color.test.ts`).

### Testing
- Ran `npm run lint` and the linter completed without errors.
- Ran `npm run typecheck` (`tsc`) and the typecheck passed.
- Ran `npm run test` and all automated tests passed: `Test Suites: 20 passed, 20 total` and `Tests: 1033 passed, 1033 total`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c7838984832a8019c0ac0d30b402)