### PR TITLE
Add import/no-cycle rule to TypeScript ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,13 @@ export default [
           ignoreExports: ['**/*.test.ts', '**/__test__/**', 'src/index.ts'],
         },
       ],
+      'import/no-cycle': [
+        'error',
+        {
+          maxDepth: Infinity,
+          ignoreExternal: true,
+        },
+      ],
       'simple-import-sort/imports': 'warn',
       'simple-import-sort/exports': 'warn',
       'prefer-const': 'warn',


### PR DESCRIPTION
### Motivation
- Enforce detection of dependency cycles in TypeScript source so circular imports are caught by linting rather than slipping through.

### Description
- Add `import/no-cycle` with severity `error` and options `{ maxDepth: Infinity, ignoreExternal: true }` to the main TypeScript `rules` block in `eslint.config.js` and preserve the existing `import/resolver` configuration that points to `./tsconfig.eslint.json` for correct module resolution.

### Testing
- Ran `npm run lint` (now fails because the new rule surfaces existing dependency cycles), `npm run typecheck` (passed), `npm run test` (all test suites passed), and `npm run format:check` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e703234832abeb43528f0e95c75)