### PR TITLE
Fix CI typecheck by limiting root TS scope to library sources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "removeComments": false,
     "jsx": "react-jsx"
   },
-  "include": ["./src", "./demo/src"]
+  "include": ["./src"]
 }


### PR DESCRIPTION
## Summary
- remove `./demo/src` from the root `tsconfig.json` `include` list
- keep root `npm run typecheck` focused on library code in `./src`
- prevent CI typecheck from depending on generated `dist/` artifacts referenced by demo-only imports

## Why
Recent package script changes removed install-time builds, so `dist/` is no longer guaranteed to exist before `tsc` runs. Because root TS config included demo files that import from `../../../dist`, CI failed with `TS2307` module resolution errors.

By excluding demo sources from the root project, typecheck no longer requires prebuilt artifacts and remains stable in clean CI environments.

## Validation
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run test`
- pre-commit hook also re-ran format/lint/typecheck/test successfully during commit

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74f95138832aa20e48554fede87b)