### PR TITLE
Parse hue angle units (deg, rad, grad, turn) in CSS color functions

### DIFF
--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -93,6 +93,11 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('hsl(180, 100%, 50%)')?.toHex()).toBe('#00ffff');
     expect(parseCSSColorFormatString('hsl(300, 100%, 50%)')?.toHex()).toBe('#ff00ff');
     expect(parseCSSColorFormatString('hsl(120deg, 100%, 25%)')?.toHex()).toBe('#008000');
+    expect(parseCSSColorFormatString('hsl(0.5turn 100% 50%)')?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hsl(3.141592653589793rad 100% 50%)')?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('hsl(200grad 100% 50%)')?.toHex()).toBe('#00ffff');
   });
 
   it('parses HSLA inputs', () => {
@@ -143,6 +148,9 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('hwb(210 10% 30% / 0.25)')?.toHex8()).toBe('#1a66b340');
     expect(parseCSSColorFormatString('hwb(210 10% 30% 25%)')?.toHex8()).toBe('#1a66b340');
     expect(parseCSSColorFormatString('hwb(480 0% 0%)')?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('hwb(0.5turn 0% 0%)')?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hwb(3.141592653589793rad 0% 0%)')?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hwb(200grad 0% 0%)')?.toHex()).toBe('#00ffff');
   });
 
   it('parses flexible HSL and HSV inputs', () => {
@@ -185,6 +193,15 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('lch(97.138% 96.91 102.852)')?.toHex()).toBe('#ffff00');
     expect(parseCSSColorFormatString('lch(91.117% 50.115 196.386)')?.toHex()).toBe('#00ffff');
     expect(parseCSSColorFormatString('lch(60.32% 115.567 328.233)')?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('lch(91.117% 50.115 0.5455166667turn)')?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('lch(91.117% 50.115 3.427586338rad)')?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('lch(91.117% 50.115 218.2066667grad)')?.toHex()).toBe(
+      '#00ffff',
+    );
   });
 
   it('parses OKLCH inputs', () => {
@@ -197,6 +214,15 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('oklch(0.967983 0.211006 109.769)')?.toHex()).toBe('#ffff00');
     expect(parseCSSColorFormatString('oklch(0.905399 0.15455 194.769)')?.toHex()).toBe('#00ffff');
     expect(parseCSSColorFormatString('oklch(0.701674 0.322491 328.363)')?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 0.541025turn)')?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 3.399358831rad)')?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 216.41grad)')?.toHex()).toBe(
+      '#00ffff',
+    );
   });
 
   it('parses additional forgiving input variations', () => {

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -19,6 +19,7 @@ const MATCH_LAB_STRING_REGEX = /^lab\((.+)\)$/;
 const MATCH_LCH_STRING_REGEX = /^lch\((.+)\)$/;
 const MATCH_OKLCH_STRING_REGEX = /^oklch\((.+)\)$/;
 const MATCH_COLOR_FUNCTION_REGEX = /^color\((.+)\)$/;
+const MATCH_HUE_ANGLE_REGEX = /^([-+]?(?:\d+\.?\d*|\.\d+)(?:e[-+]?\d+)?)(deg|rad|grad|turn)?$/i;
 
 interface SplitColorParamsOptions {
   allowAlpha?: boolean;
@@ -98,6 +99,33 @@ function clampAlpha(value: number): number {
 function normalizeHue(value: number): number {
   const normalized = value % 360;
   return normalized < 0 ? normalized + 360 : normalized;
+}
+
+function parseHueAngle(value: string): number {
+  const trimmedValue = value.trim();
+  const match = trimmedValue.match(MATCH_HUE_ANGLE_REGEX);
+  if (!match) {
+    return NaN;
+  }
+
+  const numericValue = Number(match[1]);
+  if (isNaN(numericValue)) {
+    return NaN;
+  }
+
+  const unit = match[2]?.toLowerCase() ?? 'deg';
+  if (unit === 'rad') {
+    return normalizeHue((numericValue * 180) / Math.PI);
+  }
+  if (unit === 'grad') {
+    // 400grad is a full circle, so each grad equals 0.9deg.
+    return normalizeHue(numericValue * 0.9);
+  }
+  if (unit === 'turn') {
+    return normalizeHue(numericValue * 360);
+  }
+
+  return normalizeHue(numericValue);
 }
 
 function createColorOrNull(format: ColorFormat): Color | null {
@@ -220,7 +248,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     }
 
     const [h, s, l] = [
-      normalizeHue(Math.round(parseFloat(hslParams.channels[0]))),
+      Math.round(parseHueAngle(hslParams.channels[0])),
       clampValue(Math.round(parseNumberOrPercent(hslParams.channels[1], 100)), 0, 100),
       clampValue(Math.round(parseNumberOrPercent(hslParams.channels[2], 100)), 0, 100),
     ];
@@ -249,7 +277,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     }
 
     const [h, s, l] = [
-      normalizeHue(Math.round(parseFloat(hslaParams.channels[0]))),
+      Math.round(parseHueAngle(hslaParams.channels[0])),
       clampValue(Math.round(parseNumberOrPercent(hslaParams.channels[1], 100)), 0, 100),
       clampValue(Math.round(parseNumberOrPercent(hslaParams.channels[2], 100)), 0, 100),
     ];
@@ -272,7 +300,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     }
 
     const [h, s, v] = [
-      normalizeHue(Math.round(parseFloat(hsvParams.channels[0]))),
+      Math.round(parseHueAngle(hsvParams.channels[0])),
       clampValue(Math.round(parseNumberOrPercent(hsvParams.channels[1], 100)), 0, 100),
       clampValue(Math.round(parseNumberOrPercent(hsvParams.channels[2], 100)), 0, 100),
     ];
@@ -301,7 +329,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     }
 
     const [h, s, v] = [
-      normalizeHue(Math.round(parseFloat(hsvaParams.channels[0]))),
+      Math.round(parseHueAngle(hsvaParams.channels[0])),
       clampValue(Math.round(parseNumberOrPercent(hsvaParams.channels[1], 100)), 0, 100),
       clampValue(Math.round(parseNumberOrPercent(hsvaParams.channels[2], 100)), 0, 100),
     ];
@@ -324,7 +352,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     }
 
     const [h, w, b] = [
-      normalizeHue(Math.round(parseFloat(hwbParams.channels[0]))),
+      Math.round(parseHueAngle(hwbParams.channels[0])),
       clampValue(Math.round(parseNumberOrPercent(hwbParams.channels[1], 100)), 0, 100),
       clampValue(Math.round(parseNumberOrPercent(hwbParams.channels[2], 100)), 0, 100),
     ];
@@ -383,7 +411,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     const [l, c, h] = [
       parseNumberOrPercent(lchParams.channels[0], 100),
       parseFloat(lchParams.channels[1]),
-      parseFloat(lchParams.channels[2]),
+      parseHueAngle(lchParams.channels[2]),
     ];
     if ([l, c, h].some((value) => isNaN(value))) {
       return null;
@@ -401,7 +429,7 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
     const [l, c, h] = [
       parseFloat(oklchParams.channels[0]),
       parseFloat(oklchParams.channels[1]),
-      parseFloat(oklchParams.channels[2]),
+      parseHueAngle(oklchParams.channels[2]),
     ];
     if ([l, c, h].some((value) => isNaN(value))) {
       return null;


### PR DESCRIPTION
### Motivation
- Color parsing should accept CSS hue angle units like `rad`, `grad`, and `turn` in addition to degrees so color functions can be specified with different angle units.

### Description
- Added `MATCH_HUE_ANGLE_REGEX` and a new `parseHueAngle` helper to parse numeric hue values with optional units and convert them to degrees.
- Implemented conversion for `rad`, `grad`, and `turn` (with `grad` -> degrees using 1 grad = 0.9° and `turn` -> 360°) and normalized the result via `normalizeHue`.
- Replaced direct `parseFloat`/`normalizeHue` usage with `parseHueAngle` in HSL/HSLA/HSV/HSVA/HWB parsing and used `parseHueAngle` for `lch` and `oklch` hue channels.
- Kept rounding behavior for integer-based hue channels where applicable and preserved existing alpha/channel parsing and clamping logic.

### Testing
- Updated `src/color/__test__/parse.test.ts` with additional assertions verifying `turn`, `rad`, and `grad` units for `hsl`, `hwb`, `lch`, and `oklch` produce the expected hex colors.
- Ran the color parsing test suite (the updated `parse.test.ts`) and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e390e7fc90832aa51c83c3c3ffb50e)