### PR TITLE
Normalize and validate case-insensitive option values; add validation helpers and tests

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -1279,3 +1279,21 @@ describe('Color gradients', () => {
     expect(mid.b).toBeCloseTo(-0.092635, 6);
   });
 });
+
+describe('Color option validation', () => {
+  it('throws when runtime option strings are invalid', () => {
+    const base = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+
+    expect(() => base.mix([blue], { space: 'INVALID' as never })).toThrow('Invalid space');
+    expect(() => base.blend(blue, { mode: 'INVALID' as never })).toThrow('Invalid mode');
+    expect(() => base.createGradientTo(blue, { hueInterpolationMode: 'INVALID' as never })).toThrow(
+      'Invalid hueInterpolationMode',
+    );
+    expect(() =>
+      base.isReadableAsTextColor('#ffffff', {
+        algorithm: 'INVALID' as never,
+      }),
+    ).toThrow('Invalid algorithm');
+  });
+});

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -1285,15 +1285,15 @@ describe('Color option validation', () => {
     const base = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => base.mix([blue], { space: 'INVALID' as never })).toThrow('Invalid space');
-    expect(() => base.blend(blue, { mode: 'INVALID' as never })).toThrow('Invalid mode');
+    expect(() => base.mix([blue], { space: 'INVALID' as never })).toThrow("Invalid 'space'");
+    expect(() => base.blend(blue, { mode: 'INVALID' as never })).toThrow("Invalid 'mode'");
     expect(() => base.createGradientTo(blue, { hueInterpolationMode: 'INVALID' as never })).toThrow(
-      'Invalid hueInterpolationMode',
+      "Invalid 'hueInterpolationMode'",
     );
     expect(() =>
       base.isReadableAsTextColor('#ffffff', {
         algorithm: 'INVALID' as never,
       }),
-    ).toThrow('Invalid algorithm');
+    ).toThrow("Invalid 'algorithm'");
   });
 });

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -768,4 +768,29 @@ describe('LINEAR_RGB robustness', () => {
       expect(lLum).toBeGreaterThanOrEqual(sLum - 3); // Allow small rounding error
     }
   });
+
+  it('throws for invalid mix option values', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+
+    expect(() => mixColors([red, blue], { type: 'INVALID' as never })).toThrow('Invalid type');
+    expect(() => mixColors([red, blue], { space: 'INVALID' as never })).toThrow('Invalid space');
+  });
+
+  it('throws for invalid blend option values', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+
+    expect(() => blendColors(red, blue, { mode: 'INVALID' as never })).toThrow('Invalid mode');
+    expect(() => blendColors(red, blue, { space: 'INVALID' as never })).toThrow('Invalid space');
+  });
+
+  it('throws for invalid average option values', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+
+    expect(() => averageColors([red, blue], { space: 'INVALID' as never })).toThrow(
+      'Invalid space',
+    );
+  });
 });

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -773,16 +773,16 @@ describe('LINEAR_RGB robustness', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => mixColors([red, blue], { type: 'INVALID' as never })).toThrow('Invalid type');
-    expect(() => mixColors([red, blue], { space: 'INVALID' as never })).toThrow('Invalid space');
+    expect(() => mixColors([red, blue], { type: 'INVALID' as never })).toThrow("Invalid 'type'");
+    expect(() => mixColors([red, blue], { space: 'INVALID' as never })).toThrow("Invalid 'space'");
   });
 
   it('throws for invalid blend option values', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => blendColors(red, blue, { mode: 'INVALID' as never })).toThrow('Invalid mode');
-    expect(() => blendColors(red, blue, { space: 'INVALID' as never })).toThrow('Invalid space');
+    expect(() => blendColors(red, blue, { mode: 'INVALID' as never })).toThrow("Invalid 'mode'");
+    expect(() => blendColors(red, blue, { space: 'INVALID' as never })).toThrow("Invalid 'space'");
   });
 
   it('throws for invalid average option values', () => {
@@ -790,7 +790,7 @@ describe('LINEAR_RGB robustness', () => {
     const blue = new Color('#0000ff');
 
     expect(() => averageColors([red, blue], { space: 'INVALID' as never })).toThrow(
-      'Invalid space',
+      "Invalid 'space'",
     );
   });
 });

--- a/src/color/__test__/deltaE.test.ts
+++ b/src/color/__test__/deltaE.test.ts
@@ -124,12 +124,12 @@ describe('Delta E calculations', () => {
       expect(getDeltaE(red, yellow, { method: 'CIEDE2000' })).toBeCloseTo(63.5875, 4);
     });
 
-    it('throws for unsupported methods in getDeltaE', () => {
+    it('throws for invalid methods in getDeltaE', () => {
       const colorA = new Color({ l: 50, a: 2.6772, b: -79.7751 });
       const colorB = new Color({ l: 50, a: 0, b: -82.7485 });
 
       expect(() => getDeltaE(colorA, colorB, { method: 'INVALID' as never })).toThrow(
-        'Unsupported Delta E method: INVALID',
+        'Invalid method',
       );
     });
 

--- a/src/color/__test__/deltaE.test.ts
+++ b/src/color/__test__/deltaE.test.ts
@@ -129,7 +129,7 @@ describe('Delta E calculations', () => {
       const colorB = new Color({ l: 50, a: 0, b: -82.7485 });
 
       expect(() => getDeltaE(colorA, colorB, { method: 'INVALID' as never })).toThrow(
-        'Invalid method',
+        "Invalid 'method'",
       );
     });
 

--- a/src/color/__test__/gradients.test.ts
+++ b/src/color/__test__/gradients.test.ts
@@ -117,6 +117,23 @@ describe('createColorGradient', () => {
 
     expect(gradient.map((color) => color.toHex())).toEqual(['#14213d', '#886227', '#fca311']);
   });
+
+  it('throws for invalid option values', () => {
+    const anchors = [new Color('#ff0000'), new Color('#0000ff')];
+
+    expect(() => createColorGradient(anchors, { space: 'INVALID' as never })).toThrow(
+      'Invalid space',
+    );
+    expect(() => createColorGradient(anchors, { interpolation: 'INVALID' as never })).toThrow(
+      'Invalid interpolation',
+    );
+    expect(() => createColorGradient(anchors, { easing: 'INVALID' as never })).toThrow(
+      'Invalid easing',
+    );
+    expect(() =>
+      createColorGradient(anchors, { hueInterpolationMode: 'INVALID' as never }),
+    ).toThrow('Invalid hueInterpolationMode');
+  });
 });
 
 describe('Color gradient helpers', () => {

--- a/src/color/__test__/gradients.test.ts
+++ b/src/color/__test__/gradients.test.ts
@@ -122,17 +122,17 @@ describe('createColorGradient', () => {
     const anchors = [new Color('#ff0000'), new Color('#0000ff')];
 
     expect(() => createColorGradient(anchors, { space: 'INVALID' as never })).toThrow(
-      'Invalid space',
+      "Invalid 'space'",
     );
     expect(() => createColorGradient(anchors, { interpolation: 'INVALID' as never })).toThrow(
-      'Invalid interpolation',
+      "Invalid 'interpolation'",
     );
     expect(() => createColorGradient(anchors, { easing: 'INVALID' as never })).toThrow(
-      'Invalid easing',
+      "Invalid 'easing'",
     );
     expect(() =>
       createColorGradient(anchors, { hueInterpolationMode: 'INVALID' as never }),
-    ).toThrow('Invalid hueInterpolationMode');
+    ).toThrow("Invalid 'hueInterpolationMode'");
   });
 });
 

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -952,7 +952,7 @@ describe('getHarmonyColors', () => {
 
   it('throws for unknown harmony type', () => {
     expect(() => getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony)).toThrow(
-      'Invalid harmony',
+      "Invalid 'harmony'",
     );
   });
 
@@ -961,6 +961,6 @@ describe('getHarmonyColors', () => {
       getComplementaryColors(new Color('#808080'), {
         grayscaleHandlingMode: 'unknown' as never,
       }),
-    ).toThrow('Invalid grayscaleHandlingMode');
+    ).toThrow("Invalid 'grayscaleHandlingMode'");
   });
 });

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -952,7 +952,15 @@ describe('getHarmonyColors', () => {
 
   it('throws for unknown harmony type', () => {
     expect(() => getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony)).toThrow(
-      'unknown color harmony: unknown',
+      'Invalid harmony',
     );
+  });
+
+  it('throws for invalid grayscale handling mode', () => {
+    expect(() =>
+      getComplementaryColors(new Color('#808080'), {
+        grayscaleHandlingMode: 'unknown' as never,
+      }),
+    ).toThrow('Invalid grayscaleHandlingMode');
   });
 });

--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -3044,4 +3044,30 @@ describe('APCA readability report and policy behavior', () => {
     expect(advisoryBest.toHex()).toBe('#333333');
     expect(thresholdBest.toHex()).toBe('#333333');
   });
+
+  it('throws for invalid readability option values', () => {
+    const foreground = new Color('#333333');
+    const background = new Color('#ffffff');
+
+    expect(() => isTextReadable(foreground, background, { algorithm: 'INVALID' as never })).toThrow(
+      'Invalid algorithm',
+    );
+    expect(() =>
+      getWCAGReadabilityReport(foreground, background, { level: 'INVALID' as never }),
+    ).toThrow('Invalid level');
+    expect(() =>
+      getWCAGReadabilityReport(foreground, background, { size: 'INVALID' as never }),
+    ).toThrow('Invalid size');
+    expect(() =>
+      getAPCAReadabilityReport(foreground, background, {
+        policy: 'INVALID' as never,
+      }),
+    ).toThrow('Invalid policy');
+    expect(() =>
+      getAPCAReadabilityReport(foreground, background, {
+        policy: 'PRESET',
+        preset: 'INVALID' as never,
+      }),
+    ).toThrow('Invalid preset');
+  });
 });

--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -3050,24 +3050,24 @@ describe('APCA readability report and policy behavior', () => {
     const background = new Color('#ffffff');
 
     expect(() => isTextReadable(foreground, background, { algorithm: 'INVALID' as never })).toThrow(
-      'Invalid algorithm',
+      "Invalid 'algorithm'",
     );
     expect(() =>
       getWCAGReadabilityReport(foreground, background, { level: 'INVALID' as never }),
-    ).toThrow('Invalid level');
+    ).toThrow("Invalid 'level'");
     expect(() =>
       getWCAGReadabilityReport(foreground, background, { size: 'INVALID' as never }),
-    ).toThrow('Invalid size');
+    ).toThrow("Invalid 'size'");
     expect(() =>
       getAPCAReadabilityReport(foreground, background, {
         policy: 'INVALID' as never,
       }),
-    ).toThrow('Invalid policy');
+    ).toThrow("Invalid 'policy'");
     expect(() =>
       getAPCAReadabilityReport(foreground, background, {
         policy: 'PRESET',
         preset: 'INVALID' as never,
       }),
-    ).toThrow('Invalid preset');
+    ).toThrow("Invalid 'preset'");
   });
 });

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -299,7 +299,7 @@ describe('isColorDark', () => {
       isColorDark(new Color('#ffffff'), {
         colorDarknessMode: 'INVALID' as never,
       }),
-    ).toThrow('Invalid colorDarknessMode');
+    ).toThrow("Invalid 'colorDarknessMode'");
   });
 
   it('allows customizing the WCAG threshold', () => {
@@ -437,20 +437,20 @@ describe('getColorRGBAFromInput', () => {
 describe('resolveCaseInsensitiveOption', () => {
   it('normalizes mixed casing and trims whitespace', () => {
     const resolved = resolveCaseInsensitiveOption({
-      value: '  yiQ  ',
       allowedValues: ['WCAG', 'YIQ'],
       defaultValue: 'WCAG',
-      optionName: 'colorDarknessMode',
+      key: 'colorDarknessMode',
+      options: { colorDarknessMode: '  yiQ  ' },
     });
     expect(resolved).toBe('YIQ');
   });
 
   it('returns the default when value is undefined', () => {
     const resolved = resolveCaseInsensitiveOption({
-      value: undefined,
       allowedValues: ['WCAG', 'YIQ'],
       defaultValue: 'WCAG',
-      optionName: 'colorDarknessMode',
+      key: 'colorDarknessMode',
+      options: {} as { colorDarknessMode: 'WCAG' | 'YIQ' },
     });
     expect(resolved).toBe('WCAG');
   });
@@ -458,22 +458,22 @@ describe('resolveCaseInsensitiveOption', () => {
   it('throws for unknown values', () => {
     expect(() =>
       resolveCaseInsensitiveOption({
-        value: 'unknown',
         allowedValues: ['WCAG', 'YIQ'],
         defaultValue: 'WCAG',
-        optionName: 'colorDarknessMode',
+        key: 'colorDarknessMode',
+        options: { colorDarknessMode: 'unknown' },
       }),
-    ).toThrow('Invalid colorDarknessMode');
+    ).toThrow("Invalid 'colorDarknessMode'");
   });
 
   it('throws for non-string values', () => {
     expect(() =>
       resolveCaseInsensitiveOption({
-        value: 123,
         allowedValues: ['WCAG', 'YIQ'],
         defaultValue: 'WCAG',
-        optionName: 'colorDarknessMode',
+        key: 'colorDarknessMode',
+        options: { colorDarknessMode: 123 as never as string }, // test different type
       }),
-    ).toThrow('Invalid colorDarknessMode');
+    ).toThrow("Invalid 'colorDarknessMode'");
   });
 });

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,3 +1,4 @@
+import { resolveCaseInsensitiveOption } from '../../utils';
 import { Color } from '../color';
 import { getColorFromTemperatureLabel } from '../temperature';
 import { areColorsEqual, getColorRGBAFromInput, isColorDark, isColorOffWhite } from '../utils';
@@ -293,6 +294,14 @@ describe('isColorDark', () => {
     expect(isColorDark(new Color('#00AA00'))).toBe(false); // Med Green (L ~ 0.28) -> Light
   });
 
+  it('throws for invalid darkness mode option values', () => {
+    expect(() =>
+      isColorDark(new Color('#ffffff'), {
+        colorDarknessMode: 'INVALID' as never,
+      }),
+    ).toThrow('Invalid colorDarknessMode');
+  });
+
   it('allows customizing the WCAG threshold', () => {
     const red = new Color('#ff0000'); // Luminance ~0.2126
 
@@ -422,5 +431,49 @@ describe('getColorRGBAFromInput', () => {
 
   it('throws on unknown color names', () => {
     expect(() => getColorRGBAFromInput('notacolor')).toThrow();
+  });
+});
+
+describe('resolveCaseInsensitiveOption', () => {
+  it('normalizes mixed casing and trims whitespace', () => {
+    const resolved = resolveCaseInsensitiveOption({
+      value: '  yiQ  ',
+      allowedValues: ['WCAG', 'YIQ'],
+      defaultValue: 'WCAG',
+      optionName: 'colorDarknessMode',
+    });
+    expect(resolved).toBe('YIQ');
+  });
+
+  it('returns the default when value is undefined', () => {
+    const resolved = resolveCaseInsensitiveOption({
+      value: undefined,
+      allowedValues: ['WCAG', 'YIQ'],
+      defaultValue: 'WCAG',
+      optionName: 'colorDarknessMode',
+    });
+    expect(resolved).toBe('WCAG');
+  });
+
+  it('throws for unknown values', () => {
+    expect(() =>
+      resolveCaseInsensitiveOption({
+        value: 'unknown',
+        allowedValues: ['WCAG', 'YIQ'],
+        defaultValue: 'WCAG',
+        optionName: 'colorDarknessMode',
+      }),
+    ).toThrow('Invalid colorDarknessMode');
+  });
+
+  it('throws for non-string values', () => {
+    expect(() =>
+      resolveCaseInsensitiveOption({
+        value: 123,
+        allowedValues: ['WCAG', 'YIQ'],
+        defaultValue: 'WCAG',
+        optionName: 'colorDarknessMode',
+      }),
+    ).toThrow('Invalid colorDarknessMode');
   });
 });

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -445,6 +445,16 @@ describe('resolveCaseInsensitiveOption', () => {
     expect(resolved).toBe('YIQ');
   });
 
+  it('returns the canonical allowed value when allowed values are not uppercase', () => {
+    const resolved = resolveCaseInsensitiveOption({
+      allowedValues: ['camelCase', 'PascalCase'],
+      defaultValue: 'camelCase',
+      key: 'mode',
+      options: { mode: '  PASCALcase ' },
+    });
+    expect(resolved).toBe('PascalCase');
+  });
+
   it('returns the default when value is undefined', () => {
     const resolved = resolveCaseInsensitiveOption({
       allowedValues: ['WCAG', 'YIQ'],

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -1,10 +1,13 @@
 import { type CaseInsensitive, clampValue } from '../utils';
+import { resolveCaseInsensitiveOption } from '../utils';
 import { Color } from './color';
 import type { ColorHSL, ColorHSLA, ColorLCH, ColorOKLCH, ColorRGBA } from './formats';
 import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
 
-export type MixType = 'ADDITIVE' | 'SUBTRACTIVE';
-export type MixSpace = 'RGB' | 'LINEAR_RGB' | 'HSL' | 'LCH' | 'OKLCH';
+const MIX_TYPES = ['ADDITIVE', 'SUBTRACTIVE'] as const;
+const MIX_SPACES = ['RGB', 'LINEAR_RGB', 'HSL', 'LCH', 'OKLCH'] as const;
+export type MixType = (typeof MIX_TYPES)[number];
+export type MixSpace = (typeof MIX_SPACES)[number];
 
 export interface MixColorsOptions {
   space?: CaseInsensitive<MixSpace>;
@@ -462,8 +465,18 @@ export function mixColors(colors: readonly Color[], options: MixColorsOptions = 
   if (colors.length < 2) {
     throw new Error('at least two colors are required for mixing');
   }
-  const type = (options.type?.toUpperCase() ?? 'ADDITIVE') as MixType;
-  const space = (options.space?.toUpperCase() ?? 'LINEAR_RGB') as MixSpace;
+  const type = resolveCaseInsensitiveOption({
+    value: options.type,
+    allowedValues: MIX_TYPES,
+    defaultValue: 'ADDITIVE',
+    optionName: 'type',
+  });
+  const space = resolveCaseInsensitiveOption({
+    value: options.space,
+    allowedValues: MIX_SPACES,
+    defaultValue: 'LINEAR_RGB',
+    optionName: 'space',
+  });
 
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
 
@@ -474,8 +487,10 @@ export function mixColors(colors: readonly Color[], options: MixColorsOptions = 
   return mixColorsAdditive(colors, space, weights, sumOfWeights);
 }
 
-export type BlendMode = 'NORMAL' | 'MULTIPLY' | 'SCREEN' | 'OVERLAY';
-export type BlendSpace = 'RGB' | 'HSL';
+const BLEND_MODES = ['NORMAL', 'MULTIPLY', 'SCREEN', 'OVERLAY'] as const;
+const BLEND_SPACES = ['RGB', 'HSL'] as const;
+export type BlendMode = (typeof BLEND_MODES)[number];
+export type BlendSpace = (typeof BLEND_SPACES)[number];
 
 export interface BlendColorsOptions {
   mode?: CaseInsensitive<BlendMode>;
@@ -600,8 +615,18 @@ function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio
 }
 
 export function blendColors(base: Color, blend: Color, options: BlendColorsOptions = {}): Color {
-  const mode = (options.mode?.toUpperCase() ?? 'NORMAL') as BlendMode;
-  const space = (options.space?.toUpperCase() ?? 'RGB') as BlendSpace;
+  const mode = resolveCaseInsensitiveOption({
+    value: options.mode,
+    allowedValues: BLEND_MODES,
+    defaultValue: 'NORMAL',
+    optionName: 'mode',
+  });
+  const space = resolveCaseInsensitiveOption({
+    value: options.space,
+    allowedValues: BLEND_SPACES,
+    defaultValue: 'RGB',
+    optionName: 'space',
+  });
   const ratio = clampValue(options.ratio ?? 0.5, 0, 1);
 
   if (space === 'RGB') {
@@ -758,7 +783,12 @@ export function averageColors(colors: readonly Color[], options: AverageColorsOp
   if (colors.length < 2) {
     throw new Error('at least two colors are required for averaging');
   }
-  const space = (options.space?.toUpperCase() ?? 'LINEAR_RGB') as MixSpace;
+  const space = resolveCaseInsensitiveOption({
+    value: options.space,
+    allowedValues: MIX_SPACES,
+    defaultValue: 'LINEAR_RGB',
+    optionName: 'space',
+  });
   const { normalizedWeights } = getWeights(colors.length, options.weights);
 
   switch (space) {

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -1,12 +1,12 @@
-import { type CaseInsensitive, clampValue } from '../utils';
-import { resolveCaseInsensitiveOption } from '../utils';
+import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
 import { Color } from './color';
 import type { ColorHSL, ColorHSLA, ColorLCH, ColorOKLCH, ColorRGBA } from './formats';
 import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
 
 const MIX_TYPES = ['ADDITIVE', 'SUBTRACTIVE'] as const;
-const MIX_SPACES = ['RGB', 'LINEAR_RGB', 'HSL', 'LCH', 'OKLCH'] as const;
 export type MixType = (typeof MIX_TYPES)[number];
+
+const MIX_SPACES = ['RGB', 'LINEAR_RGB', 'HSL', 'LCH', 'OKLCH'] as const;
 export type MixSpace = (typeof MIX_SPACES)[number];
 
 export interface MixColorsOptions {
@@ -466,16 +466,16 @@ export function mixColors(colors: readonly Color[], options: MixColorsOptions = 
     throw new Error('at least two colors are required for mixing');
   }
   const type = resolveCaseInsensitiveOption({
-    value: options.type,
     allowedValues: MIX_TYPES,
     defaultValue: 'ADDITIVE',
-    optionName: 'type',
+    key: 'type',
+    options,
   });
   const space = resolveCaseInsensitiveOption({
-    value: options.space,
     allowedValues: MIX_SPACES,
     defaultValue: 'LINEAR_RGB',
-    optionName: 'space',
+    key: 'space',
+    options,
   });
 
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
@@ -488,8 +488,9 @@ export function mixColors(colors: readonly Color[], options: MixColorsOptions = 
 }
 
 const BLEND_MODES = ['NORMAL', 'MULTIPLY', 'SCREEN', 'OVERLAY'] as const;
-const BLEND_SPACES = ['RGB', 'HSL'] as const;
 export type BlendMode = (typeof BLEND_MODES)[number];
+
+const BLEND_SPACES = ['RGB', 'HSL'] as const;
 export type BlendSpace = (typeof BLEND_SPACES)[number];
 
 export interface BlendColorsOptions {
@@ -616,16 +617,16 @@ function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio
 
 export function blendColors(base: Color, blend: Color, options: BlendColorsOptions = {}): Color {
   const mode = resolveCaseInsensitiveOption({
-    value: options.mode,
     allowedValues: BLEND_MODES,
     defaultValue: 'NORMAL',
-    optionName: 'mode',
+    key: 'mode',
+    options,
   });
   const space = resolveCaseInsensitiveOption({
-    value: options.space,
     allowedValues: BLEND_SPACES,
     defaultValue: 'RGB',
-    optionName: 'space',
+    key: 'space',
+    options,
   });
   const ratio = clampValue(options.ratio ?? 0.5, 0, 1);
 
@@ -784,10 +785,10 @@ export function averageColors(colors: readonly Color[], options: AverageColorsOp
     throw new Error('at least two colors are required for averaging');
   }
   const space = resolveCaseInsensitiveOption({
-    value: options.space,
     allowedValues: MIX_SPACES,
     defaultValue: 'LINEAR_RGB',
-    optionName: 'space',
+    key: 'space',
+    options,
   });
   const { normalizedWeights } = getWeights(colors.length, options.weights);
 

--- a/src/color/deltaE.ts
+++ b/src/color/deltaE.ts
@@ -1,7 +1,9 @@
 import type { CaseInsensitive } from '../utils';
+import { resolveCaseInsensitiveOption } from '../utils';
 import type { Color } from './color';
 
-export type DeltaEMethod = 'CIE76' | 'CIE94' | 'CIEDE2000';
+const DELTA_E_METHODS = ['CIE76', 'CIE94', 'CIEDE2000'] as const;
+export type DeltaEMethod = (typeof DELTA_E_METHODS)[number];
 
 /**
  * Optional weighting factors for the CIE94 Delta E calculation.
@@ -172,7 +174,12 @@ function deltaECIEDE2000(colorA: Color, colorB: Color, options: CIEDE2000Options
 }
 
 export function getDeltaE(colorA: Color, colorB: Color, options: DeltaEOptions = {}): number {
-  const method = options.method?.toUpperCase() ?? ('CIEDE2000' as DeltaEMethod);
+  const method = resolveCaseInsensitiveOption({
+    value: options.method,
+    allowedValues: DELTA_E_METHODS,
+    defaultValue: 'CIEDE2000',
+    optionName: 'method',
+  });
 
   if (method === 'CIE76') {
     return deltaECIE76(colorA, colorB);

--- a/src/color/deltaE.ts
+++ b/src/color/deltaE.ts
@@ -1,5 +1,4 @@
-import type { CaseInsensitive } from '../utils';
-import { resolveCaseInsensitiveOption } from '../utils';
+import { type CaseInsensitive, resolveCaseInsensitiveOption } from '../utils';
 import type { Color } from './color';
 
 const DELTA_E_METHODS = ['CIE76', 'CIE94', 'CIEDE2000'] as const;
@@ -175,10 +174,10 @@ function deltaECIEDE2000(colorA: Color, colorB: Color, options: CIEDE2000Options
 
 export function getDeltaE(colorA: Color, colorB: Color, options: DeltaEOptions = {}): number {
   const method = resolveCaseInsensitiveOption({
-    value: options.method,
     allowedValues: DELTA_E_METHODS,
     defaultValue: 'CIEDE2000',
-    optionName: 'method',
+    key: 'method',
+    options,
   });
 
   if (method === 'CIE76') {

--- a/src/color/gradients.ts
+++ b/src/color/gradients.ts
@@ -1,5 +1,4 @@
-import { type CaseInsensitive, clampValue } from '../utils';
-import { resolveCaseInsensitiveOption } from '../utils';
+import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
 import type { Color } from './color';
 import type {
   ColorHSL,
@@ -12,9 +11,19 @@ import type {
 } from './formats';
 import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
 
-const GRADIENT_EASING_MODES = ['LINEAR', 'EASE_IN', 'EASE_OUT', 'EASE_IN_OUT'] as const;
 const GRADIENT_SPACES = ['RGB', 'HSL', 'HSV', 'LCH', 'OKLAB', 'OKLCH'] as const;
+export type ColorGradientSpace = (typeof GRADIENT_SPACES)[number];
+
 const GRADIENT_INTERPOLATIONS = ['LINEAR', 'BEZIER'] as const;
+export type ColorGradientInterpolation = (typeof GRADIENT_INTERPOLATIONS)[number];
+
+const GRADIENT_EASING_MODES = ['LINEAR', 'EASE_IN', 'EASE_OUT', 'EASE_IN_OUT'] as const;
+type ColorGradientEasingMode = (typeof GRADIENT_EASING_MODES)[number];
+
+export type ColorGradientEasing =
+  | CaseInsensitive<ColorGradientEasingMode>
+  | ((t: number) => number);
+
 const HUE_INTERPOLATION_MODES = [
   'CARTESIAN',
   'SHORTEST',
@@ -23,15 +32,7 @@ const HUE_INTERPOLATION_MODES = [
   'DECREASING',
   'RAW',
 ] as const;
-const HUE_INTERPOLATION_MODES_WITH_AUTO = [...HUE_INTERPOLATION_MODES, 'AUTO'] as const;
-export type ColorGradientSpace = (typeof GRADIENT_SPACES)[number];
-export type ColorGradientInterpolation = (typeof GRADIENT_INTERPOLATIONS)[number];
-type ColorGradientEasingMode = (typeof GRADIENT_EASING_MODES)[number];
 export type HueInterpolationMode = (typeof HUE_INTERPOLATION_MODES)[number];
-type HueInterpolationModeWithAuto = (typeof HUE_INTERPOLATION_MODES_WITH_AUTO)[number];
-export type ColorGradientEasing =
-  | CaseInsensitive<ColorGradientEasingMode>
-  | ((t: number) => number);
 
 export interface ColorGradientOptions {
   /**
@@ -92,16 +93,16 @@ function wrapHue(degrees: number): number {
 /**
  * Convert a supplied easing configuration into a normalized easing function.
  */
-function getEasingFunction(easing?: ColorGradientEasing): (t: number) => number {
-  if (typeof easing === 'function') {
-    return easing;
+function getEasingFunction(options: ColorGradientOptions): (t: number) => number {
+  if (typeof options.easing === 'function') {
+    return options.easing;
   }
 
   const easingMode = resolveCaseInsensitiveOption({
-    value: easing,
     allowedValues: GRADIENT_EASING_MODES,
     defaultValue: 'LINEAR',
-    optionName: 'easing',
+    key: 'easing',
+    options,
   });
   switch (easingMode) {
     case 'EASE_IN':
@@ -793,34 +794,28 @@ export function createColorGradient(
   const ColorConstructor = colors[0].constructor as typeof Color;
   const stopCount = getStopCount(options.stops);
   const space = resolveCaseInsensitiveOption({
-    value: options.space,
     allowedValues: GRADIENT_SPACES,
     defaultValue: DEFAULT_SPACE,
-    optionName: 'space',
+    key: 'space',
+    options,
   });
   const interpolation = resolveCaseInsensitiveOption({
-    value: options.interpolation,
     allowedValues: GRADIENT_INTERPOLATIONS,
     defaultValue: DEFAULT_INTERPOLATION,
-    optionName: 'interpolation',
+    key: 'interpolation',
+    options,
   });
   const clamp = options.clamp ?? true;
-  const easing = getEasingFunction(options.easing);
+  const easing = getEasingFunction(options);
   const isBezier = interpolation === 'BEZIER';
 
-  // Determine Hue Interpolation Mode
-  // Default to 'SHORTEST' for Polar spaces, 'CARTESIAN' (legacy) for RGB or if explicit.
-  // Actually, legacy for Polar was Cartesian.
-  // New default for Polar is Shortest.
-  const resolvedHueMode = resolveCaseInsensitiveOption({
-    value: options.hueInterpolationMode,
-    allowedValues: HUE_INTERPOLATION_MODES_WITH_AUTO,
-    defaultValue: 'AUTO',
-    optionName: 'hueInterpolationMode',
+  let hueMode = resolveCaseInsensitiveOption({
+    allowedValues: HUE_INTERPOLATION_MODES,
+    defaultValue: null,
+    key: 'hueInterpolationMode',
+    options,
   });
-  let hueMode: HueInterpolationModeWithAuto = resolvedHueMode;
-
-  if (hueMode === 'AUTO') {
+  if (!hueMode) {
     if (isBezier && space === 'LCH') {
       hueMode = 'CARTESIAN';
     } else if (space === 'RGB') {
@@ -833,8 +828,6 @@ export function createColorGradient(
   const isCartesian = hueMode === 'CARTESIAN';
 
   let vectors = colors.map((color) => colorToVector(color, space, isCartesian));
-
-  // Adjust hues if not Cartesian
   if (!isCartesian) {
     vectors = adjustHueStops(vectors, hueMode, space);
   }

--- a/src/color/gradients.ts
+++ b/src/color/gradients.ts
@@ -1,4 +1,5 @@
 import { type CaseInsensitive, clampValue } from '../utils';
+import { resolveCaseInsensitiveOption } from '../utils';
 import type { Color } from './color';
 import type {
   ColorHSL,
@@ -11,21 +12,26 @@ import type {
 } from './formats';
 import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
 
-export type ColorGradientSpace = 'RGB' | 'HSL' | 'HSV' | 'LCH' | 'OKLAB' | 'OKLCH';
-export type ColorGradientInterpolation = 'LINEAR' | 'BEZIER';
-
-type ColorGradientEasingMode = 'LINEAR' | 'EASE_IN' | 'EASE_OUT' | 'EASE_IN_OUT';
+const GRADIENT_EASING_MODES = ['LINEAR', 'EASE_IN', 'EASE_OUT', 'EASE_IN_OUT'] as const;
+const GRADIENT_SPACES = ['RGB', 'HSL', 'HSV', 'LCH', 'OKLAB', 'OKLCH'] as const;
+const GRADIENT_INTERPOLATIONS = ['LINEAR', 'BEZIER'] as const;
+const HUE_INTERPOLATION_MODES = [
+  'CARTESIAN',
+  'SHORTEST',
+  'LONGEST',
+  'INCREASING',
+  'DECREASING',
+  'RAW',
+] as const;
+const HUE_INTERPOLATION_MODES_WITH_AUTO = [...HUE_INTERPOLATION_MODES, 'AUTO'] as const;
+export type ColorGradientSpace = (typeof GRADIENT_SPACES)[number];
+export type ColorGradientInterpolation = (typeof GRADIENT_INTERPOLATIONS)[number];
+type ColorGradientEasingMode = (typeof GRADIENT_EASING_MODES)[number];
+export type HueInterpolationMode = (typeof HUE_INTERPOLATION_MODES)[number];
+type HueInterpolationModeWithAuto = (typeof HUE_INTERPOLATION_MODES_WITH_AUTO)[number];
 export type ColorGradientEasing =
   | CaseInsensitive<ColorGradientEasingMode>
   | ((t: number) => number);
-
-export type HueInterpolationMode =
-  | 'CARTESIAN'
-  | 'SHORTEST'
-  | 'LONGEST'
-  | 'INCREASING'
-  | 'DECREASING'
-  | 'RAW';
 
 export interface ColorGradientOptions {
   /**
@@ -91,7 +97,12 @@ function getEasingFunction(easing?: ColorGradientEasing): (t: number) => number 
     return easing;
   }
 
-  const easingMode = (easing ? easing.toUpperCase() : 'LINEAR') as ColorGradientEasingMode;
+  const easingMode = resolveCaseInsensitiveOption({
+    value: easing,
+    allowedValues: GRADIENT_EASING_MODES,
+    defaultValue: 'LINEAR',
+    optionName: 'easing',
+  });
   switch (easingMode) {
     case 'EASE_IN':
       return (t: number) => t ** 2;
@@ -781,9 +792,18 @@ export function createColorGradient(
 
   const ColorConstructor = colors[0].constructor as typeof Color;
   const stopCount = getStopCount(options.stops);
-  const space = (options.space?.toUpperCase() ?? DEFAULT_SPACE) as ColorGradientSpace;
-  const interpolation = (options.interpolation?.toUpperCase() ??
-    DEFAULT_INTERPOLATION) as ColorGradientInterpolation;
+  const space = resolveCaseInsensitiveOption({
+    value: options.space,
+    allowedValues: GRADIENT_SPACES,
+    defaultValue: DEFAULT_SPACE,
+    optionName: 'space',
+  });
+  const interpolation = resolveCaseInsensitiveOption({
+    value: options.interpolation,
+    allowedValues: GRADIENT_INTERPOLATIONS,
+    defaultValue: DEFAULT_INTERPOLATION,
+    optionName: 'interpolation',
+  });
   const clamp = options.clamp ?? true;
   const easing = getEasingFunction(options.easing);
   const isBezier = interpolation === 'BEZIER';
@@ -792,9 +812,15 @@ export function createColorGradient(
   // Default to 'SHORTEST' for Polar spaces, 'CARTESIAN' (legacy) for RGB or if explicit.
   // Actually, legacy for Polar was Cartesian.
   // New default for Polar is Shortest.
-  let hueMode = options.hueInterpolationMode?.toUpperCase() as HueInterpolationMode | undefined;
+  const resolvedHueMode = resolveCaseInsensitiveOption({
+    value: options.hueInterpolationMode,
+    allowedValues: HUE_INTERPOLATION_MODES_WITH_AUTO,
+    defaultValue: 'AUTO',
+    optionName: 'hueInterpolationMode',
+  });
+  let hueMode: HueInterpolationModeWithAuto = resolvedHueMode;
 
-  if (!hueMode) {
+  if (hueMode === 'AUTO') {
     if (isBezier && space === 'LCH') {
       hueMode = 'CARTESIAN';
     } else if (space === 'RGB') {

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -1,19 +1,22 @@
 import { type CaseInsensitive, clampValue } from '../utils';
+import { resolveCaseInsensitiveOption, resolveRequiredCaseInsensitiveOption } from '../utils';
 import { Color } from './color';
 import type { ColorHSLA } from './formats';
 
 // TODO: consider using LCH or OKLCH space mode for more human perceptual accuracy
 
-export type ColorHarmony =
-  | 'COMPLEMENTARY'
-  | 'SPLIT_COMPLEMENTARY'
-  | 'TRIADIC'
-  | 'SQUARE'
-  | 'TETRADIC'
-  | 'ANALOGOUS'
-  | 'MONOCHROMATIC';
-
-export type GrayscaleHandlingMode = 'SPIN_LIGHTNESS' | 'IGNORE';
+const GRAYSCALE_HANDLING_MODES = ['SPIN_LIGHTNESS', 'IGNORE'] as const;
+const COLOR_HARMONIES = [
+  'COMPLEMENTARY',
+  'SPLIT_COMPLEMENTARY',
+  'TRIADIC',
+  'SQUARE',
+  'TETRADIC',
+  'ANALOGOUS',
+  'MONOCHROMATIC',
+] as const;
+export type GrayscaleHandlingMode = (typeof GRAYSCALE_HANDLING_MODES)[number];
+export type ColorHarmony = (typeof COLOR_HARMONIES)[number];
 
 export interface ColorHarmonyOptions {
   grayscaleHandlingMode?: CaseInsensitive<GrayscaleHandlingMode>;
@@ -50,10 +53,12 @@ function spinColorOnHueOrLightness(
 function resolveGrayscaleHandlingMode({
   grayscaleHandlingMode,
 }: ColorHarmonyOptions = {}): GrayscaleHandlingMode {
-  if (!grayscaleHandlingMode) {
-    return 'SPIN_LIGHTNESS';
-  }
-  return grayscaleHandlingMode.toUpperCase() as GrayscaleHandlingMode;
+  return resolveCaseInsensitiveOption({
+    value: grayscaleHandlingMode,
+    allowedValues: GRAYSCALE_HANDLING_MODES,
+    defaultValue: 'SPIN_LIGHTNESS',
+    optionName: 'grayscaleHandlingMode',
+  });
 }
 
 export function getComplementaryColors(
@@ -146,7 +151,13 @@ export function getHarmonyColors(
   harmony: CaseInsensitive<ColorHarmony>,
   options?: ColorHarmonyOptions,
 ): Color[] {
-  switch (harmony.toUpperCase() as ColorHarmony) {
+  const resolvedHarmony = resolveRequiredCaseInsensitiveOption({
+    value: harmony,
+    allowedValues: COLOR_HARMONIES,
+    optionName: 'harmony',
+  });
+
+  switch (resolvedHarmony) {
     case 'COMPLEMENTARY':
       return getComplementaryColors(color, options);
     case 'SPLIT_COMPLEMENTARY':

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -6,6 +6,8 @@ import type { ColorHSLA } from './formats';
 // TODO: consider using LCH or OKLCH space mode for more human perceptual accuracy
 
 const GRAYSCALE_HANDLING_MODES = ['SPIN_LIGHTNESS', 'IGNORE'] as const;
+export type GrayscaleHandlingMode = (typeof GRAYSCALE_HANDLING_MODES)[number];
+
 const COLOR_HARMONIES = [
   'COMPLEMENTARY',
   'SPLIT_COMPLEMENTARY',
@@ -15,7 +17,6 @@ const COLOR_HARMONIES = [
   'ANALOGOUS',
   'MONOCHROMATIC',
 ] as const;
-export type GrayscaleHandlingMode = (typeof GRAYSCALE_HANDLING_MODES)[number];
 export type ColorHarmony = (typeof COLOR_HARMONIES)[number];
 
 export interface ColorHarmonyOptions {
@@ -50,20 +51,18 @@ function spinColorOnHueOrLightness(
   return color.spin(degrees);
 }
 
-function resolveGrayscaleHandlingMode({
-  grayscaleHandlingMode,
-}: ColorHarmonyOptions = {}): GrayscaleHandlingMode {
+function resolveGrayscaleHandlingMode(options: ColorHarmonyOptions): GrayscaleHandlingMode {
   return resolveCaseInsensitiveOption({
-    value: grayscaleHandlingMode,
     allowedValues: GRAYSCALE_HANDLING_MODES,
     defaultValue: 'SPIN_LIGHTNESS',
-    optionName: 'grayscaleHandlingMode',
+    key: 'grayscaleHandlingMode',
+    options,
   });
 }
 
 export function getComplementaryColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [color.clone(), spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode)];
@@ -71,7 +70,7 @@ export function getComplementaryColors(
 
 export function getSplitComplementaryColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
@@ -83,7 +82,7 @@ export function getSplitComplementaryColors(
 
 export function getTriadicHarmonyColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
@@ -95,7 +94,7 @@ export function getTriadicHarmonyColors(
 
 export function getSquareHarmonyColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color, Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
@@ -108,7 +107,7 @@ export function getSquareHarmonyColors(
 
 export function getTetradicHarmonyColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color, Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: tetradic harmonies can also be "wide" (120, 180, 300) or go in the other direction, or potentially any rectangle
@@ -124,7 +123,7 @@ export function getTetradicHarmonyColors(
 
 export function getAnalogousHarmonyColors(
   color: Color,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): [Color, Color, Color, Color, Color] {
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: verify, because other libraries seem to have a slightly narrower angle
@@ -149,12 +148,12 @@ export function getMonochromaticHarmonyColors(color: Color): [Color, Color, Colo
 export function getHarmonyColors(
   color: Color,
   harmony: CaseInsensitive<ColorHarmony>,
-  options?: ColorHarmonyOptions,
+  options: ColorHarmonyOptions = {},
 ): Color[] {
   const resolvedHarmony = resolveRequiredCaseInsensitiveOption({
-    value: harmony,
     allowedValues: COLOR_HARMONIES,
-    optionName: 'harmony',
+    key: 'harmony',
+    options: { harmony },
   });
 
   switch (resolvedHarmony) {

--- a/src/color/readability.ts
+++ b/src/color/readability.ts
@@ -3,6 +3,21 @@ import type { Color } from './color';
 import type { ColorRGBA } from './formats';
 import { getRelativeLuminance } from './utils';
 
+const APCA_THRESHOLD_PRESETS = ['BODY', 'LARGE_TEXT', 'NON_TEXT', 'VERY_LOW_VISION'] as const;
+export type APCAThresholdPreset = (typeof APCA_THRESHOLD_PRESETS)[number];
+
+const APCA_READABILITY_POLICIES = ['NONE', 'PRESET', 'CUSTOM'] as const;
+export type APCAReadabilityPolicy = (typeof APCA_READABILITY_POLICIES)[number];
+
+const WCAG_CONFORMANCE_LEVELS = ['AA', 'AAA'] as const;
+export type WCAGReadabilityConformanceLevel = (typeof WCAG_CONFORMANCE_LEVELS)[number];
+
+const WCAG_TEXT_SIZES = ['SMALL', 'LARGE'] as const;
+export type WCAGReadabilityTextSizeOptions = (typeof WCAG_TEXT_SIZES)[number];
+
+const READABILITY_ALGORITHMS = ['WCAG', 'APCA'] as const;
+export type ReadabilityAlgorithm = (typeof READABILITY_ALGORITHMS)[number];
+
 // Does alpha blending between the two RGBA colors. Calculates what the a
 // semi-transparent foreground color would look like on the background color.
 function getCompositeRGBA(fg: ColorRGBA, bg: ColorRGBA): ColorRGBA {
@@ -134,17 +149,6 @@ export function getAPCAReadabilityScore(foreground: Color, background: Color): n
   return getAPCAContrast(txtY, bgY);
 }
 
-const APCA_THRESHOLD_PRESETS = ['BODY', 'LARGE_TEXT', 'NON_TEXT', 'VERY_LOW_VISION'] as const;
-const APCA_READABILITY_POLICIES = ['NONE', 'PRESET', 'CUSTOM'] as const;
-const WCAG_CONFORMANCE_LEVELS = ['AA', 'AAA'] as const;
-const WCAG_TEXT_SIZES = ['SMALL', 'LARGE'] as const;
-const READABILITY_ALGORITHMS = ['WCAG', 'APCA'] as const;
-export type APCAThresholdPreset = (typeof APCA_THRESHOLD_PRESETS)[number];
-export type APCAReadabilityPolicy = (typeof APCA_READABILITY_POLICIES)[number];
-export type WCAGReadabilityConformanceLevel = (typeof WCAG_CONFORMANCE_LEVELS)[number];
-export type WCAGReadabilityTextSizeOptions = (typeof WCAG_TEXT_SIZES)[number];
-export type ReadabilityAlgorithm = (typeof READABILITY_ALGORITHMS)[number];
-
 export interface APCAReadabilityOptions {
   policy?: CaseInsensitive<APCAReadabilityPolicy>;
   preset?: CaseInsensitive<APCAThresholdPreset>;
@@ -168,10 +172,10 @@ const APCA_REQUIRED_PRESETS = {
 
 function getAPCARequiredLc(options: APCAReadabilityOptions = {}): number | null {
   const policy = resolveCaseInsensitiveOption({
-    value: options.policy,
     allowedValues: APCA_READABILITY_POLICIES,
     defaultValue: 'NONE',
-    optionName: 'policy',
+    key: 'policy',
+    options,
   });
 
   if (policy === 'NONE') {
@@ -183,10 +187,10 @@ function getAPCARequiredLc(options: APCAReadabilityOptions = {}): number | null 
   }
 
   const preset = resolveCaseInsensitiveOption({
-    value: options.preset,
     allowedValues: APCA_THRESHOLD_PRESETS,
     defaultValue: 'BODY',
-    optionName: 'preset',
+    key: 'preset',
+    options,
   });
   return APCA_REQUIRED_PRESETS[preset];
 }
@@ -289,16 +293,16 @@ export function getWCAGReadabilityReport(
   options: WCAGReadabilityOptions = {},
 ): WCAGReadabilityReport {
   const level = resolveCaseInsensitiveOption({
-    value: options.level,
     allowedValues: WCAG_CONFORMANCE_LEVELS,
     defaultValue: 'AA',
-    optionName: 'level',
+    key: 'level',
+    options,
   });
   const size = resolveCaseInsensitiveOption({
-    value: options.size,
     allowedValues: WCAG_TEXT_SIZES,
     defaultValue: 'SMALL',
-    optionName: 'size',
+    key: 'size',
+    options,
   });
 
   const contrastRatio = getWCAGContrastRatio(foreground, background);
@@ -317,10 +321,10 @@ export function isTextReadable(
   options: ReadabilityOptions = {},
 ): boolean {
   const algorithm = resolveCaseInsensitiveOption({
-    value: options.algorithm,
     allowedValues: READABILITY_ALGORITHMS,
     defaultValue: 'WCAG',
-    optionName: 'algorithm',
+    key: 'algorithm',
+    options,
   });
 
   if (algorithm === 'APCA') {
@@ -337,10 +341,10 @@ function getReadabilityComparisonResult(
   options: ReadabilityOptions = {},
 ): ReadabilityComparisonResult {
   const algorithm = resolveCaseInsensitiveOption({
-    value: options.algorithm,
     allowedValues: READABILITY_ALGORITHMS,
     defaultValue: 'WCAG',
-    optionName: 'algorithm',
+    key: 'algorithm',
+    options,
   });
   const { apcaOptions, wcagOptions } = options;
 

--- a/src/color/readability.ts
+++ b/src/color/readability.ts
@@ -1,4 +1,4 @@
-import { type CaseInsensitive } from '../utils';
+import { type CaseInsensitive, resolveCaseInsensitiveOption } from '../utils';
 import type { Color } from './color';
 import type { ColorRGBA } from './formats';
 import { getRelativeLuminance } from './utils';
@@ -134,8 +134,16 @@ export function getAPCAReadabilityScore(foreground: Color, background: Color): n
   return getAPCAContrast(txtY, bgY);
 }
 
-export type APCAThresholdPreset = 'BODY' | 'LARGE_TEXT' | 'NON_TEXT' | 'VERY_LOW_VISION';
-export type APCAReadabilityPolicy = 'NONE' | 'PRESET' | 'CUSTOM';
+const APCA_THRESHOLD_PRESETS = ['BODY', 'LARGE_TEXT', 'NON_TEXT', 'VERY_LOW_VISION'] as const;
+const APCA_READABILITY_POLICIES = ['NONE', 'PRESET', 'CUSTOM'] as const;
+const WCAG_CONFORMANCE_LEVELS = ['AA', 'AAA'] as const;
+const WCAG_TEXT_SIZES = ['SMALL', 'LARGE'] as const;
+const READABILITY_ALGORITHMS = ['WCAG', 'APCA'] as const;
+export type APCAThresholdPreset = (typeof APCA_THRESHOLD_PRESETS)[number];
+export type APCAReadabilityPolicy = (typeof APCA_READABILITY_POLICIES)[number];
+export type WCAGReadabilityConformanceLevel = (typeof WCAG_CONFORMANCE_LEVELS)[number];
+export type WCAGReadabilityTextSizeOptions = (typeof WCAG_TEXT_SIZES)[number];
+export type ReadabilityAlgorithm = (typeof READABILITY_ALGORITHMS)[number];
 
 export interface APCAReadabilityOptions {
   policy?: CaseInsensitive<APCAReadabilityPolicy>;
@@ -159,7 +167,12 @@ const APCA_REQUIRED_PRESETS = {
 } as const satisfies Record<APCAThresholdPreset, number>;
 
 function getAPCARequiredLc(options: APCAReadabilityOptions = {}): number | null {
-  const policy = (options.policy?.toUpperCase() ?? 'NONE') as APCAReadabilityPolicy;
+  const policy = resolveCaseInsensitiveOption({
+    value: options.policy,
+    allowedValues: APCA_READABILITY_POLICIES,
+    defaultValue: 'NONE',
+    optionName: 'policy',
+  });
 
   if (policy === 'NONE') {
     return null;
@@ -169,7 +182,12 @@ function getAPCARequiredLc(options: APCAReadabilityOptions = {}): number | null 
     return Math.max(0, Math.abs(options.threshold ?? APCA_REQUIRED_PRESETS.BODY));
   }
 
-  const preset = (options.preset?.toUpperCase() ?? 'BODY') as APCAThresholdPreset;
+  const preset = resolveCaseInsensitiveOption({
+    value: options.preset,
+    allowedValues: APCA_THRESHOLD_PRESETS,
+    defaultValue: 'BODY',
+    optionName: 'preset',
+  });
   return APCA_REQUIRED_PRESETS[preset];
 }
 
@@ -201,11 +219,6 @@ export function getAPCAReadabilityReport(
   };
 }
 
-export type WCAGReadabilityConformanceLevel = 'AA' | 'AAA';
-export type WCAGReadabilityTextSizeOptions =
-  | 'SMALL' // normal body text (< 18pt or < 14pt if bold)
-  | 'LARGE'; // large-scale text (>= 18pt or >= 14pt if bold)
-
 const WCAG_CONTRAST_READABILITY_THRESHOLDS: {
   [key in WCAGReadabilityConformanceLevel]: { [key in WCAGReadabilityTextSizeOptions]: number };
 } = {
@@ -230,8 +243,6 @@ export interface WCAGReadabilityReport {
   requiredContrast: number;
   shortfall: number;
 }
-
-export type ReadabilityAlgorithm = 'WCAG' | 'APCA';
 
 export interface ReadabilityOptions {
   algorithm?: CaseInsensitive<ReadabilityAlgorithm>;
@@ -277,8 +288,18 @@ export function getWCAGReadabilityReport(
   background: Color,
   options: WCAGReadabilityOptions = {},
 ): WCAGReadabilityReport {
-  const level = (options.level?.toUpperCase() ?? 'AA') as WCAGReadabilityConformanceLevel;
-  const size = (options.size?.toUpperCase() ?? 'SMALL') as WCAGReadabilityTextSizeOptions;
+  const level = resolveCaseInsensitiveOption({
+    value: options.level,
+    allowedValues: WCAG_CONFORMANCE_LEVELS,
+    defaultValue: 'AA',
+    optionName: 'level',
+  });
+  const size = resolveCaseInsensitiveOption({
+    value: options.size,
+    allowedValues: WCAG_TEXT_SIZES,
+    defaultValue: 'SMALL',
+    optionName: 'size',
+  });
 
   const contrastRatio = getWCAGContrastRatio(foreground, background);
   const requiredContrast = WCAG_CONTRAST_READABILITY_THRESHOLDS[level][size];
@@ -295,7 +316,12 @@ export function isTextReadable(
   background: Color,
   options: ReadabilityOptions = {},
 ): boolean {
-  const algorithm = (options.algorithm?.toUpperCase() ?? 'WCAG') as ReadabilityAlgorithm;
+  const algorithm = resolveCaseInsensitiveOption({
+    value: options.algorithm,
+    allowedValues: READABILITY_ALGORITHMS,
+    defaultValue: 'WCAG',
+    optionName: 'algorithm',
+  });
 
   if (algorithm === 'APCA') {
     const report = getAPCAReadabilityReport(foreground, background, options.apcaOptions);
@@ -310,7 +336,12 @@ function getReadabilityComparisonResult(
   background: Color,
   options: ReadabilityOptions = {},
 ): ReadabilityComparisonResult {
-  const algorithm = (options.algorithm?.toUpperCase() ?? 'WCAG') as ReadabilityAlgorithm;
+  const algorithm = resolveCaseInsensitiveOption({
+    value: options.algorithm,
+    allowedValues: READABILITY_ALGORITHMS,
+    defaultValue: 'WCAG',
+    optionName: 'algorithm',
+  });
   const { apcaOptions, wcagOptions } = options;
 
   if (algorithm === 'APCA') {

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -1,4 +1,4 @@
-import { type CaseInsensitive, clampValue } from '../utils';
+import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
 import { Color } from './color';
 import { CSS_COLOR_NAME_TO_HEX_MAP } from './color.consts';
 import { toRGBA } from './conversions';
@@ -96,7 +96,8 @@ export function getRelativeLuminance(rgb: ColorRGBA): number {
 /**
  * The algorithm mode to use for calculating if a color is dark.
  */
-export type ColorDarknessMode = 'WCAG' | 'YIQ';
+const COLOR_DARKNESS_MODES = ['WCAG', 'YIQ'] as const;
+export type ColorDarknessMode = (typeof COLOR_DARKNESS_MODES)[number];
 
 interface IsColorDarkWCAGOptions {
   /**
@@ -147,7 +148,14 @@ function isColorDarkYIQ(color: Color, threshold: number): boolean {
 
 // Checks if a color is dark based on the specified algorithm and threshold.
 export function isColorDark(color: Color, options: IsColorDarkOptions = {}): boolean {
-  if (options.colorDarknessMode?.toUpperCase() === 'YIQ') {
+  const colorDarknessMode = resolveCaseInsensitiveOption({
+    value: options.colorDarknessMode,
+    allowedValues: COLOR_DARKNESS_MODES,
+    defaultValue: 'WCAG',
+    optionName: 'colorDarknessMode',
+  });
+
+  if (colorDarknessMode === 'YIQ') {
     return isColorDarkYIQ(color, options.yiqThreshold ?? 128);
   }
 

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -149,10 +149,10 @@ function isColorDarkYIQ(color: Color, threshold: number): boolean {
 // Checks if a color is dark based on the specified algorithm and threshold.
 export function isColorDark(color: Color, options: IsColorDarkOptions = {}): boolean {
   const colorDarknessMode = resolveCaseInsensitiveOption({
-    value: options.colorDarknessMode,
     allowedValues: COLOR_DARKNESS_MODES,
     defaultValue: 'WCAG',
-    optionName: 'colorDarknessMode',
+    key: 'colorDarknessMode',
+    options,
   });
 
   if (colorDarknessMode === 'YIQ') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,61 @@ export function clampValue(inputValue: number, min: number, max: number): number
 export function capitalizeString(input: string): string {
   return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
 }
+
+function getAllowedOptionList<T extends string>(allowedValues: readonly T[]): string {
+  return allowedValues.join(', ');
+}
+
+export function resolveCaseInsensitiveOption<T extends string>({
+  value,
+  allowedValues,
+  defaultValue,
+  optionName,
+}: {
+  value: unknown;
+  allowedValues: readonly T[];
+  defaultValue: T;
+  optionName: string;
+}): T {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Invalid ${optionName}: expected one of ${getAllowedOptionList(allowedValues)}, got ${String(value)}`,
+    );
+  }
+
+  const normalized = value.trim().toUpperCase();
+  if ((allowedValues as readonly string[]).includes(normalized)) {
+    return normalized as T;
+  }
+
+  throw new Error(
+    `Invalid ${optionName}: "${value}". Expected one of ${getAllowedOptionList(allowedValues)}`,
+  );
+}
+
+export function resolveRequiredCaseInsensitiveOption<T extends string>({
+  value,
+  allowedValues,
+  optionName,
+}: {
+  value: unknown;
+  allowedValues: readonly T[];
+  optionName: string;
+}): T {
+  if (value === undefined || value === null) {
+    throw new Error(
+      `Missing required ${optionName}. Expected one of ${getAllowedOptionList(allowedValues)}`,
+    );
+  }
+
+  return resolveCaseInsensitiveOption({
+    value,
+    allowedValues,
+    defaultValue: allowedValues[0],
+    optionName,
+  });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,7 +85,7 @@ export function resolveCaseInsensitiveOption<
     (allowedValue) => allowedValue.trim().toUpperCase() === normalized,
   );
   if (matchedValue !== undefined) {
-    return normalized as V;
+    return matchedValue;
   }
 
   throw new Error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,10 @@ export function resolveCaseInsensitiveOption<
   }
 
   const normalized = value.trim().toUpperCase();
-  if ((allowedValues as readonly string[]).includes(normalized)) {
+  const matchedValue = allowedValues.find(
+    (allowedValue) => allowedValue.trim().toUpperCase() === normalized,
+  );
+  if (matchedValue !== undefined) {
     return normalized as V;
   }
 
@@ -103,10 +106,17 @@ export function resolveRequiredCaseInsensitiveOption<
     );
   }
 
-  return resolveCaseInsensitiveOption({
+  const resolvedValue = resolveCaseInsensitiveOption({
     allowedValues,
-    defaultValue: allowedValues[0],
+    defaultValue: null,
     key,
     options,
   });
+
+  if (resolvedValue === null) {
+    throw new Error(
+      `Missing required option '${String(key)}'. Expected one of ${getAllowedOptionList(allowedValues)}`,
+    );
+  }
+  return resolvedValue;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,56 +18,95 @@ function getAllowedOptionList<T extends string>(allowedValues: readonly T[]): st
   return allowedValues.join(', ');
 }
 
-export function resolveCaseInsensitiveOption<T extends string>({
-  value,
+// Type signature: If the given `defaultValue` is `null`, then the return type will be either
+// the resolved value if present, or `null` if the key was not provided.
+export function resolveCaseInsensitiveOption<
+  T extends object,
+  K extends keyof T,
+  V extends Extract<T[K], string>,
+>({
   allowedValues,
   defaultValue,
-  optionName,
+  key,
+  options,
 }: {
-  value: unknown;
-  allowedValues: readonly T[];
-  defaultValue: T;
-  optionName: string;
-}): T {
+  allowedValues: readonly V[];
+  defaultValue: null;
+  key: K;
+  options: T;
+}): V | null;
+// Type signature: If the given `defaultValue` is one of the options, then the return type will always be
+// non-null - either the resolved value, or the given `defaultValue` if the key was not provided.
+export function resolveCaseInsensitiveOption<
+  T extends object,
+  K extends keyof T,
+  V extends Extract<T[K], string>,
+>({
+  allowedValues,
+  defaultValue,
+  key,
+  options,
+}: {
+  allowedValues: readonly V[];
+  defaultValue: V;
+  key: K;
+  options: T;
+}): V;
+// Function implementation:
+export function resolveCaseInsensitiveOption<
+  T extends object,
+  K extends keyof T,
+  V extends Extract<T[K], string>,
+>({
+  allowedValues,
+  defaultValue,
+  key,
+  options,
+}: {
+  allowedValues: readonly V[];
+  defaultValue: V | null;
+  key: K;
+  options: T;
+}): V | null {
+  const value = options[key];
+
   if (value === undefined || value === null) {
     return defaultValue;
   }
 
   if (typeof value !== 'string') {
     throw new Error(
-      `Invalid ${optionName}: expected one of ${getAllowedOptionList(allowedValues)}, got ${String(value)}`,
+      `Invalid '${String(key)}': "${value}". Expected one of ${getAllowedOptionList(allowedValues)}`,
     );
   }
 
   const normalized = value.trim().toUpperCase();
   if ((allowedValues as readonly string[]).includes(normalized)) {
-    return normalized as T;
+    return normalized as V;
   }
 
   throw new Error(
-    `Invalid ${optionName}: "${value}". Expected one of ${getAllowedOptionList(allowedValues)}`,
+    `Invalid '${String(key)}': "${value}". Expected one of ${getAllowedOptionList(allowedValues)}`,
   );
 }
 
-export function resolveRequiredCaseInsensitiveOption<T extends string>({
-  value,
-  allowedValues,
-  optionName,
-}: {
-  value: unknown;
-  allowedValues: readonly T[];
-  optionName: string;
-}): T {
+export function resolveRequiredCaseInsensitiveOption<
+  T extends object,
+  K extends keyof T,
+  V extends Extract<T[K], string>,
+>({ allowedValues, key, options }: { allowedValues: readonly V[]; key: K; options: T }): V {
+  const value = options[key];
+
   if (value === undefined || value === null) {
     throw new Error(
-      `Missing required ${optionName}. Expected one of ${getAllowedOptionList(allowedValues)}`,
+      `Missing required option '${String(key)}'. Expected one of ${getAllowedOptionList(allowedValues)}`,
     );
   }
 
   return resolveCaseInsensitiveOption({
-    value,
     allowedValues,
     defaultValue: allowedValues[0],
-    optionName,
+    key,
+    options,
   });
 }


### PR DESCRIPTION
### Motivation
- Ensure all APIs that accept case-insensitive string options consistently normalize inputs and surface clear errors for invalid values.
- Replace ad-hoc `.toUpperCase()` handling with a shared resolver to centralize validation and improve error messages.
- Add unit tests that assert invalid option values throw predictable errors and verify the resolver behavior.

### Description
- Added `resolveCaseInsensitiveOption` and `resolveRequiredCaseInsensitiveOption` helpers to `src/utils.ts` to normalize, validate, and provide consistent error messages for case-insensitive options.
- Replaced manual `.toUpperCase()` conversions with the resolver in multiple modules, including `combinations.ts`, `deltaE.ts`, `gradients.ts`, `harmonies.ts`, `readability.ts`, and `utils.ts`, and introduced const arrays for allowed values to derive stronger union types.
- Updated type definitions to use literal arrays (e.g., `MIX_TYPES`, `GRADIENT_SPACES`, `APCA_THRESHOLD_PRESETS`, etc.) and adjusted function behavior to use the resolved/validated option values (e.g., `mixColors`, `blendColors`, `averageColors`, `createColorGradient`, `getDeltaE`, `getHarmonyColors`, `getAPCAReadabilityReport`, `getWCAGReadabilityReport`, `isColorDark`).
- Added numerous tests that assert invalid option values throw the expected `Invalid <optionName>` errors and added direct tests for `resolveCaseInsensitiveOption` in `src/color/__test__/utils.test.ts`.

### Testing
- Ran the unit test suite (`npm test`) which includes new validation tests in `__test__` files under `src/color/` such as `color.test.ts`, `combinations.test.ts`, `deltaE.test.ts`, `gradients.test.ts`, `harmonies.test.ts`, `readability.test.ts`, and `utils.test.ts`.
- All automated tests passed, and new tests verify that invalid string options throw errors and that valid but mixed-cased inputs are normalized as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61aeff9a8832a9775284ab6209105)