### PR TITLE
Add Color.isPaletteSuitable with shared palette suitability helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ new Color('#ffffff').isOffWhite(); // true
 new Color('#cccccc').isOffWhite(); // false
 ```
 
+#### `isPaletteSuitable(): boolean`
+
+- <ins>Returns</ins> `true` if the color matches the same "palette suitable" constraints used by `Color.random({ paletteSuitable: true })`.
+- A palette-suitable color must have:
+  - saturation **>= 40%**
+  - lightness **between 25% and 75%** (inclusive)
+
+```ts
+new Color('#ff0000').isPaletteSuitable(); // true
+new Color('#f2f2f2').isPaletteSuitable(); // false
+```
+
 #### `getTemperature(): { temperature: number; label: ColorTemperatureLabel }`
 
 - <ins>Returns</ins> the estimated correlated color temperature in Kelvin plus a [`ColorTemperatureLabel`](#types-color-temperature-label) describing the closest standard lighting condition.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ new Color('#cccccc').isOffWhite(); // false
 
 - <ins>Returns</ins> `true` if the color matches the same "palette suitable" constraints used by `Color.random({ paletteSuitable: true })`.
 - A palette-suitable color must have:
-  - saturation **>= 40%**
-  - lightness **between 25% and 75%** (inclusive)
+  - saturation >= 40%
+  - lightness between 25% and 75% (inclusive)
 
 ```ts
 new Color('#ff0000').isPaletteSuitable(); // true

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -819,6 +819,16 @@ describe('Color.isOffWhite sanity check', () => {
   });
 });
 
+describe('Color.isPaletteSuitable sanity check', () => {
+  it('matches the paletteSuitable threshold criteria', () => {
+    expect(new Color({ h: 0, s: 40, l: 25 }).isPaletteSuitable()).toBe(true);
+    expect(new Color({ h: 240, s: 70, l: 75 }).isPaletteSuitable()).toBe(true);
+    expect(new Color({ h: 0, s: 39, l: 25 }).isPaletteSuitable()).toBe(false);
+    expect(new Color({ h: 0, s: 40, l: 24 }).isPaletteSuitable()).toBe(false);
+    expect(new Color({ h: 0, s: 40, l: 76 }).isPaletteSuitable()).toBe(false);
+  });
+});
+
 describe('Color.getWCAGContrastRatio', () => {
   it('calculates the WCAG contrast ratio between colors', () => {
     const c1 = new Color('#444444');

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -2,6 +2,7 @@ import {
   type ColorPalette,
   generateColorPaletteFromBaseColor,
   type GenerateColorPaletteOptions,
+  isColorPaletteSuitable,
 } from '../palette/palette';
 import { type CaseInsensitive, clampValue } from '../utils';
 import type { ColorStringOptions } from './colorSpaces';
@@ -921,6 +922,22 @@ export class Color {
    */
   isOffWhite(): boolean {
     return isColorOffWhite(this);
+  }
+
+  /**
+   * Determine whether this color is suitable as a palette anchor.
+   *
+   * Uses the same thresholds as `Color.random({ paletteSuitable: true })`:
+   * saturation must be at least 40%, and lightness must be between 25% and 75% (inclusive).
+   *
+   * @example
+   * ```ts
+   * new Color('#ff0000').isPaletteSuitable(); // true
+   * new Color('#f2f2f2').isPaletteSuitable(); // false
+   * ```
+   */
+  isPaletteSuitable(): boolean {
+    return isColorPaletteSuitable(this);
   }
 
   /**

--- a/src/color/random.ts
+++ b/src/color/random.ts
@@ -1,3 +1,8 @@
+import {
+  SUITABLE_PALETTE_MAX_LIGHTNESS,
+  SUITABLE_PALETTE_MIN_LIGHTNESS,
+  SUITABLE_PALETTE_MIN_SATURATION,
+} from '../palette/palette';
 import type { CaseInsensitive } from '../utils';
 import { capitalizeString, clampValue } from '../utils';
 import { toRGBA } from './conversions';
@@ -12,10 +17,6 @@ import {
   WHITE_MAX_LIGHTNESS_THRESHOLD,
   WHITE_MAX_LIGHTNESS_THRESHOLD_LOW_SATURATION,
 } from './names';
-
-const SUITABLE_PALETTE_MIN_SATURATION = 40;
-const SUITABLE_PALETTE_MIN_LIGHTNESS = 25;
-const SUITABLE_PALETTE_MAX_LIGHTNESS = 75;
 
 export interface RandomColorOptions {
   /**

--- a/src/palette/__test__/palette.test.ts
+++ b/src/palette/__test__/palette.test.ts
@@ -1,5 +1,55 @@
 import { Color } from '../../color/color';
-import { generateColorPaletteFromBaseColor } from '../palette';
+import {
+  generateColorPaletteFromBaseColor,
+  isColorPaletteSuitable,
+  SUITABLE_PALETTE_MAX_LIGHTNESS,
+  SUITABLE_PALETTE_MIN_LIGHTNESS,
+  SUITABLE_PALETTE_MIN_SATURATION,
+} from '../palette';
+
+describe('isColorPaletteSuitable()', () => {
+  it('returns true when saturation and lightness are within palette-suitable ranges', () => {
+    expect(
+      isColorPaletteSuitable(new Color({ h: 0, s: SUITABLE_PALETTE_MIN_SATURATION, l: 50 })),
+    ).toBe(true);
+    expect(
+      isColorPaletteSuitable(new Color({ h: 220, s: 85, l: SUITABLE_PALETTE_MIN_LIGHTNESS })),
+    ).toBe(true);
+    expect(
+      isColorPaletteSuitable(new Color({ h: 120, s: 60, l: SUITABLE_PALETTE_MAX_LIGHTNESS })),
+    ).toBe(true);
+  });
+
+  it('returns false when saturation or lightness are outside palette-suitable ranges', () => {
+    expect(
+      isColorPaletteSuitable(
+        new Color({
+          h: 0,
+          s: SUITABLE_PALETTE_MIN_SATURATION - 1,
+          l: SUITABLE_PALETTE_MIN_LIGHTNESS,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isColorPaletteSuitable(
+        new Color({
+          h: 0,
+          s: SUITABLE_PALETTE_MIN_SATURATION,
+          l: SUITABLE_PALETTE_MIN_LIGHTNESS - 1,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isColorPaletteSuitable(
+        new Color({
+          h: 0,
+          s: SUITABLE_PALETTE_MIN_SATURATION,
+          l: SUITABLE_PALETTE_MAX_LIGHTNESS + 1,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe('generateColorPaletteFromBaseColor()', () => {
   it('harmonizes neutrals with the base color', () => {

--- a/src/palette/palette.ts
+++ b/src/palette/palette.ts
@@ -6,22 +6,11 @@ import { type CaseInsensitive, clampValue } from '../utils';
 
 type SemanticColor = 'info' | 'positive' | 'negative' | 'warning' | 'special';
 
-/**
- * Minimum HSL saturation (%) for a color to be considered suitable as a palette anchor.
- * This matches the `paletteSuitable` option behavior in `Color.random()`.
- */
+// Minimum HSL saturation (%) for a color to be considered suitable as a palette anchor:
 export const SUITABLE_PALETTE_MIN_SATURATION = 40;
-
-/**
- * Minimum HSL lightness (%) for a color to be considered suitable as a palette anchor.
- * This matches the `paletteSuitable` option behavior in `Color.random()`.
- */
+// Minimum HSL lightness (%) for a color to be considered suitable as a palette anchor:
 export const SUITABLE_PALETTE_MIN_LIGHTNESS = 25;
-
-/**
- * Maximum HSL lightness (%) for a color to be considered suitable as a palette anchor.
- * This matches the `paletteSuitable` option behavior in `Color.random()`.
- */
+// Maximum HSL lightness (%) for a color to be considered suitable as a palette anchor:
 export const SUITABLE_PALETTE_MAX_LIGHTNESS = 75;
 
 export interface ColorPalette {

--- a/src/palette/palette.ts
+++ b/src/palette/palette.ts
@@ -6,6 +6,24 @@ import { type CaseInsensitive, clampValue } from '../utils';
 
 type SemanticColor = 'info' | 'positive' | 'negative' | 'warning' | 'special';
 
+/**
+ * Minimum HSL saturation (%) for a color to be considered suitable as a palette anchor.
+ * This matches the `paletteSuitable` option behavior in `Color.random()`.
+ */
+export const SUITABLE_PALETTE_MIN_SATURATION = 40;
+
+/**
+ * Minimum HSL lightness (%) for a color to be considered suitable as a palette anchor.
+ * This matches the `paletteSuitable` option behavior in `Color.random()`.
+ */
+export const SUITABLE_PALETTE_MIN_LIGHTNESS = 25;
+
+/**
+ * Maximum HSL lightness (%) for a color to be considered suitable as a palette anchor.
+ * This matches the `paletteSuitable` option behavior in `Color.random()`.
+ */
+export const SUITABLE_PALETTE_MAX_LIGHTNESS = 75;
+
 export interface ColorPalette {
   // Main colors:
   primary: ColorSwatch;
@@ -64,6 +82,20 @@ const DEFAULT_NEUTRAL_COLOR_HARMONIZATION_OPTIONS: Required<NeutralColorHarmoniz
   tintChromaFactor: 0.1,
   maxTintChroma: 0.04,
 };
+
+/**
+ * Determine if a color meets the same "palette suitable" constraints used by `Color.random({ paletteSuitable: true })`:
+ * - saturation >= `SUITABLE_PALETTE_MIN_SATURATION`
+ * - lightness between `SUITABLE_PALETTE_MIN_LIGHTNESS` and `SUITABLE_PALETTE_MAX_LIGHTNESS` (inclusive)
+ */
+export function isColorPaletteSuitable(color: Color): boolean {
+  const { s, l } = color.toHSL();
+  return (
+    s >= SUITABLE_PALETTE_MIN_SATURATION &&
+    l >= SUITABLE_PALETTE_MIN_LIGHTNESS &&
+    l <= SUITABLE_PALETTE_MAX_LIGHTNESS
+  );
+}
 
 export interface GenerateColorPaletteOptions {
   neutralHarmonization?: NeutralColorHarmonizationOptions;


### PR DESCRIPTION
### Motivation
- Provide a single authoritative definition of the "palette suitable" thresholds so the same logic can be used across the codebase (random generation and Color API). 

### Description
- Exported shared constants `SUITABLE_PALETTE_MIN_SATURATION`, `SUITABLE_PALETTE_MIN_LIGHTNESS`, and `SUITABLE_PALETTE_MAX_LIGHTNESS` and added `isColorPaletteSuitable(color: Color)` in `src/palette/palette.ts` to centralize the criteria (saturation >= 40, lightness between 25 and 75 inclusive). 
- Updated `getRandomColorRGBA()` in `src/color/random.ts` to import and use the shared constants instead of duplicating them. 
- Added `Color.isPaletteSuitable(): boolean` in `src/color/color.ts` that delegates to `isColorPaletteSuitable()` and included JSDoc describing the behaviour. 
- Documented `isPaletteSuitable()` in `README.md`. 
- Added tests: unit tests for `isColorPaletteSuitable()` in `src/palette/__test__/palette.test.ts` and a sanity test for `Color.isPaletteSuitable()` in `src/color/__test__/color.test.ts` and applied minor formatting fixes.

### Testing
- Ran `npm run build` and the build succeeded. 
- Ran `npm run lint` and ESLint passed (auto-fix applied where needed). 
- Ran `npm run typecheck` (`tsc`) and it passed. 
- Ran `npm run test` (Jest) and all test suites passed (20/20 suites, 1060 tests). 
- Ran `npm run format:check` (Prettier) and formatting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb72f9e86c832aa9ab3970c52fae96)