### PR TITLE
Add toast notification system and use toasts for copy actions

### DIFF
--- a/demo/src/assets/icons/info-circle.svg
+++ b/demo/src/assets/icons/info-circle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+</svg>
+

--- a/demo/src/assets/icons/x.svg
+++ b/demo/src/assets/icons/x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+</svg>
+

--- a/demo/src/components/ExpandableCodeSnippet.tsx
+++ b/demo/src/components/ExpandableCodeSnippet.tsx
@@ -15,7 +15,6 @@ export function ExpandableCodeSnippet({ codeSnippet }: Props) {
       showSuccessToast('Copied code to clipboard!');
     } catch (err) {
       showErrorToast('Could not copy code to clipboard.', err);
-      console.error('Failed to copy:', err);
     }
   }, [trimmedCodeSnippet]);
 
@@ -32,7 +31,11 @@ export function ExpandableCodeSnippet({ codeSnippet }: Props) {
           {trimmedCodeSnippet}
         </pre>
         <div className="absolute bottom-2 right-2">
-          <button onClick={handleCopyCodeToClipboard}>
+          <button
+            aria-label="Copy code snippet to clipboard"
+            className="icon-button"
+            onClick={handleCopyCodeToClipboard}
+          >
             <Icon size={20} type={Icon.TYPE.COPY} />
           </button>
         </div>

--- a/demo/src/components/ExpandableCodeSnippet.tsx
+++ b/demo/src/components/ExpandableCodeSnippet.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { showErrorToast, showSuccessToast } from '../toast';
 import { Icon } from './Icon';
 
 interface Props {
@@ -11,7 +12,9 @@ export function ExpandableCodeSnippet({ codeSnippet }: Props) {
   const handleCopyCodeToClipboard = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(trimmedCodeSnippet);
+      showSuccessToast('Copied code to clipboard!');
     } catch (err) {
+      showErrorToast('Could not copy code to clipboard.', err);
       console.error('Failed to copy:', err);
     }
   }, [trimmedCodeSnippet]);

--- a/demo/src/components/Icon.tsx
+++ b/demo/src/components/Icon.tsx
@@ -5,9 +5,11 @@ import Check from '../assets/icons/check.svg?react';
 import CheckCircle from '../assets/icons/check-circle.svg?react';
 import ChevronDown from '../assets/icons/chevron-down.svg?react';
 import Copy from '../assets/icons/copy.svg?react';
+import InfoCircle from '../assets/icons/info-circle.svg?react';
 import Moon from '../assets/icons/moon.svg?react';
 import Plus from '../assets/icons/plus.svg?react';
 import Sun from '../assets/icons/sun.svg?react';
+import X from '../assets/icons/x.svg?react';
 import XCircle from '../assets/icons/x-circle.svg?react';
 
 interface Props {
@@ -36,12 +38,16 @@ export function Icon({ color, size = 24, type }: Props) {
       return <ChevronDown {...iconProps} />;
     case IconType.COPY:
       return <Copy {...iconProps} />;
+    case IconType.INFO_CIRCLE:
+      return <InfoCircle {...iconProps} />;
     case IconType.MOON:
       return <Moon {...iconProps} />;
     case IconType.PLUS:
       return <Plus {...iconProps} />;
     case IconType.SUN:
       return <Sun {...iconProps} />;
+    case IconType.X:
+      return <X {...iconProps} />;
     case IconType.X_CIRCLE:
       return <XCircle {...iconProps} />;
     default:

--- a/demo/src/components/Icon.types.ts
+++ b/demo/src/components/Icon.types.ts
@@ -5,8 +5,10 @@ export enum IconType {
   CHECK_CIRCLE = 'CHECK_CIRCLE',
   CHEVRON_DOWN = 'CHEVRON_DOWN',
   COPY = 'COPY',
+  INFO_CIRCLE = 'INFO_CIRCLE',
   MOON = 'MOON',
   PLUS = 'PLUS',
   SUN = 'SUN',
+  X = 'X',
   X_CIRCLE = 'X_CIRCLE',
 }

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -116,3 +116,9 @@ h6 {
     @apply text-indigo-600;
   }
 }
+
+@layer components {
+  .icon-button {
+    @apply !bg-transparent !p-1 !text-indigo-900 hover:!text-indigo-700 active:!text-indigo-500 dark:!text-indigo-100 dark:hover:!text-indigo-300 dark:active:!text-indigo-400 !shadow-none;
+  }
+}

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { DemoPage } from './pages/DemoPage';
 import { PlaygroundPage } from './pages/PlaygroundPage';
+import { ToastProvider } from './toast';
 
 import './index.css';
 
@@ -17,6 +18,8 @@ const router = createBrowserRouter(
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>
   </StrictMode>,
 );

--- a/demo/src/toast/ToastProvider.tsx
+++ b/demo/src/toast/ToastProvider.tsx
@@ -1,7 +1,6 @@
-import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
-
+import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 import { Icon } from '../components/Icon';
-import { subscribeToToast, ToastEvent, ToastVariant } from './toastBus';
+import { subscribeToToast, type ToastEvent, type ToastVariant } from './toastBus';
 
 interface ToastItem extends ToastEvent {
   id: string;
@@ -25,7 +24,7 @@ function getToastVariantStyles(toastVariant: ToastVariant) {
     default:
       return {
         iconClassName: 'text-blue-600 dark:text-blue-300',
-        iconType: Icon.TYPE.CHEVRON_DOWN,
+        iconType: Icon.TYPE.INFO_CIRCLE,
       };
   }
 }
@@ -86,14 +85,13 @@ export function ToastProvider({ children }: PropsWithChildren) {
       <div className="pointer-events-none fixed right-4 bottom-4 z-50 flex max-w-sm flex-col gap-2">
         {toasts.map((toast) => {
           const variantStyles = getToastVariantStyles(toast.variant);
-
           return (
             <div
               className="pointer-events-auto rounded-xl border border-slate-200 bg-white/95 p-3 text-left shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/95"
               key={toast.id}
               role="status"
             >
-              <div className="flex items-start gap-3">
+              <div className="flex items-center gap-3">
                 <span className={variantStyles.iconClassName}>
                   <Icon size={20} type={variantStyles.iconType} />
                 </span>
@@ -107,11 +105,11 @@ export function ToastProvider({ children }: PropsWithChildren) {
                 </div>
                 <button
                   aria-label="Dismiss alert"
-                  className="bg-transparent px-0 py-0 font-normal shadow-none hover:shadow-none"
+                  className="icon-button"
                   onClick={() => dismissToast(toast.id)}
                   type="button"
                 >
-                  <Icon size={18} type={Icon.TYPE.X_CIRCLE} />
+                  <Icon size={18} type={Icon.TYPE.X} />
                 </button>
               </div>
             </div>

--- a/demo/src/toast/ToastProvider.tsx
+++ b/demo/src/toast/ToastProvider.tsx
@@ -87,9 +87,10 @@ export function ToastProvider({ children }: PropsWithChildren) {
           const variantStyles = getToastVariantStyles(toast.variant);
           return (
             <div
+              aria-atomic="true"
               className="pointer-events-auto rounded-xl border border-slate-200 bg-white/95 p-3 text-left shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/95"
               key={toast.id}
-              role="status"
+              role={toast.variant === 'ERROR' ? 'alert' : 'status'}
             >
               <div className="flex items-center gap-3">
                 <span className={variantStyles.iconClassName}>

--- a/demo/src/toast/ToastProvider.tsx
+++ b/demo/src/toast/ToastProvider.tsx
@@ -1,0 +1,123 @@
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+
+import { Icon } from '../components/Icon';
+import { subscribeToToast, ToastEvent, ToastVariant } from './toastBus';
+
+interface ToastItem extends ToastEvent {
+  id: string;
+}
+
+const DEFAULT_TOAST_DURATION_MS = 4500;
+
+function getToastVariantStyles(toastVariant: ToastVariant) {
+  switch (toastVariant) {
+    case 'SUCCESS':
+      return {
+        iconClassName: 'text-emerald-600 dark:text-emerald-300',
+        iconType: Icon.TYPE.CHECK_CIRCLE,
+      };
+    case 'ERROR':
+      return {
+        iconClassName: 'text-rose-600 dark:text-rose-300',
+        iconType: Icon.TYPE.X_CIRCLE,
+      };
+    case 'INFO':
+    default:
+      return {
+        iconClassName: 'text-blue-600 dark:text-blue-300',
+        iconType: Icon.TYPE.CHEVRON_DOWN,
+      };
+  }
+}
+
+export function ToastProvider({ children }: PropsWithChildren) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const dismissTimeoutMapRef = useRef(new Map<string, number>());
+
+  const dismissToast = useCallback((toastID: string) => {
+    const dismissTimeout = dismissTimeoutMapRef.current.get(toastID);
+
+    if (dismissTimeout != null) {
+      window.clearTimeout(dismissTimeout);
+      dismissTimeoutMapRef.current.delete(toastID);
+    }
+
+    setToasts((currentToasts) =>
+      currentToasts.filter((currentToast) => currentToast.id !== toastID),
+    );
+  }, []);
+
+  const enqueueToast = useCallback(
+    (toastEvent: ToastEvent) => {
+      const toastID = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const toastDurationMs =
+        toastEvent.durationMs == null ? DEFAULT_TOAST_DURATION_MS : toastEvent.durationMs;
+
+      setToasts((currentToasts) => [...currentToasts, { ...toastEvent, id: toastID }]);
+
+      if (toastDurationMs > 0) {
+        const dismissTimeout = window.setTimeout(() => {
+          dismissToast(toastID);
+        }, toastDurationMs);
+
+        dismissTimeoutMapRef.current.set(toastID, dismissTimeout);
+      }
+    },
+    [dismissToast],
+  );
+
+  useEffect(() => {
+    const dismissTimeoutMap = dismissTimeoutMapRef.current;
+
+    return () => {
+      dismissTimeoutMap.forEach((dismissTimeout) => {
+        window.clearTimeout(dismissTimeout);
+      });
+
+      dismissTimeoutMap.clear();
+    };
+  }, []);
+
+  useEffect(() => subscribeToToast(enqueueToast), [enqueueToast]);
+
+  return (
+    <>
+      {children}
+      <div className="pointer-events-none fixed right-4 bottom-4 z-50 flex max-w-sm flex-col gap-2">
+        {toasts.map((toast) => {
+          const variantStyles = getToastVariantStyles(toast.variant);
+
+          return (
+            <div
+              className="pointer-events-auto rounded-xl border border-slate-200 bg-white/95 p-3 text-left shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/95"
+              key={toast.id}
+              role="status"
+            >
+              <div className="flex items-start gap-3">
+                <span className={variantStyles.iconClassName}>
+                  <Icon size={20} type={variantStyles.iconType} />
+                </span>
+                <div className="flex-1 text-sm text-slate-800 dark:text-slate-100">
+                  <p className="font-medium">{toast.message}</p>
+                  {toast.description != null ? (
+                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      {toast.description}
+                    </p>
+                  ) : null}
+                </div>
+                <button
+                  aria-label="Dismiss alert"
+                  className="bg-transparent px-0 py-0 font-normal shadow-none hover:shadow-none"
+                  onClick={() => dismissToast(toast.id)}
+                  type="button"
+                >
+                  <Icon size={18} type={Icon.TYPE.X_CIRCLE} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/demo/src/toast/index.ts
+++ b/demo/src/toast/index.ts
@@ -1,0 +1,2 @@
+export { ToastProvider } from './ToastProvider';
+export { showErrorToast, showInfoToast, showSuccessToast } from './toastBus';

--- a/demo/src/toast/toastBus.ts
+++ b/demo/src/toast/toastBus.ts
@@ -1,0 +1,46 @@
+export type ToastVariant = 'SUCCESS' | 'ERROR' | 'INFO';
+
+export interface ToastEvent {
+  description?: string;
+  durationMs?: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+type ToastListener = (toastEvent: ToastEvent) => void;
+
+const toastListeners = new Set<ToastListener>();
+
+export function subscribeToToast(listener: ToastListener) {
+  toastListeners.add(listener);
+
+  return () => {
+    toastListeners.delete(listener);
+  };
+}
+
+function showToast(toastEvent: ToastEvent) {
+  toastListeners.forEach((listener) => {
+    listener(toastEvent);
+  });
+}
+
+export function showSuccessToast(message: string, durationMs?: number) {
+  showToast({ durationMs, message, variant: 'SUCCESS' });
+}
+
+export function showInfoToast(message: string, durationMs?: number) {
+  showToast({ durationMs, message, variant: 'INFO' });
+}
+
+export function showErrorToast(message: string, error?: unknown, durationMs?: number) {
+  const errorDescription =
+    error instanceof Error ? error.message : error != null ? String(error) : undefined;
+
+  showToast({
+    description: errorDescription,
+    durationMs,
+    message,
+    variant: 'ERROR',
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide user feedback for clipboard actions and a reusable, global toast UI for the demo app.

### Description
- Add a toast event bus with `showSuccessToast`, `showErrorToast`, and `showInfoToast` in `demo/src/toast/toastBus.ts`.
- Implement a `ToastProvider` in `demo/src/toast/ToastProvider.tsx` to render and manage toast lifecycle and styles.
- Export the toast API from `demo/src/toast/index.ts` and wrap the app with `ToastProvider` in `demo/src/main.tsx`.
- Update `ExpandableCodeSnippet` to call `showSuccessToast` on successful clipboard copy and `showErrorToast` on failure.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which succeeded.
- Performed a production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61c574b5c832aa1aeca193d6e8d94)