### PR TITLE
docs: update manipulation examples to options-object API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import { Color } from 'omni-color';
 
 const color = new Color('#ff7f50');
 const translucent = color.setAlpha(0.5);
-const darker = translucent.darken();
+const darker = translucent.darken({ amount: 20 });
 const hex8String = darker.toHex8();
 ```
 

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -132,7 +132,7 @@ import {
  * ```ts
  * const red = new Color('#ff0000');
  * red.toHSL(); // { h: 0, s: 100, l: 50 }
- * const darker = red.darken(20); // new Color
+ * const darker = red.darken({ amount: 20 }); // new Color
  * red.toHex(); // '#ff0000'
  * ```
  */
@@ -480,7 +480,7 @@ export class Color {
    *
    * @example
    * ```ts
-   * new Color('#808080').brighten(20).toHex(); // '#b3b3b3'
+   * new Color('#808080').brighten({ amount: 20 }).toHex(); // '#b3b3b3'
    * ```
    */
   brighten(options?: ColorBrightnessOptions): Color {
@@ -497,7 +497,7 @@ export class Color {
    *
    * @example
    * ```ts
-   * new Color('#808080').darken(20).toHex(); // '#4d4d4d'
+   * new Color('#808080').darken({ amount: 20 }).toHex(); // '#4d4d4d'
    * ```
    */
   darken(options?: ColorBrightnessOptions): Color {
@@ -514,7 +514,7 @@ export class Color {
    *
    * @example
    * ```ts
-   * new Color('hsl(0, 50%, 50%)').saturate(20).toHSLString();
+   * new Color('hsl(0, 50%, 50%)').saturate({ amount: 20 }).toHSLString();
    * // 'hsl(0, 70%, 50%)'
    * ```
    */
@@ -532,7 +532,7 @@ export class Color {
    *
    * @example
    * ```ts
-   * new Color('hsl(0, 50%, 50%)').desaturate(20).toHSLString();
+   * new Color('hsl(0, 50%, 50%)').desaturate({ amount: 20 }).toHSLString();
    * // 'hsl(0, 30%, 50%)'
    * ```
    */


### PR DESCRIPTION
### Motivation
- Update outdated JSDoc and README examples that showed the older positional API for manipulation methods so they reflect the current options-object API (e.g. `darken({ amount: 20 })`).

### Description
- Replace example calls in `src/color/color.ts` and the README so `brighten`, `darken`, `saturate`, and `desaturate` use the `options` object form (for example, `brighten({ amount: 20 })` and `saturate({ amount: 20 })`).

### Testing
- Ran `npm run lint`, `npm run typecheck`, and `npm run test`, and all checks passed (test suites: 20 passed, 1033 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3898f3f9c832ab2e4b3a697a65cb8)