### PR TITLE
Add HSV/HSVA string conversion methods to Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,28 @@ new Color('#663399').toHSLAString(); // 'hsl(270 50% 40% / 1)'
 new Color('#1e90ff').toHSV(); // { h: 210, s: 88, v: 100 }
 ```
 
+#### `toHSVString(): string`
+
+- <ins>Returns</ins> an `"hsv(h s% v%)"` string.
+
+```ts
+new Color('#1e90ff').toHSVString(); // 'hsv(210 88.235% 100%)'
+```
+
 #### `toHSVA(): { h: number; s: number; v: number; a: number }`
 
 - <ins>Returns</ins> a [`ColorHSVA`](#types-color-hsva) object with hue 0–360, saturation/value 0–100, and alpha 0–1.
 
 ```ts
 new Color('#1e90ff').toHSVA(); // { h: 210, s: 88, v: 100, a: 1 }
+```
+
+#### `toHSVAString(): string`
+
+- <ins>Returns</ins> an `"hsva(h s% v% / a)"` string.
+
+```ts
+new Color('#1e90ff').toHSVAString(); // 'hsva(210 88.235% 100% / 1)'
 ```
 
 #### `toHWB(): { h: number; w: number; b: number }`

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ new Color('#1e90ff').toHSVA(); // { h: 210, s: 88, v: 100, a: 1 }
 - <ins>Returns</ins> an `"hsva(h s% v% / a)"` string.
 
 ```ts
-new Color('#1e90ff').toHSVAString(); // 'hsva(210 88.235% 100% / 1)'
+new Color('#1e90ff').toHSVAString(); // 'hsv(210 88.235% 100% / 1)'
 ```
 
 #### `toHWB(): { h: number; w: number; b: number }`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omni-color",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omni-color",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/chroma-js": "^3.1.2",

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -276,7 +276,7 @@ describe('Color.toXString methods', () => {
     expect(color.toHSLString()).toBe('hsl(0 100% 50%)');
     expect(color.toHSLAString()).toBe('hsl(0 100% 50% / 0.5)');
     expect(color.toHSVString()).toBe('hsv(0 100% 100%)');
-    expect(color.toHSVAString()).toBe('hsva(0 100% 100% / 0.5)');
+    expect(color.toHSVAString()).toBe('hsv(0 100% 100% / 0.5)');
     expect(color.toHWBString()).toBe('hwb(0 0% 0%)');
     expect(color.toHWBAString()).toBe('hwb(0 0% 0% / 0.5)');
     expect(color.toCMYKString()).toBe('device-cmyk(0% 100% 100% 0%)');

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -275,6 +275,8 @@ describe('Color.toXString methods', () => {
     expect(color.toRGBAString()).toBe('rgb(255 0 0 / 0.5)');
     expect(color.toHSLString()).toBe('hsl(0 100% 50%)');
     expect(color.toHSLAString()).toBe('hsl(0 100% 50% / 0.5)');
+    expect(color.toHSVString()).toBe('hsv(0 100% 100%)');
+    expect(color.toHSVAString()).toBe('hsva(0 100% 100% / 0.5)');
     expect(color.toHWBString()).toBe('hwb(0 0% 0%)');
     expect(color.toHWBAString()).toBe('hwb(0 0% 0% / 0.5)');
     expect(color.toCMYKString()).toBe('device-cmyk(0% 100% 100% 0%)');

--- a/src/color/__test__/formats.test.ts
+++ b/src/color/__test__/formats.test.ts
@@ -242,29 +242,29 @@ describe('hsvToString', () => {
 describe('hsvaToString', () => {
   it('generates hsva strings', () => {
     const transparentBlack = new Color('#00000000');
-    expect(hsvaToString(transparentBlack.toHSVA())).toBe('hsva(0 0% 0% / 0)');
-    expect(transparentBlack.toHSVAString()).toBe('hsva(0 0% 0% / 0)');
+    expect(hsvaToString(transparentBlack.toHSVA())).toBe('hsv(0 0% 0% / 0)');
+    expect(transparentBlack.toHSVAString()).toBe('hsv(0 0% 0% / 0)');
 
     const opaqueWhite = new Color('#ffffffff');
-    expect(hsvaToString(opaqueWhite.toHSVA())).toBe('hsva(0 0% 100% / 1)');
-    expect(opaqueWhite.toHSVAString()).toBe('hsva(0 0% 100% / 1)');
+    expect(hsvaToString(opaqueWhite.toHSVA())).toBe('hsv(0 0% 100% / 1)');
+    expect(opaqueWhite.toHSVAString()).toBe('hsv(0 0% 100% / 1)');
 
     const red = new Color('#ff000080');
-    expect(hsvaToString(red.toHSVA())).toBe('hsva(0 100% 100% / 0.502)');
-    expect(red.toHSVAString()).toBe('hsva(0 100% 100% / 0.502)');
+    expect(hsvaToString(red.toHSVA())).toBe('hsv(0 100% 100% / 0.502)');
+    expect(red.toHSVAString()).toBe('hsv(0 100% 100% / 0.502)');
 
     const green = new Color('#00ff007f');
-    expect(hsvaToString(green.toHSVA())).toBe('hsva(120 100% 100% / 0.498)');
-    expect(green.toHSVAString()).toBe('hsva(120 100% 100% / 0.498)');
+    expect(hsvaToString(green.toHSVA())).toBe('hsv(120 100% 100% / 0.498)');
+    expect(green.toHSVAString()).toBe('hsv(120 100% 100% / 0.498)');
 
     const custom = new Color('#abc123d6');
-    expect(hsvaToString(custom.toHSVA())).toBe('hsva(68.354 81.865% 75.686% / 0.839)');
-    expect(custom.toHSVAString()).toBe('hsva(68.354 81.865% 75.686% / 0.839)');
+    expect(hsvaToString(custom.toHSVA())).toBe('hsv(68.354 81.865% 75.686% / 0.839)');
+    expect(custom.toHSVAString()).toBe('hsv(68.354 81.865% 75.686% / 0.839)');
   });
 
   it('rounds hsva components to three decimals', () => {
     expect(hsvaToString({ h: 123.4567, s: 50.5555, v: 10.1234, a: 0.98765 })).toBe(
-      'hsva(123.457 50.556% 10.123% / 0.988)',
+      'hsv(123.457 50.556% 10.123% / 0.988)',
     );
   });
 });

--- a/src/color/__test__/formats.test.ts
+++ b/src/color/__test__/formats.test.ts
@@ -5,6 +5,8 @@ import {
   getColorFormatType,
   hslaToString,
   hslToString,
+  hsvaToString,
+  hsvToString,
   hwbToString,
   labToString,
   lchToString,
@@ -203,6 +205,66 @@ describe('hslaToString', () => {
   it('rounds hsla components to three decimals', () => {
     expect(hslaToString({ h: 123.4567, s: 50.5555, l: 10.1234, a: 0.98765 })).toBe(
       'hsl(123.457 50.556% 10.123% / 0.988)',
+    );
+  });
+});
+
+describe('hsvToString', () => {
+  it('generates hsv strings', () => {
+    const black = new Color('#000000');
+    expect(hsvToString(black.toHSV())).toBe('hsv(0 0% 0%)');
+    expect(black.toHSVString()).toBe('hsv(0 0% 0%)');
+
+    const white = new Color('#ffffff');
+    expect(hsvToString(white.toHSV())).toBe('hsv(0 0% 100%)');
+    expect(white.toHSVString()).toBe('hsv(0 0% 100%)');
+
+    const red = new Color('#ff0000');
+    expect(hsvToString(red.toHSV())).toBe('hsv(0 100% 100%)');
+    expect(red.toHSVString()).toBe('hsv(0 100% 100%)');
+
+    const green = new Color('#00ff00');
+    expect(hsvToString(green.toHSV())).toBe('hsv(120 100% 100%)');
+    expect(green.toHSVString()).toBe('hsv(120 100% 100%)');
+
+    const custom = new Color('#abc123');
+    expect(hsvToString(custom.toHSV())).toBe('hsv(68.354 81.865% 75.686%)');
+    expect(custom.toHSVString()).toBe('hsv(68.354 81.865% 75.686%)');
+  });
+
+  it('rounds hsv components to three decimals', () => {
+    expect(hsvToString({ h: 123.4567, s: 50.5555, v: 10.1234 })).toBe(
+      'hsv(123.457 50.556% 10.123%)',
+    );
+  });
+});
+
+describe('hsvaToString', () => {
+  it('generates hsva strings', () => {
+    const transparentBlack = new Color('#00000000');
+    expect(hsvaToString(transparentBlack.toHSVA())).toBe('hsva(0 0% 0% / 0)');
+    expect(transparentBlack.toHSVAString()).toBe('hsva(0 0% 0% / 0)');
+
+    const opaqueWhite = new Color('#ffffffff');
+    expect(hsvaToString(opaqueWhite.toHSVA())).toBe('hsva(0 0% 100% / 1)');
+    expect(opaqueWhite.toHSVAString()).toBe('hsva(0 0% 100% / 1)');
+
+    const red = new Color('#ff000080');
+    expect(hsvaToString(red.toHSVA())).toBe('hsva(0 100% 100% / 0.502)');
+    expect(red.toHSVAString()).toBe('hsva(0 100% 100% / 0.502)');
+
+    const green = new Color('#00ff007f');
+    expect(hsvaToString(green.toHSVA())).toBe('hsva(120 100% 100% / 0.498)');
+    expect(green.toHSVAString()).toBe('hsva(120 100% 100% / 0.498)');
+
+    const custom = new Color('#abc123d6');
+    expect(hsvaToString(custom.toHSVA())).toBe('hsva(68.354 81.865% 75.686% / 0.839)');
+    expect(custom.toHSVAString()).toBe('hsva(68.354 81.865% 75.686% / 0.839)');
+  });
+
+  it('rounds hsva components to three decimals', () => {
+    expect(hsvaToString({ h: 123.4567, s: 50.5555, v: 10.1234, a: 0.98765 })).toBe(
+      'hsva(123.457 50.556% 10.123% / 0.988)',
     );
   });
 });

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -49,6 +49,8 @@ import {
   colorToString,
   hslaToString,
   hslToString,
+  hsvaToString,
+  hsvToString,
   hwbaToString,
   hwbToString,
   labToString,
@@ -349,10 +351,24 @@ export class Color {
   }
 
   /**
+   * Get the color as an `hsv(h s% v%)` string.
+   */
+  toHSVString(): string {
+    return hsvToString(this.toHSV());
+  }
+
+  /**
    * Get the color as a {@link ColorHSVA} `{ h, s, v, a }` object.
    */
   toHSVA(): ColorHSVA {
     return toHSVA(this.#color);
+  }
+
+  /**
+   * Get the color as an `hsva(h s% v% / a)` string.
+   */
+  toHSVAString(): string {
+    return hsvaToString(this.toHSVA());
   }
 
   /**

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -365,7 +365,7 @@ export class Color {
   }
 
   /**
-   * Get the color as an `hsva(h s% v% / a)` string.
+   * Get the color as an `hsv(h s% v% / a)` string.
    */
   toHSVAString(): string {
     return hsvaToString(this.toHSVA());

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -284,7 +284,7 @@ export function hsvToString({ h, s, v }: ColorHSV): string {
 }
 
 export function hsvaToString({ h, s, v, a }: ColorHSVA): string {
-  return `hsva(${getDecimalString(h)} ${getDecimalString(s)}% ${getDecimalString(
+  return `hsv(${getDecimalString(h)} ${getDecimalString(s)}% ${getDecimalString(
     v,
   )}% / ${getDecimalString(a)})`;
 }

--- a/src/color/formats.ts
+++ b/src/color/formats.ts
@@ -279,6 +279,16 @@ export function hslaToString({ h, s, l, a }: ColorHSLA): string {
   )}% / ${getDecimalString(a)})`;
 }
 
+export function hsvToString({ h, s, v }: ColorHSV): string {
+  return `hsv(${getDecimalString(h)} ${getDecimalString(s)}% ${getDecimalString(v)}%)`;
+}
+
+export function hsvaToString({ h, s, v, a }: ColorHSVA): string {
+  return `hsva(${getDecimalString(h)} ${getDecimalString(s)}% ${getDecimalString(
+    v,
+  )}% / ${getDecimalString(a)})`;
+}
+
 export function hwbToString(color: ColorHWB): string {
   return `hwb(${getDecimalString(color.h)} ${getDecimalString(color.w)}% ${getDecimalString(
     color.b,


### PR DESCRIPTION
### Motivation
- Provide string output helpers for HSV/HSVA to match existing `toHSLString()`/`toHSLAString()`/`toHWBString()` APIs and keep the `Color` surface consistent across color spaces. 
- Reuse the same rounding/formatting conventions used by other `to*String()` helpers so HSV string output is predictable and consistent.

### Description
- Add `hsvToString()` and `hsvaToString()` formatter helpers in `src/color/formats.ts` that use the same `getDecimalString` rounding as other formatters. 
- Add `Color#toHSVString()` directly below `toHSV()` and `Color#toHSVAString()` directly below `toHSVA()` in `src/color/color.ts`, delegating to the new formatter helpers. 
- Import the new format helpers where needed and keep placement/ordering consistent with neighboring methods. 
- Extend unit tests in `src/color/__test__/formats.test.ts` and `src/color/__test__/color.test.ts` to validate HSV/HSVA string output and rounding behavior, and update the README examples to document `toHSVString()` and `toHSVAString()`.

### Testing
- Ran `npm run lint` and it passed. 
- Ran `npm run build && npm run typecheck` and type checking passed after building the `dist` artifacts. 
- Ran `npm run test` and all test suites passed (`20` suites, `1061` tests). 
- Ran `npm run format:check` and Prettier checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb71003828832a9843a22f8752cb4c)