### PR TITLE
Add CSS `oklab()` parsing support in `parseCSSColorFormatString`

### DIFF
--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -225,6 +225,30 @@ describe('parseCSSColorFormatString', () => {
     );
   });
 
+  it('parses OKLAB inputs', () => {
+    expect(parseCSSColorFormatString('oklab(0 0 0)')?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('oklab(1 0 0)')?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('oklab(0.599871 0 0)')?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846)')?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498)')?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528)')?.toHex()).toBe(
+      '#0000ff',
+    );
+  });
+
+  it('parses OKLAB inputs with optional alpha', () => {
+    expect(parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846 / 0.5)')?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498 / 25%)')?.toHex8()).toBe(
+      '#00ff0040',
+    );
+    expect(parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528 0.75)')?.toHex8()).toBe(
+      '#0000ffbf',
+    );
+    expect(parseCSSColorFormatString('oklab(0.599871 0 0 / 0%)')?.toHex8()).toBe('#80808000');
+  });
+
   it('parses additional forgiving input variations', () => {
     expect(parseCSSColorFormatString('cmyk(0% 100% 100% 0%)')?.toHex()).toBe('#ff0000');
     expect(parseCSSColorFormatString('lab(53.233%, 80.109, 67.22)')?.toHex()).toBe('#ff0000');
@@ -248,6 +272,10 @@ describe('parseCSSColorFormatString', () => {
     expect(parseCSSColorFormatString('lab(50% 0)')).toBeNull();
     expect(parseCSSColorFormatString('lch(120% 0 0)')).toBeNull();
     expect(parseCSSColorFormatString('lch(50% 30)')).toBeNull();
+    expect(parseCSSColorFormatString('oklab(1.1 0 0)')).toBeNull();
+    expect(parseCSSColorFormatString('oklab(-0.1 0 0)')).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0)')).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0 0 / foo)')).toBeNull();
     expect(parseCSSColorFormatString('oklch(1.1 0 0)')).toBeNull();
     expect(parseCSSColorFormatString('oklch(-0.1 0 0)')).toBeNull();
     expect(parseCSSColorFormatString('hwb(0 0%)')).toBeNull();

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -17,6 +17,7 @@ const MATCH_HWB_STRING_REGEX = /^hwb\((.+)\)$/;
 const MATCH_CMYK_STRING_REGEX = /^cmyk\((.+)\)$/;
 const MATCH_LAB_STRING_REGEX = /^lab\((.+)\)$/;
 const MATCH_LCH_STRING_REGEX = /^lch\((.+)\)$/;
+const MATCH_OKLAB_STRING_REGEX = /^oklab\((.+)\)$/;
 const MATCH_OKLCH_STRING_REGEX = /^oklch\((.+)\)$/;
 const MATCH_COLOR_FUNCTION_REGEX = /^color\((.+)\)$/;
 const MATCH_HUE_ANGLE_REGEX = /^([-+]?(?:\d+\.?\d*|\.\d+)(?:e[-+]?\d+)?)(deg|rad|grad|turn)?$/i;
@@ -417,6 +418,45 @@ export function parseCSSColorFormatString(colorFormatString: string): Color | nu
       return null;
     }
     return createColorOrNull({ l, c, h });
+  }
+
+  const oklabMatch = str.match(MATCH_OKLAB_STRING_REGEX);
+  if (oklabMatch) {
+    const oklabParams = splitColorFunctionParams(oklabMatch[1], {
+      expectedChannels: 3,
+      allowAlpha: true,
+      allowSlashForAlpha: true,
+    });
+    if (!oklabParams) {
+      return null;
+    }
+
+    const [l, a, b] = [
+      parseFloat(oklabParams.channels[0]),
+      parseFloat(oklabParams.channels[1]),
+      parseFloat(oklabParams.channels[2]),
+    ];
+    if ([l, a, b].some((value) => isNaN(value))) {
+      return null;
+    }
+    if (l < 0 || l > 1) {
+      return null;
+    }
+
+    const parsedColor = createColorOrNull({ l, a, b, format: 'OKLAB' });
+    if (!parsedColor) {
+      return null;
+    }
+
+    if (oklabParams.alpha !== undefined) {
+      const alphaValue = clampAlpha(parseAlphaValue(oklabParams.alpha));
+      if (isNaN(alphaValue)) {
+        return null;
+      }
+      return parsedColor.setAlpha(alphaValue);
+    }
+
+    return parsedColor;
   }
 
   const oklchMatch = str.match(MATCH_OKLCH_STRING_REGEX);


### PR DESCRIPTION
### Motivation
- The parser supported `lab()`, `lch()`, and `oklch()` but lacked a CSS `oklab()` input path, which breaks parity with modern CSS color support and competitor behavior.

### Description
- Added a dedicated matcher `MATCH_OKLAB_STRING_REGEX` and a parsing branch in `src/color/parse.ts` to recognize `oklab(...)` strings and extract channels. 
- Reused `splitColorFunctionParams` with `allowAlpha` and `allowSlashForAlpha` to accept both `/ alpha` and compact fourth-channel alpha forms. 
- Parsed `l a b` via `parseFloat`, enforced Oklab lightness validation (`l` in `[0, 1]`), and constructed the color with `createColorOrNull({ l, a, b, format: 'OKLAB' })`. 
- If alpha was present the code clamps and parses it with `parseAlphaValue`/`clampAlpha` and applies it with `setAlpha(...)`. 
- Added comprehensive tests to `src/color/__test__/parse.test.ts` covering canonical primaries and gray, optional alpha forms, and invalid cases (out-of-range `l`, missing channels, invalid alpha). 

### Testing
- Ran lint with `npm run lint` and it passed. 
- Ran type checking with `npm run typecheck` and it passed. 
- Ran the full test suite with `npm run test` (`jest`) and all tests passed (`20` test suites, `1035` tests). 
- Ran formatting check with `npm run format:check` and it passed after applying Prettier fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e395dbe834832a8b96c3b44023c4a2)