### PR TITLE
Clarify WCAG/APCA terminology and update accessibility references

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,8 +821,14 @@ palette.info[500].toHex(); // '#9d40d4'
 
 `omni-color` supports two readability algorithms:
 
-- **WCAG 2.x contrast ratio** (`getWCAGContrastRatio`, `getWCAGReadabilityReport`, `isReadableAsTextColor`) for established pass/fail conformance checks.
-- **APCA Lc score** (`getAPCAReadabilityScore`, `getAPCAReadabilityReport`) for directional contrast analysis. APCA is still draft guidance for WCAG 3, so this library defaults APCA to **advisory mode** unless you opt into a threshold policy.
+- **WCAG 2.x contrast ratio** (`getWCAGContrastRatio`, `getWCAGReadabilityReport`, `isReadableAsTextColor`) for established pass/fail conformance checks. WCAG stands for **Web Content Accessibility Guidelines** (W3C).
+- **APCA Lc score** (`getAPCAReadabilityScore`, `getAPCAReadabilityReport`) for directional contrast analysis. APCA stands for **Advanced Perceptual Contrast Algorithm**. APCA is still draft guidance for WCAG 3, so this library defaults APCA to **advisory mode** unless you opt into a threshold policy.
+
+Reference resources:
+- WCAG 2.2 specification: https://www.w3.org/TR/WCAG22/
+- WCAG Understanding SC 1.4.3 (Contrast Minimum): https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html
+- APCA project repository (used for ongoing algorithm drafts): https://github.com/Myndex/apca-w3
+- APCA documentation index: https://git.apcacontrast.com/documentation/
 
 #### `getWCAGContrastRatio(color: Color | ColorFormat | string): number`
 
@@ -836,7 +842,7 @@ new Color('#000000').getWCAGContrastRatio('#ffffff'); // 21
 
 #### `getAPCAReadabilityScore(background: Color | ColorFormat | string): number`
 
-**Note:** This implementation uses the `0.0.98G-4g` constants from the draft APCA recommendations. As WCAG 3 is not yet finalized, this score is experimental and provided for advisory use only.
+**Note:** This implementation uses the `0.0.98G-4g` constants from the draft APCA recommendations published via the APCA project. As WCAG 3 is not yet finalized, this score is experimental and provided for advisory use only.
 
 - <ins>Returns</ins> the signed APCA readability score (Lc) against a background color.
 - <ins>Inputs</ins>:

--- a/demo/src/AppFooter.tsx
+++ b/demo/src/AppFooter.tsx
@@ -9,11 +9,11 @@ export function AppFooter() {
       </div>
       <div className="flex flex-col gap-1">
         <span className="mb-1 font-semibold text-neutral-500">Accessibility</span>
-        <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
+        <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2 specification</a>
         <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html">
-          Understanding contrast
+          WCAG contrast guidance
         </a>
-        <a href="https://github.com/Myndex/apca-w3">APCA W3C</a>
+        <a href="https://github.com/Myndex/apca-w3">APCA draft source (apca-w3)</a>
         <a href="https://git.apcacontrast.com/documentation/">APCA documentation</a>
       </div>
       <div className="flex flex-col gap-1">

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -926,6 +926,9 @@ export class Color {
   /**
    * Get the contrast ratio between this color and another color.
    *
+   * WCAG (Web Content Accessibility Guidelines, from W3C) defines this as a
+   * luminance-based ratio from `1` to `21` commonly used for accessibility checks.
+   *
    * @param other The other {@link Color} or color input to compare against.
    * @returns The WCAG contrast ratio between the two colors.
    */
@@ -935,6 +938,9 @@ export class Color {
 
   /**
    * Get the readability score of this color against a given background color.
+   *
+   * APCA (Advanced Perceptual Contrast Algorithm) is a newer, directional
+   * contrast model being explored for WCAG 3 guidance.
    *
    * NOTE: This is based on draft recommendations and is provided for advisory use only as WCAG 3 is not finalized.
    *
@@ -947,6 +953,9 @@ export class Color {
 
   /**
    * Get APCA readability details of this color against a given background color.
+   *
+   * APCA (Advanced Perceptual Contrast Algorithm) provides a signed Lc score
+   * where polarity (dark-on-light vs light-on-dark) matters.
    *
    * NOTE: APCA policy defaults to advisory mode (`'NONE'`), which returns
    * a signed Lc score with `isReadable`, `requiredLc`, and `shortfall` as `null`.
@@ -974,6 +983,9 @@ export class Color {
   /**
    * Get detailed WCAG readability metrics against a background color.
    *
+   * WCAG (Web Content Accessibility Guidelines) defines standard AA/AAA
+   * thresholds for text contrast conformance.
+   *
    * Calculates the WCAG contrast ratio and determines whether this color meets
    * the specified conformance level and text size requirements.
    *
@@ -997,6 +1009,9 @@ export class Color {
   /**
    * Find the most readable text color against this color as a background.
    *
+   * This ranks candidates using either WCAG contrast ratio (default) or APCA
+   * scoring, depending on `options.algorithm`.
+   *
    * @param textColors A non-empty list of {@link Color} or color input candidate text colors, or a {@link ColorSwatch} to pick from.
    * @param options Optional {@link ReadabilityOptions} to pick the readability algorithm and WCAG inputs.
    * @returns The candidate color with the strongest readability against this color.
@@ -1011,7 +1026,8 @@ export class Color {
   /**
    * Determine whether this color is readable as text against a background color.
    *
-   * By default this uses WCAG contrast checks. You can opt into APCA by passing
+   * By default this uses WCAG contrast checks (Web Content Accessibility Guidelines).
+   * You can opt into APCA (Advanced Perceptual Contrast Algorithm) by passing
    * `options.algorithm = 'APCA'` and optional `apcaOptions`.
    *
    * @param backgroundColor The background {@link Color} or color input to compare against.
@@ -1033,6 +1049,9 @@ export class Color {
 
   /**
    * Find the best background color for this color as foreground text.
+   *
+   * This ranks candidates using either WCAG contrast ratio (default) or APCA
+   * scoring, depending on `options.algorithm`.
    *
    * @param backgroundColors A non-empty list of candidate background {@link Color}s or color inputs, or a {@link ColorSwatch} to pick from.
    * @param options Optional {@link ReadabilityOptions} to pick the readability algorithm and WCAG inputs.


### PR DESCRIPTION
### Motivation
- Make the Color class readability APIs explicitly clear about what WCAG and APCA mean so users immediately understand the algorithms referenced by the methods.
- Surface authoritative references in the README and ensure demo footer links accurately describe where they point for easier developer verification.
- Improve JSDoc on the Color methods so in-editor help is explicit about which accessibility model is used and when to opt into APCA.

### Description
- Expanded JSDoc for the Color methods `getWCAGContrastRatio`, `getAPCAReadabilityScore`, `getAPCAReadabilityReport`, `getWCAGReadabilityReport`, `getMostReadableTextColor`, `isReadableAsTextColor`, and `getBestBackgroundColor` to briefly spell out WCAG (Web Content Accessibility Guidelines) and APCA (Advanced Perceptual Contrast Algorithm) and clarify ranking/algorithm behavior where applicable.
- Updated the README `Readability and Accessibility` section to define WCAG/APCA, clarify the library's advisory stance on APCA, and add direct reference links to WCAG 2.2 and APCA resources.
- Refreshed the demo footer links/labels in `demo/src/AppFooter.tsx` to more clearly describe each accessibility resource (WCAG spec, WCAG contrast guidance, APCA draft source, and APCA docs).

### Testing
- Ran `npm run lint`, `npm run typecheck`, and `npm run format:check` and all succeeded with no errors.
- Ran `npm run test` and all test suites passed (`20` test suites, `1044` tests total all passing).
- Verified accessibility reference URLs return HTTP 200 using `curl -I -L` for the added links.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e619dece3c832aaed95c5b0222bfd3)