### PR TITLE
demo: add dynamic code snippets for combination and gradient cards

### DIFF
--- a/demo/src/demo/ColorManipulationDemo.tsx
+++ b/demo/src/demo/ColorManipulationDemo.tsx
@@ -27,6 +27,7 @@ function getAdjustColorCodeSnippet({
   const inputs = `{ amount: ${amount}, space: ${colorSpace}${labSpaceInput} }`;
   return `
 const color = new Color(${colorHex});
+
 const brightened = color.brighten(${inputs});
 const darkened = color.darken(${inputs});
 const saturated = color.saturate(${inputs});
@@ -43,6 +44,7 @@ function getSpinHueCodeSnippet({
 }) {
   return `
 const color = new Color(${colorHex});
+
 const spun = color.spin(${spinDegrees});
 `;
 }

--- a/demo/src/demo/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/demo/combinations/ColorCombinationDemo.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { AverageColorsOptions, BlendColorsOptions, MixColorsOptions } from '../../../../dist';
 import { Color } from '../../../../dist';
 import { ColorBox } from '../../components/ColorBox';
 import { MixColorsOptionInputs } from './MixColorsOptionInputs';
@@ -14,6 +15,52 @@ import {
 
 interface Props {
   color: Color;
+}
+
+function getMixCodeSnippet(colorHex: string, mixOptions: MixColorsOptions) {
+  const mixSpace = mixOptions.space ?? DEFAULT_MIX_COLORS_OPTIONS.space;
+  const mixType = mixOptions.type ?? DEFAULT_MIX_COLORS_OPTIONS.type;
+  return `
+const color = new Color('${colorHex}');
+const red = new Color('red');
+const green = new Color('green');
+const blue = new Color('blue');
+
+const mixed = color.mix([red], {
+  space: '${mixSpace}',
+  type: '${mixType}',
+});
+`;
+}
+
+function getBlendCodeSnippet(colorHex: string, blendOptions: BlendColorsOptions) {
+  const blendMode = blendOptions.mode ?? DEFAULT_BLEND_COLORS_OPTIONS.mode;
+  const blendSpace = blendOptions.space ?? DEFAULT_BLEND_COLORS_OPTIONS.space;
+  const blendRatio = blendOptions.ratio ?? DEFAULT_BLEND_COLORS_OPTIONS.ratio;
+  return `
+const color = new Color('${colorHex}');
+const targetColor = new Color('red');
+
+const blended = color.blend(targetColor, {
+  mode: '${blendMode}',
+  space: '${blendSpace}',
+  ratio: ${blendRatio},
+});
+`;
+}
+
+function getAverageCodeSnippet(colorHex: string, averageOptions: AverageColorsOptions) {
+  const averageSpace = averageOptions.space ?? DEFAULT_AVERAGE_COLORS_OPTIONS.space;
+  return `
+const color = new Color('${colorHex}');
+const red = new Color('red');
+const green = new Color('green');
+const blue = new Color('blue');
+
+const averaged = color.average([red, green, blue], {
+  space: '${averageSpace}',
+});
+`;
 }
 
 export function ColorCombinationDemo({ color }: Props) {
@@ -43,7 +90,7 @@ export function ColorCombinationDemo({ color }: Props) {
 
   return (
     <div className="w-full flex flex-col gap-4">
-      <Card title="Mix">
+      <Card title="Mix" codeSnippet={getMixCodeSnippet(color.toHex8(), mixOptions)}>
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}
@@ -83,7 +130,7 @@ export function ColorCombinationDemo({ color }: Props) {
         </div>
         <MixColorsOptionInputs mixOptions={mixOptions} onOptionsChanged={setMixOptions} />
       </Card>
-      <Card title="Blend">
+      <Card title="Blend" codeSnippet={getBlendCodeSnippet(color.toHex8(), blendOptions)}>
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}
@@ -123,7 +170,7 @@ export function ColorCombinationDemo({ color }: Props) {
         </div>
         <BlendColorsOptionInputs blendOptions={blendOptions} onOptionsChanged={setBlendOptions} />
       </Card>
-      <Card title="Average">
+      <Card title="Average" codeSnippet={getAverageCodeSnippet(color.toHex8(), averageOptions)}>
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}

--- a/demo/src/demo/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/demo/combinations/ColorCombinationDemo.tsx
@@ -22,14 +22,15 @@ function getMixCodeSnippet(colorHex: string, mixOptions: MixColorsOptions) {
   const mixType = mixOptions.type ?? DEFAULT_MIX_COLORS_OPTIONS.type;
   return `
 const color = new Color('${colorHex}');
+
 const red = new Color('red');
 const green = new Color('green');
 const blue = new Color('blue');
 
-const mixed = color.mix([red], {
-  space: '${mixSpace}',
-  type: '${mixType}',
-});
+const mixedWithRed = color.mix([red], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithGreen = color.mix([green], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithBlue = color.mix([blue], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithAll = color.mix([red, green, blue], { space: '${mixSpace}', type: '${mixType}' });
 `;
 }
 
@@ -39,13 +40,14 @@ function getBlendCodeSnippet(colorHex: string, blendOptions: BlendColorsOptions)
   const blendRatio = blendOptions.ratio ?? DEFAULT_BLEND_COLORS_OPTIONS.ratio;
   return `
 const color = new Color('${colorHex}');
-const targetColor = new Color('red');
 
-const blended = color.blend(targetColor, {
-  mode: '${blendMode}',
-  space: '${blendSpace}',
-  ratio: ${blendRatio},
-});
+const red = new Color('red');
+const green = new Color('green');
+const blue = new Color('blue');
+
+const blendedWithRed = color.blend(red, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
+const blendedWithGreen = color.blend(green, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
+const blendedWithBlue = color.blend(blue, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
 `;
 }
 
@@ -53,13 +55,15 @@ function getAverageCodeSnippet(colorHex: string, averageOptions: AverageColorsOp
   const averageSpace = averageOptions.space ?? DEFAULT_AVERAGE_COLORS_OPTIONS.space;
   return `
 const color = new Color('${colorHex}');
+
 const red = new Color('red');
 const green = new Color('green');
 const blue = new Color('blue');
 
-const averaged = color.average([red, green, blue], {
-  space: '${averageSpace}',
-});
+const averagedWithRed = color.average([red], { space: '${averageSpace}' });
+const averagedWithGreen = color.average([green], { space: '${averageSpace}' });
+const averagedWithBlue = color.average([blue], { space: '${averageSpace}' });
+const averagedWithAll = color.average([red, green, blue], { space: '${averageSpace}' });
 `;
 }
 
@@ -90,7 +94,7 @@ export function ColorCombinationDemo({ color }: Props) {
 
   return (
     <div className="w-full flex flex-col gap-4">
-      <Card title="Mix" codeSnippet={getMixCodeSnippet(color.toHex8(), mixOptions)}>
+      <Card codeSnippet={getMixCodeSnippet(color.toHex8(), mixOptions)} title="Mix">
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}
@@ -130,7 +134,7 @@ export function ColorCombinationDemo({ color }: Props) {
         </div>
         <MixColorsOptionInputs mixOptions={mixOptions} onOptionsChanged={setMixOptions} />
       </Card>
-      <Card title="Blend" codeSnippet={getBlendCodeSnippet(color.toHex8(), blendOptions)}>
+      <Card codeSnippet={getBlendCodeSnippet(color.toHex8(), blendOptions)} title="Blend">
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}
@@ -170,7 +174,7 @@ export function ColorCombinationDemo({ color }: Props) {
         </div>
         <BlendColorsOptionInputs blendOptions={blendOptions} onOptionsChanged={setBlendOptions} />
       </Card>
-      <Card title="Average" codeSnippet={getAverageCodeSnippet(color.toHex8(), averageOptions)}>
+      <Card codeSnippet={getAverageCodeSnippet(color.toHex8(), averageOptions)} title="Average">
         <div className="grid grid-cols-1 sm:grid-cols-5 gap-2 mb-4">
           <ColorBox
             color={color}

--- a/demo/src/demo/gradients/GradientThroughCard.tsx
+++ b/demo/src/demo/gradients/GradientThroughCard.tsx
@@ -26,6 +26,7 @@ function getGradientThroughCodeSnippet({
   const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.clamp;
   const hueInterpolationMode =
     options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.hueInterpolationMode;
+  const easingInput = typeof easing === 'function' ? easing.toString() : `'${easing}'`;
 
   const hueInterpolationInput =
     space !== 'RGB'
@@ -41,7 +42,7 @@ const gradient = color.createGradientThrough(stopColors, {
   stops: ${stops},
   space: '${space}',
   interpolation: '${interpolation}',
-  easing: '${easing}',
+  easing: ${easingInput},
   clamp: ${clamp}${hueInterpolationInput},
 });
 `;

--- a/demo/src/demo/gradients/GradientThroughCard.tsx
+++ b/demo/src/demo/gradients/GradientThroughCard.tsx
@@ -68,11 +68,11 @@ export function GradientThroughCard({ color }: Props) {
 
   return (
     <Card
-      title="Gradient through red, green, and blue"
       codeSnippet={getGradientThroughCodeSnippet({
         colorHex: color.toHex8(),
         options,
       })}
+      title="Gradient through red, green, and blue"
     >
       <div className="flex flex-col sm:flex-row gap-2 mb-4">{colorBoxes}</div>
       <GradientOptionInputs

--- a/demo/src/demo/gradients/GradientThroughCard.tsx
+++ b/demo/src/demo/gradients/GradientThroughCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Color } from '../../../../dist';
+import { Color, type ColorGradientOptions } from '../../../../dist';
 import { Card } from '../../components/Card';
 import { ColorBox } from '../../components/ColorBox';
 import { GradientOptionInputs } from './GradientOptionInputs';
@@ -9,6 +9,36 @@ const STOP_COLORS = ['Red', 'Green', 'Blue'] as const;
 
 interface Props {
   color: Color;
+}
+
+function getGradientThroughCodeSnippet({
+  colorHex,
+  options,
+}: {
+  colorHex: string;
+  options: ColorGradientOptions;
+}) {
+  const stops = options.stops ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.stops;
+  const space = options.space ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.space;
+  const interpolation =
+    options.interpolation ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.interpolation;
+  const easing = String(options.easing);
+  const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.clamp;
+  const hueInterpolationMode =
+    options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.hueInterpolationMode;
+  return `
+const color = new Color('${colorHex}');
+const stopColors = ['red', 'green', 'blue'];
+
+const gradient = color.createGradientThrough(stopColors, {
+  stops: ${stops},
+  space: '${space}',
+  interpolation: '${interpolation}',
+  easing: '${easing}',
+  clamp: ${clamp},
+  hueInterpolationMode: '${hueInterpolationMode}',
+});
+`;
 }
 
 export function GradientThroughCard({ color }: Props) {
@@ -37,7 +67,13 @@ export function GradientThroughCard({ color }: Props) {
   }, [color, options]);
 
   return (
-    <Card title="Gradient through red, green, and blue">
+    <Card
+      title="Gradient through red, green, and blue"
+      codeSnippet={getGradientThroughCodeSnippet({
+        colorHex: color.toHex8(),
+        options,
+      })}
+    >
       <div className="flex flex-col sm:flex-row gap-2 mb-4">{colorBoxes}</div>
       <GradientOptionInputs
         options={options}

--- a/demo/src/demo/gradients/GradientThroughCard.tsx
+++ b/demo/src/demo/gradients/GradientThroughCard.tsx
@@ -22,10 +22,17 @@ function getGradientThroughCodeSnippet({
   const space = options.space ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.space;
   const interpolation =
     options.interpolation ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.interpolation;
-  const easing = String(options.easing);
+  const easing = options.easing ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.easing;
   const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.clamp;
   const hueInterpolationMode =
     options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_THROUGH_OPTIONS.hueInterpolationMode;
+
+  const hueInterpolationInput =
+    space !== 'RGB'
+      ? `,
+  hueInterpolationMode: '${hueInterpolationMode}'`
+      : '';
+
   return `
 const color = new Color('${colorHex}');
 const stopColors = ['red', 'green', 'blue'];
@@ -35,8 +42,7 @@ const gradient = color.createGradientThrough(stopColors, {
   space: '${space}',
   interpolation: '${interpolation}',
   easing: '${easing}',
-  clamp: ${clamp},
-  hueInterpolationMode: '${hueInterpolationMode}',
+  clamp: ${clamp}${hueInterpolationInput},
 });
 `;
 }

--- a/demo/src/demo/gradients/GradientToCard.tsx
+++ b/demo/src/demo/gradients/GradientToCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Color } from '../../../../dist';
+import { Color, type ColorGradientOptions } from '../../../../dist';
 import { Card } from '../../components/Card';
 import { ColorBox } from '../../components/ColorBox';
 import { GradientOptionInputs } from './GradientOptionInputs';
@@ -7,6 +7,37 @@ import { DEFAULT_COLOR_GRADIENT_TO_OPTIONS } from './gradientOptions.consts';
 
 interface Props {
   color: Color;
+}
+
+function getGradientToCodeSnippet({
+  colorHex,
+  targetColorHex,
+  options,
+}: {
+  colorHex: string;
+  targetColorHex: string;
+  options: ColorGradientOptions;
+}) {
+  const stops = options.stops ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.stops;
+  const space = options.space ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.space;
+  const interpolation = options.interpolation ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.interpolation;
+  const easing = String(options.easing);
+  const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.clamp;
+  const hueInterpolationMode =
+    options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.hueInterpolationMode;
+  return `
+const color = new Color('${colorHex}');
+const targetColor = new Color('${targetColorHex}');
+
+const gradient = color.createGradientTo(targetColor, {
+  stops: ${stops},
+  space: '${space}',
+  interpolation: '${interpolation}',
+  easing: '${easing}',
+  clamp: ${clamp},
+  hueInterpolationMode: '${hueInterpolationMode}',
+});
+`;
 }
 
 export function GradientToCard({ color }: Props) {
@@ -21,7 +52,14 @@ export function GradientToCard({ color }: Props) {
   };
 
   return (
-    <Card title="Gradient to">
+    <Card
+      title="Gradient to"
+      codeSnippet={getGradientToCodeSnippet({
+        colorHex: color.toHex8(),
+        targetColorHex: targetColor.toHex8(),
+        options,
+      })}
+    >
       <div className="flex flex-col sm:flex-row gap-2 mb-4">
         {gradientColors.map((color, index) => {
           const colorHex = color.toHex();

--- a/demo/src/demo/gradients/GradientToCard.tsx
+++ b/demo/src/demo/gradients/GradientToCard.tsx
@@ -21,10 +21,17 @@ function getGradientToCodeSnippet({
   const stops = options.stops ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.stops;
   const space = options.space ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.space;
   const interpolation = options.interpolation ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.interpolation;
-  const easing = String(options.easing);
+  const easing = options.easing ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.easing;
   const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.clamp;
   const hueInterpolationMode =
     options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.hueInterpolationMode;
+
+  const hueInterpolationInput =
+    space !== 'RGB'
+      ? `,
+  hueInterpolationMode: '${hueInterpolationMode}'`
+      : '';
+
   return `
 const color = new Color('${colorHex}');
 const targetColor = new Color('${targetColorHex}');
@@ -34,8 +41,7 @@ const gradient = color.createGradientTo(targetColor, {
   space: '${space}',
   interpolation: '${interpolation}',
   easing: '${easing}',
-  clamp: ${clamp},
-  hueInterpolationMode: '${hueInterpolationMode}',
+  clamp: ${clamp}${hueInterpolationInput},
 });
 `;
 }

--- a/demo/src/demo/gradients/GradientToCard.tsx
+++ b/demo/src/demo/gradients/GradientToCard.tsx
@@ -16,15 +16,15 @@ function getGradientToCodeSnippet({
 }: {
   colorHex: string;
   targetColorHex: string;
-  options: ColorGradientOptions;
+  options: Omit<ColorGradientOptions, 'interpolation'>;
 }) {
   const stops = options.stops ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.stops;
   const space = options.space ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.space;
-  const interpolation = options.interpolation ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.interpolation;
   const easing = options.easing ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.easing;
   const clamp = options.clamp ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.clamp;
   const hueInterpolationMode =
     options.hueInterpolationMode ?? DEFAULT_COLOR_GRADIENT_TO_OPTIONS.hueInterpolationMode;
+  const easingInput = typeof easing === 'function' ? easing.toString() : `'${easing}'`;
 
   const hueInterpolationInput =
     space !== 'RGB'
@@ -39,8 +39,7 @@ const targetColor = new Color('${targetColorHex}');
 const gradient = color.createGradientTo(targetColor, {
   stops: ${stops},
   space: '${space}',
-  interpolation: '${interpolation}',
-  easing: '${easing}',
+  easing: ${easingInput},
   clamp: ${clamp}${hueInterpolationInput},
 });
 `;

--- a/demo/src/demo/gradients/GradientToCard.tsx
+++ b/demo/src/demo/gradients/GradientToCard.tsx
@@ -53,12 +53,12 @@ export function GradientToCard({ color }: Props) {
 
   return (
     <Card
-      title="Gradient to"
       codeSnippet={getGradientToCodeSnippet({
         colorHex: color.toHex8(),
         targetColorHex: targetColor.toHex8(),
         options,
       })}
+      title="Gradient to"
     >
       <div className="flex flex-col sm:flex-row gap-2 mb-4">
         {gradientColors.map((color, index) => {


### PR DESCRIPTION
### Motivation
- Surface runnable example snippets in the demo UI so users can see the exact constructor and option inputs used for the displayed color operations (Mix, Blend, Average, Gradient to, Gradient through). 

### Description
- Added `getMixCodeSnippet`, `getBlendCodeSnippet`, and `getAverageCodeSnippet` helpers to `demo/src/demo/combinations/ColorCombinationDemo.tsx` and wired each `<Card>` to the `codeSnippet` prop using the live `mixOptions`, `blendOptions`, and `averageOptions` and the current constructor color via `color.toHex8()`.
- Added `getGradientToCodeSnippet` to `demo/src/demo/gradients/GradientToCard.tsx` and `getGradientThroughCodeSnippet` to `demo/src/demo/gradients/GradientThroughCard.tsx`, and wired those `<Card>` components to render dynamic snippets that reflect `color.toHex8()`, `targetColor.toHex8()` (where applicable), and the active `ColorGradientOptions`.
- Updated a few imports to bring in typed option shapes (`MixColorsOptions`, `BlendColorsOptions`, `AverageColorsOptions`, `ColorGradientOptions`) and applied sensible default fallbacks when building the snippet so values are always rendered as concrete literals.
- Kept formatting and style consistent with the demo (snippets are simple template strings that mirror the runtime API calls such as `color.mix(...)`, `color.blend(...)`, `color.average(...)`, `color.createGradientTo(...)`, and `color.createGradientThrough(...)`).

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Ran static type checking with `npm run typecheck` and the project typecheck passed. 
- Ran unit tests with `npm run test` and all test suites passed (`20` test suites, `1037` tests). 
- Ran formatting check with `npm run format:check` and Prettier validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f0c580bc832aab579aed685402fc)