### PR TITLE
Introduce injectable Color factory and refactor color utilities to use it (plus srgb module)

### DIFF
--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import { CSS_COLOR_NAME_TO_HEX_MAP } from '../color.consts';
 import type {
   ColorCMYK,
@@ -17,8 +17,6 @@ import type {
 import { getRandomColorRGBA } from '../random';
 import type { ReadabilityOptions } from '../readability';
 import { getColorFromTemperatureLabel } from '../temperature';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 jest.mock('../random', () => {
   const actual = jest.requireActual('../random');
@@ -188,17 +186,21 @@ describe('Color constructor and conversion tests', () => {
   it('accepts color temperature label strings', () => {
     let color = new Color('fluorescent');
     expect(color.toHex()).toBe(
-      getColorFromTemperatureLabel('Fluorescent lamp', createColor).toHex(),
+      getColorFromTemperatureLabel('Fluorescent lamp', createColorInstance).toHex(),
     );
 
     color = new Color('Daylight');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Daylight', createColor).toHex());
+    expect(color.toHex()).toBe(
+      getColorFromTemperatureLabel('Daylight', createColorInstance).toHex(),
+    );
 
     color = new Color('  shade ');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Shade', createColor).toHex());
+    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Shade', createColorInstance).toHex());
 
     color = new Color('blue sky');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Blue sky', createColor).toHex());
+    expect(color.toHex()).toBe(
+      getColorFromTemperatureLabel('Blue sky', createColorInstance).toHex(),
+    );
   });
 });
 

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -18,6 +18,8 @@ import { getRandomColorRGBA } from '../random';
 import type { ReadabilityOptions } from '../readability';
 import { getColorFromTemperatureLabel } from '../temperature';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 jest.mock('../random', () => {
   const actual = jest.requireActual('../random');
   return {
@@ -185,16 +187,18 @@ describe('Color constructor and conversion tests', () => {
 
   it('accepts color temperature label strings', () => {
     let color = new Color('fluorescent');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Fluorescent lamp').toHex());
+    expect(color.toHex()).toBe(
+      getColorFromTemperatureLabel('Fluorescent lamp', createColor).toHex(),
+    );
 
     color = new Color('Daylight');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Daylight').toHex());
+    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Daylight', createColor).toHex());
 
     color = new Color('  shade ');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Shade').toHex());
+    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Shade', createColor).toHex());
 
     color = new Color('blue sky');
-    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Blue sky').toHex());
+    expect(color.toHex()).toBe(getColorFromTemperatureLabel('Blue sky', createColor).toHex());
   });
 });
 

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -1,14 +1,20 @@
 import { Color } from '../color';
 import { averageColors, blendColors, mixColors } from '../combinations';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('mixColors', () => {
   it('mixes colors additively in RGB space', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = mixColors([red, green], {
-      type: 'ADDITIVE',
-      space: 'RGB',
-    });
+    const result = mixColors(
+      [red, green],
+      {
+        type: 'ADDITIVE',
+        space: 'RGB',
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#ffff00');
   });
 
@@ -16,17 +22,21 @@ describe('mixColors', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, green, blue], {
-      type: 'ADDITIVE',
-      space: 'RGB',
-    });
+    const result = mixColors(
+      [red, green, blue],
+      {
+        type: 'ADDITIVE',
+        space: 'RGB',
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#ffffff');
   });
 
   it('mixes colors subtractively in CMYK space', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' });
+    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColor);
     expect(result.toHex()).toBe('#00ff00');
   });
 
@@ -34,19 +44,27 @@ describe('mixColors', () => {
     const cyan = new Color('#00ffff');
     const magenta = new Color('#ff00ff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, magenta, yellow], {
-      type: 'SUBTRACTIVE',
-    });
+    const result = mixColors(
+      [cyan, magenta, yellow],
+      {
+        type: 'SUBTRACTIVE',
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#000000');
   });
 
   it('mixes colors in HSL space with weighted interpolation', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], {
-      space: 'HSL',
-      weights: [1, 3],
-    });
+    const result = mixColors(
+      [red, blue],
+      {
+        space: 'HSL',
+        weights: [1, 3],
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#5100ff');
     const { h, s, l } = result.toHSL();
     expect(h).toBeCloseTo(259, 0);
@@ -57,10 +75,10 @@ describe('mixColors', () => {
   it('accepts mixed case mix space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const mix1 = mixColors([c1, c2], { space: 'RGB' });
-    const mix2 = mixColors([c1, c2], { space: 'rgb' });
+    const mix1 = mixColors([c1, c2], { space: 'RGB' }, createColor);
+    const mix2 = mixColors([c1, c2], { space: 'rgb' }, createColor);
     // @ts-expect-error - testing mixed casing not covered by type but valid runtime
-    const mix3 = mixColors([c1, c2], { space: 'rGb' });
+    const mix3 = mixColors([c1, c2], { space: 'rGb' }, createColor);
 
     expect(mix1.toHex()).toBe(mix2.toHex());
     expect(mix1.toHex()).toBe(mix3.toHex());
@@ -69,8 +87,8 @@ describe('mixColors', () => {
   it('accepts mixed case mix type', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const sub1 = mixColors([c1, c2], { type: 'SUBTRACTIVE' });
-    const sub2 = mixColors([c1, c2], { type: 'subtractive' });
+    const sub1 = mixColors([c1, c2], { type: 'SUBTRACTIVE' }, createColor);
+    const sub2 = mixColors([c1, c2], { type: 'subtractive' }, createColor);
 
     expect(sub1.toHex()).toBe(sub2.toHex());
   });
@@ -78,7 +96,7 @@ describe('mixColors', () => {
   it('defaults to additive Linear RGB mixing', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = mixColors([red, green]);
+    const result = mixColors([red, green], createColor);
     expect(result.toHex()).toBe('#bcbc00');
   });
 
@@ -93,7 +111,11 @@ describe('mixColors', () => {
     // Linear(0.6) -> sRGB(0.8) -> 204.
     // Wait, pure additive of non-clipping colors should be similar?
     // Let's test averaging behavior via weights summing to 1.
-    const result = mixColors([red, green], { space: 'LINEAR_RGB', weights: [0.5, 0.5] });
+    const result = mixColors(
+      [red, green],
+      { space: 'LINEAR_RGB', weights: [0.5, 0.5] },
+      createColor,
+    );
     // sRGB Avg: 102, 102, 0 -> #666600
     // Linear Avg: 0.6*0.5 + 0 = 0.3. sRGB(0.3) -> ~150 (#96)
     expect(result.toHex()).not.toBe('#666600');
@@ -105,20 +127,22 @@ describe('mixColors', () => {
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => mixColors([red])).toThrow('at least two colors are required for mixing');
+    expect(() => mixColors([red], createColor)).toThrow(
+      'at least two colors are required for mixing',
+    );
   });
 
   it('defaults weights to 1 when provided weights sum to 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [1, -1] });
+    const result = mixColors([red, blue], { weights: [1, -1] }, createColor);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('mixes colors with alpha channel in RGB space', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 1 });
-    const result = mixColors([semiRed, blue], { type: 'ADDITIVE', space: 'RGB' });
+    const result = mixColors([semiRed, blue], { type: 'ADDITIVE', space: 'RGB' }, createColor);
     expect(result.toHex()).toBe('#ff00ff');
     expect(result.toRGBA().a).toBe(0.75);
   });
@@ -126,21 +150,21 @@ describe('mixColors', () => {
   it('mixes colors in LCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { space: 'LCH' });
+    const result = mixColors([black, white], { space: 'LCH' }, createColor);
     expect(result.toHex()).toBe('#777777');
   });
 
   it('mixes colors in OKLCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { space: 'OKLCH' });
+    const result = mixColors([black, white], { space: 'OKLCH' }, createColor);
     expect(result.toHex()).toBe('#636363');
   });
 
   it('mixes colors across the red hue boundary using linear addition', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'HSL' });
+    const result = mixColors([h1, h2], { space: 'HSL' }, createColor);
     expect(result.toHex()).toBe('#ff0000');
   });
 
@@ -157,10 +181,14 @@ describe('mixColors', () => {
     // Result sRGB:
     // R: 0.42 -> ~0.68 -> ~174
     // B: 0.21 -> ~0.50 -> ~128
-    const result = mixColors([darkRed, darkBlue], {
-      space: 'HSL',
-      weights: [2, 1],
-    });
+    const result = mixColors(
+      [darkRed, darkBlue],
+      {
+        space: 'HSL',
+        weights: [2, 1],
+      },
+      createColor,
+    );
 
     const { r, b } = result.toRGBA();
     expect(result.toHex()).toBe('#800040');
@@ -172,7 +200,7 @@ describe('mixColors', () => {
   it('handles hue wrap-around in LCH space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'LCH' });
+    const result = mixColors([h1, h2], { space: 'LCH' }, createColor);
     const hue = result.toLCH().h;
     const distanceFromZero = Math.min(hue, 360 - hue);
     expect(distanceFromZero).toBeLessThan(45);
@@ -182,7 +210,7 @@ describe('mixColors', () => {
   it('handles hue wrap-around in OKLCH space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'OKLCH' });
+    const result = mixColors([h1, h2], { space: 'OKLCH' }, createColor);
     const hue = result.toOKLCH().h;
     const distanceFromZero = Math.min(hue, 360 - hue);
     expect(distanceFromZero).toBeLessThan(45);
@@ -192,20 +220,20 @@ describe('mixColors', () => {
   it('defaults to equal weights when weights length mismatches', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [2] });
+    const result = mixColors([red, blue], { weights: [2] }, createColor);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('ignores colors with zero weight', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [0, 1] });
+    const result = mixColors([red, blue], { weights: [0, 1] }, createColor);
     expect(result.toHex()).toBe('#0000ff');
   });
 
   it('accumulates light when mixing identical colors in HSL space', () => {
     const darkRed = new Color('#800000');
-    const result = mixColors([darkRed, darkRed], { space: 'HSL' });
+    const result = mixColors([darkRed, darkRed], { space: 'HSL' }, createColor);
     expect(result.toHex()).toBe('#800000');
   });
 
@@ -213,9 +241,9 @@ describe('mixColors', () => {
     const red = new Color('#ff0000');
     const cyan = new Color('#00ffff');
 
-    const hslMix = mixColors([red, cyan], { space: 'HSL' });
-    const lchMix = mixColors([red, cyan], { space: 'LCH' });
-    const oklchMix = mixColors([red, cyan], { space: 'OKLCH' });
+    const hslMix = mixColors([red, cyan], { space: 'HSL' }, createColor);
+    const lchMix = mixColors([red, cyan], { space: 'LCH' }, createColor);
+    const oklchMix = mixColors([red, cyan], { space: 'OKLCH' }, createColor);
 
     expect(hslMix.toHex()).toBe('#80ff00');
     expect(lchMix.toHex()).toBe('#dda581');
@@ -225,7 +253,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in RGB space using normalized absorption', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE', space: 'RGB' });
+    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE', space: 'RGB' }, createColor);
 
     expect(result.toHex()).toBe('#00ff00');
     expect(result.toRGBA().a).toBe(1);
@@ -234,16 +262,24 @@ describe('mixColors', () => {
   it('mixes colors subtractively in Linear RGB space and respects weight ratios', () => {
     const green = new Color('#00ff00');
     const blue = new Color('#0000ff');
-    const mixA = mixColors([green, blue], {
-      type: 'SUBTRACTIVE',
-      space: 'LINEAR_RGB',
-      weights: [2, 1],
-    });
-    const mixB = mixColors([green, blue], {
-      type: 'SUBTRACTIVE',
-      space: 'LINEAR_RGB',
-      weights: [200, 100],
-    });
+    const mixA = mixColors(
+      [green, blue],
+      {
+        type: 'SUBTRACTIVE',
+        space: 'LINEAR_RGB',
+        weights: [2, 1],
+      },
+      createColor,
+    );
+    const mixB = mixColors(
+      [green, blue],
+      {
+        type: 'SUBTRACTIVE',
+        space: 'LINEAR_RGB',
+        weights: [200, 100],
+      },
+      createColor,
+    );
 
     expect(mixA.toHex()).toBe(mixB.toHex());
   });
@@ -251,7 +287,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in HSL space while handling hue wrap-around', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { type: 'SUBTRACTIVE', space: 'HSL' });
+    const result = mixColors([h1, h2], { type: 'SUBTRACTIVE', space: 'HSL' }, createColor);
 
     expect(result.toHex()).toBe('#ff0000');
     expect(result.toHSL().h).toBe(0);
@@ -260,7 +296,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in LCH space with chroma-driven hue', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { type: 'SUBTRACTIVE', space: 'LCH' });
+    const result = mixColors([red, blue], { type: 'SUBTRACTIVE', space: 'LCH' }, createColor);
 
     const { h, c } = result.toLCH();
     expect(c).toBeGreaterThan(0);
@@ -276,7 +312,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in OKLCH space with clamped lightness', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { type: 'SUBTRACTIVE', space: 'OKLCH' });
+    const result = mixColors([black, white], { type: 'SUBTRACTIVE', space: 'OKLCH' }, createColor);
 
     expect(result.toHex()).toBe('#000000');
     expect(result.toRGBA().a).toBe(1);
@@ -285,7 +321,7 @@ describe('mixColors', () => {
   it('handles alpha when mixing subtractively', () => {
     const yellow = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
     const magenta = new Color({ r: 255, g: 0, b: 255, a: 1 });
-    const result = mixColors([yellow, magenta], { type: 'SUBTRACTIVE', space: 'RGB' });
+    const result = mixColors([yellow, magenta], { type: 'SUBTRACTIVE', space: 'RGB' }, createColor);
 
     expect(result.toHex()).toBe('#ff0000');
     expect(result.toRGBA().a).toBe(0.75);
@@ -294,7 +330,7 @@ describe('mixColors', () => {
   it('defaults to Linear RGB subtractive mixing when type is subtractive but space omitted', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' });
+    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColor);
 
     expect(result.toHex()).toBe('#00ff00');
   });
@@ -304,14 +340,14 @@ describe('averageColors', () => {
   it('averages colors in RGB space', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { space: 'RGB' });
+    const result = averageColors([red, blue], { space: 'RGB' }, createColor);
     expect(result.toHex()).toBe('#800080');
   });
 
   it('averages colors in Linear RGB space (brighter purple)', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { space: 'LINEAR_RGB' });
+    const result = averageColors([red, blue], { space: 'LINEAR_RGB' }, createColor);
     // RGB avg: 128, 0, 128 -> #800080
     // Linear avg: #bc00bc
     expect(result.toHex()).toBe('#bc00bc');
@@ -321,37 +357,43 @@ describe('averageColors', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, green, blue], { space: 'RGB' });
+    const result = averageColors([red, green, blue], { space: 'RGB' }, createColor);
     expect(result.toHex()).toBe('#555555');
   });
 
   it('averages colors in HSL space with weights', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = averageColors([red, green], {
-      space: 'HSL',
-      weights: [1, 2],
-    });
+    const result = averageColors(
+      [red, green],
+      {
+        space: 'HSL',
+        weights: [1, 2],
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#80c936');
   });
 
   it('defaults to Linear RGB averaging', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = averageColors([red, green]);
+    const result = averageColors([red, green], createColor);
     // Expect brighter yellow than #808000
     expect(result.toHex()).toBe('#bcbc00');
   });
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => averageColors([red])).toThrow('at least two colors are required for averaging');
+    expect(() => averageColors([red], createColor)).toThrow(
+      'at least two colors are required for averaging',
+    );
   });
 
   it('averages colors with alpha channel', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 1 });
-    const result = averageColors([semiRed, blue], { space: 'RGB' });
+    const result = averageColors([semiRed, blue], { space: 'RGB' }, createColor);
     expect(result.toHex()).toBe('#800080');
     expect(result.toRGBA().a).toBe(0.75);
   });
@@ -359,21 +401,21 @@ describe('averageColors', () => {
   it('averages black and white in LCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'LCH' });
+    const result = averageColors([black, white], { space: 'LCH' }, createColor);
     expect(result.toHex()).toBe('#777777');
   });
 
   it('averages black and white in OKLCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'OKLCH' });
+    const result = averageColors([black, white], { space: 'OKLCH' }, createColor);
     expect(result.toHex()).toBe('#636363');
   });
 
   it('averages hues correctly across the 360° boundary', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = averageColors([h1, h2], { space: 'HSL' });
+    const result = averageColors([h1, h2], { space: 'HSL' }, createColor);
     expect(result.toHex()).toBe('#fc0303');
     expect(result.toHSL().h).toBe(0);
   });
@@ -382,7 +424,7 @@ describe('averageColors', () => {
     const h1 = new Color({ h: 0, s: 100, l: 50 });
     const h2 = new Color({ h: 180, s: 100, l: 50 });
 
-    const result = averageColors([h1, h2], { space: 'HSL' });
+    const result = averageColors([h1, h2], { space: 'HSL' }, createColor);
     const hsl = result.toHSL();
 
     expect(Number.isNaN(hsl.h)).toBe(false);
@@ -395,7 +437,7 @@ describe('averageColors', () => {
     const warmGray = new Color({ h: 30, s: 40, l: 60 });
     const coolGray = new Color({ h: 210, s: 40, l: 40 });
 
-    const result = averageColors([warmGray, coolGray], { space: 'HSL' });
+    const result = averageColors([warmGray, coolGray], { space: 'HSL' }, createColor);
     const hsl = result.toHSL();
 
     expect(hsl.h).toBe(0);
@@ -407,7 +449,7 @@ describe('averageColors', () => {
   it('averages LCH hues correctly across 360 boundary', () => {
     const h1 = new Color({ l: 50, c: 50, h: 350 });
     const h2 = new Color({ l: 50, c: 50, h: 10 });
-    const result = averageColors([h1, h2], { space: 'LCH' });
+    const result = averageColors([h1, h2], { space: 'LCH' }, createColor);
     const h = result.toLCH().h;
     const distTo0 = Math.min(h, 360 - h);
     expect(distTo0).toBeLessThan(10);
@@ -417,7 +459,7 @@ describe('averageColors', () => {
     const h1 = new Color({ l: 60, c: 40, h: 0 });
     const h2 = new Color({ l: 60, c: 40, h: 180 });
 
-    const result = averageColors([h1, h2], { space: 'LCH' });
+    const result = averageColors([h1, h2], { space: 'LCH' }, createColor);
     const lch = result.toLCH();
     const { r, g, b } = result.toRGBA();
 
@@ -428,7 +470,7 @@ describe('averageColors', () => {
   it('averages OKLCH hues correctly across 360 boundary', () => {
     const h1 = new Color({ l: 0.5, c: 0.1, h: 350 });
     const h2 = new Color({ l: 0.5, c: 0.1, h: 10 });
-    const result = averageColors([h1, h2], { space: 'OKLCH' });
+    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColor);
     const h = result.toOKLCH().h;
     const distTo0 = Math.min(h, 360 - h);
     expect(distTo0).toBeLessThan(10);
@@ -438,7 +480,7 @@ describe('averageColors', () => {
     const h1 = new Color({ l: 0.6, c: 0.05, h: 0 });
     const h2 = new Color({ l: 0.6, c: 0.05, h: 180 });
 
-    const result = averageColors([h1, h2], { space: 'OKLCH' });
+    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColor);
     const oklch = result.toOKLCH();
 
     expect(oklch.c).toBeLessThan(0.001);
@@ -449,7 +491,7 @@ describe('averageColors', () => {
     const saturated = new Color({ l: 60, c: 40, h: 0 });
     const desaturatedOpponent = new Color({ l: 60, c: 39, h: 180 });
 
-    const result = averageColors([saturated, desaturatedOpponent], { space: 'LCH' });
+    const result = averageColors([saturated, desaturatedOpponent], { space: 'LCH' }, createColor);
     const lch = result.toLCH();
 
     expect(lch.c).toBeLessThan(1);
@@ -460,7 +502,7 @@ describe('averageColors', () => {
     const saturated = new Color({ l: 0.6, c: 0.05, h: 0 });
     const desaturatedOpponent = new Color({ l: 0.6, c: 0.045, h: 180 });
 
-    const result = averageColors([saturated, desaturatedOpponent], { space: 'OKLCH' });
+    const result = averageColors([saturated, desaturatedOpponent], { space: 'OKLCH' }, createColor);
     const oklch = result.toOKLCH();
 
     expect(oklch.c).toBeLessThan(0.005);
@@ -471,9 +513,21 @@ describe('averageColors', () => {
     const translucentRed = new Color({ h: 0, s: 100, l: 50, a: 0.2 });
     const translucentBlue = new Color({ h: 240, s: 100, l: 50, a: 0.8 });
 
-    const hslAverage = averageColors([translucentRed, translucentBlue], { space: 'HSL' });
-    const lchAverage = averageColors([translucentRed, translucentBlue], { space: 'LCH' });
-    const oklchAverage = averageColors([translucentRed, translucentBlue], { space: 'OKLCH' });
+    const hslAverage = averageColors(
+      [translucentRed, translucentBlue],
+      { space: 'HSL' },
+      createColor,
+    );
+    const lchAverage = averageColors(
+      [translucentRed, translucentBlue],
+      { space: 'LCH' },
+      createColor,
+    );
+    const oklchAverage = averageColors(
+      [translucentRed, translucentBlue],
+      { space: 'OKLCH' },
+      createColor,
+    );
 
     expect(hslAverage.toRGBA().a).toBeCloseTo(0.5, 5);
     expect(lchAverage.toRGBA().a).toBeCloseTo(0.5, 5);
@@ -487,11 +541,19 @@ describe('averageColors', () => {
     const weights = [1, 3];
     const expectedAlpha = 0.25 * 0.25 + 1 * 0.75;
 
-    const rgb = averageColors([lowAlphaRed, opaqueBlue], { space: 'RGB', weights });
-    const linearRgb = averageColors([lowAlphaRed, opaqueBlue], { space: 'LINEAR_RGB', weights });
-    const hsl = averageColors([lowAlphaRed, opaqueBlue], { space: 'HSL', weights });
-    const lch = averageColors([lowAlphaRed, opaqueBlue], { space: 'LCH', weights });
-    const oklch = averageColors([lowAlphaRed, opaqueBlue], { space: 'OKLCH', weights });
+    const rgb = averageColors([lowAlphaRed, opaqueBlue], { space: 'RGB', weights }, createColor);
+    const linearRgb = averageColors(
+      [lowAlphaRed, opaqueBlue],
+      { space: 'LINEAR_RGB', weights },
+      createColor,
+    );
+    const hsl = averageColors([lowAlphaRed, opaqueBlue], { space: 'HSL', weights }, createColor);
+    const lch = averageColors([lowAlphaRed, opaqueBlue], { space: 'LCH', weights }, createColor);
+    const oklch = averageColors(
+      [lowAlphaRed, opaqueBlue],
+      { space: 'OKLCH', weights },
+      createColor,
+    );
 
     expect(rgb.toRGBA().a).toBeCloseTo(expectedAlpha, 3);
     expect(linearRgb.toRGBA().a).toBeCloseTo(expectedAlpha, 3);
@@ -503,14 +565,14 @@ describe('averageColors', () => {
   it('defaults to equal weights when weights length mismatches', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { weights: [2] });
+    const result = averageColors([red, blue], { weights: [2] }, createColor);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('defaults weights to equal when provided weights sum to 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { weights: [1, -1] });
+    const result = averageColors([red, blue], { weights: [1, -1] }, createColor);
     expect(result.toHex()).toBe('#bc00bc');
   });
 });
@@ -519,15 +581,15 @@ describe('blendColors', () => {
   it('blends using multiply mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'MULTIPLY', ratio: 1 });
+    const result = blendColors(red, blue, { mode: 'MULTIPLY', ratio: 1 }, createColor);
     expect(result.toHex()).toBe('#000000');
   });
 
   it('accepts mixed case blend mode', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const b1 = blendColors(c1, c2, { mode: 'MULTIPLY' });
-    const b2 = blendColors(c1, c2, { mode: 'multiply' });
+    const b1 = blendColors(c1, c2, { mode: 'MULTIPLY' }, createColor);
+    const b2 = blendColors(c1, c2, { mode: 'multiply' }, createColor);
 
     expect(b1.toHex()).toBe(b2.toHex());
   });
@@ -535,8 +597,8 @@ describe('blendColors', () => {
   it('accepts mixed case blend space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const b1 = blendColors(c1, c2, { space: 'HSL' });
-    const b2 = blendColors(c1, c2, { space: 'hsl' });
+    const b1 = blendColors(c1, c2, { space: 'HSL' }, createColor);
+    const b2 = blendColors(c1, c2, { space: 'hsl' }, createColor);
 
     expect(b1.toHex()).toBe(b2.toHex());
   });
@@ -544,72 +606,87 @@ describe('blendColors', () => {
   it('partially blends using multiply mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, {
-      mode: 'MULTIPLY',
-      ratio: 0.5,
-    });
+    const result = blendColors(
+      red,
+      blue,
+      {
+        mode: 'MULTIPLY',
+        ratio: 0.5,
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#800000');
   });
 
   it('blends using screen mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'SCREEN', ratio: 1 });
+    const result = blendColors(red, blue, { mode: 'SCREEN', ratio: 1 }, createColor);
     expect(result.toHex()).toBe('#ff00ff');
   });
 
   it('partially blends using screen mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, {
-      mode: 'SCREEN',
-      ratio: 0.5,
-    });
+    const result = blendColors(
+      red,
+      blue,
+      {
+        mode: 'SCREEN',
+        ratio: 0.5,
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#ff0080');
   });
 
   it('blends using overlay mode', () => {
     const gray = new Color('#808080');
     const white = new Color('#ffffff');
-    const result = blendColors(gray, white, { mode: 'OVERLAY', ratio: 1 });
+    const result = blendColors(gray, white, { mode: 'OVERLAY', ratio: 1 }, createColor);
     expect(result.toHex()).toBe('#ffffff');
   });
 
   it('returns base color when ratio is 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { ratio: 0 });
+    const result = blendColors(red, blue, { ratio: 0 }, createColor);
     expect(result.toHex()).toBe('#ff0000');
   });
 
   it('returns blend color when ratio is 1 in normal mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'NORMAL', ratio: 1 });
+    const result = blendColors(red, blue, { mode: 'NORMAL', ratio: 1 }, createColor);
     expect(result.toHex()).toBe('#0000ff');
   });
 
   it('blends in HSL space', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, {
-      space: 'HSL',
-      ratio: 0.5,
-    });
+    const result = blendColors(
+      red,
+      blue,
+      {
+        space: 'HSL',
+        ratio: 0.5,
+      },
+      createColor,
+    );
     expect(result.toHex()).toBe('#ff00ff');
   });
 
   it('clamps ratio outside of range 0-1', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    expect(blendColors(red, blue, { ratio: -1 }).toHex()).toBe('#ff0000');
-    expect(blendColors(red, blue, { ratio: 2 }).toHex()).toBe('#0000ff');
+    expect(blendColors(red, blue, { ratio: -1 }, createColor).toHex()).toBe('#ff0000');
+    expect(blendColors(red, blue, { ratio: 2 }, createColor).toHex()).toBe('#0000ff');
   });
 
   it('blends colors with alpha channel in RGB space', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 0.2 });
-    const result = blendColors(semiRed, blue, { ratio: 0.5 });
+    const result = blendColors(semiRed, blue, { ratio: 0.5 }, createColor);
     expect(result.toHex()).toBe('#800080');
     expect(result.toRGBA().a).toBe(0.35);
   });
@@ -617,24 +694,44 @@ describe('blendColors', () => {
   it('handles hue wrap-around when blending in HSL space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = blendColors(h1, h2, { space: 'HSL', ratio: 0.5 });
+    const result = blendColors(h1, h2, { space: 'HSL', ratio: 0.5 }, createColor);
     expect(result.toHex()).toBe('#ff0000');
   });
 
   it('blends using overlay mode with dark base color', () => {
     const darkGray = new Color('#404040');
     const red = new Color('#ff0000');
-    const result = blendColors(darkGray, red, { mode: 'OVERLAY', ratio: 1 });
+    const result = blendColors(darkGray, red, { mode: 'OVERLAY', ratio: 1 }, createColor);
     expect(result.toHex()).toBe('#800000');
   });
 
   it('applies blend modes within HSL space', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const normal = blendColors(red, blue, { space: 'HSL', mode: 'NORMAL', ratio: 0.5 });
-    const multiply = blendColors(red, blue, { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 });
-    const screen = blendColors(red, blue, { space: 'HSL', mode: 'SCREEN', ratio: 0.5 });
-    const overlay = blendColors(red, blue, { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 });
+    const normal = blendColors(
+      red,
+      blue,
+      { space: 'HSL', mode: 'NORMAL', ratio: 0.5 },
+      createColor,
+    );
+    const multiply = blendColors(
+      red,
+      blue,
+      { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
+      createColor,
+    );
+    const screen = blendColors(
+      red,
+      blue,
+      { space: 'HSL', mode: 'SCREEN', ratio: 0.5 },
+      createColor,
+    );
+    const overlay = blendColors(
+      red,
+      blue,
+      { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 },
+      createColor,
+    );
 
     expect(normal.toHex()).toBe('#ff00ff');
     expect(multiply.toHex()).toBe('#b900bf');
@@ -648,9 +745,14 @@ describe('blendColors', () => {
   it('handles hue wrap-around for multiple HSL blend modes', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const multiply = blendColors(h1, h2, { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 });
-    const screen = blendColors(h1, h2, { space: 'HSL', mode: 'SCREEN', ratio: 0.5 });
-    const overlay = blendColors(h1, h2, { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 });
+    const multiply = blendColors(
+      h1,
+      h2,
+      { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
+      createColor,
+    );
+    const screen = blendColors(h1, h2, { space: 'HSL', mode: 'SCREEN', ratio: 0.5 }, createColor);
+    const overlay = blendColors(h1, h2, { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 }, createColor);
 
     expect(multiply.toHex()).toBe('#bf003e');
     expect(screen.toHex()).toBe('#ff5f40');
@@ -662,7 +764,12 @@ describe('blendColors', () => {
   it('preserves alpha handling when blending in HSL space', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 0.2 });
-    const result = blendColors(semiRed, blue, { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 });
+    const result = blendColors(
+      semiRed,
+      blue,
+      { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
+      createColor,
+    );
 
     expect(result.toHex()).toBe('#b900bf');
     expect(result.toRGBA().a).toBe(0.35);
@@ -673,7 +780,7 @@ describe('LINEAR_RGB robustness', () => {
   it('produces physically accurate middle gray from black and white', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'LINEAR_RGB' });
+    const result = averageColors([black, white], { space: 'LINEAR_RGB' }, createColor);
     // In sRGB averaging, (0+255)/2 = 127.5 -> #808080
     // In Linear averaging, light intensity is averaged.
     // 0 + 1 = 1. / 2 = 0.5 intensity.
@@ -685,10 +792,10 @@ describe('LINEAR_RGB robustness', () => {
     const blue = new Color('#0000ff');
     const yellow = new Color('#ffff00');
 
-    const srgbResult = averageColors([blue, yellow], { space: 'RGB' });
+    const srgbResult = averageColors([blue, yellow], { space: 'RGB' }, createColor);
     expect(srgbResult.toHex()).toBe('#808080'); // Dark gray
 
-    const linearResult = averageColors([blue, yellow], { space: 'LINEAR_RGB' });
+    const linearResult = averageColors([blue, yellow], { space: 'LINEAR_RGB' }, createColor);
     expect(linearResult.toHex()).toBe('#bcbcbc'); // Lighter gray (physically correct)
   });
 
@@ -696,8 +803,12 @@ describe('LINEAR_RGB robustness', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
 
-    const srgbMix = mixColors([red, green], { space: 'RGB', weights: [0.5, 0.5] });
-    const linearMix = mixColors([red, green], { space: 'LINEAR_RGB', weights: [0.5, 0.5] });
+    const srgbMix = mixColors([red, green], { space: 'RGB', weights: [0.5, 0.5] }, createColor);
+    const linearMix = mixColors(
+      [red, green],
+      { space: 'LINEAR_RGB', weights: [0.5, 0.5] },
+      createColor,
+    );
 
     expect(srgbMix.toHex()).toBe('#808000');
     expect(linearMix.toHex()).toBe('#bcbc00');
@@ -709,10 +820,14 @@ describe('LINEAR_RGB robustness', () => {
     const blue = new Color('#0000ff'); // Linear (0, 0, 1)
 
     // 75% Red, 25% Blue. LINEAR_RGB mixing normalizes weights to preserve the intended ratio.
-    const result = mixColors([red, blue], {
-      space: 'LINEAR_RGB',
-      weights: [0.75, 0.25],
-    });
+    const result = mixColors(
+      [red, blue],
+      {
+        space: 'LINEAR_RGB',
+        weights: [0.75, 0.25],
+      },
+      createColor,
+    );
 
     expect(result.toHex()).toBe('#e10089');
     expect(result.toRGBA().a).toBe(1);
@@ -724,7 +839,11 @@ describe('LINEAR_RGB robustness', () => {
     const opaqueGreen = new Color('rgba(0, 255, 0, 1)');
 
     // Using averageColors for equal weighting
-    const result = averageColors([transparentRed, opaqueGreen], { space: 'LINEAR_RGB' });
+    const result = averageColors(
+      [transparentRed, opaqueGreen],
+      { space: 'LINEAR_RGB' },
+      createColor,
+    );
 
     // Alpha should be 0.5
     expect(result.toRGBA().a).toBe(0.5);
@@ -745,8 +864,8 @@ describe('LINEAR_RGB robustness', () => {
       const c1 = Color.random();
       const c2 = Color.random();
 
-      const linear = averageColors([c1, c2], { space: 'LINEAR_RGB' });
-      const srgb = averageColors([c1, c2], { space: 'RGB' });
+      const linear = averageColors([c1, c2], { space: 'LINEAR_RGB' }, createColor);
+      const srgb = averageColors([c1, c2], { space: 'RGB' }, createColor);
 
       const lLum = linear.toRGBA().r + linear.toRGBA().g + linear.toRGBA().b;
       const sLum = srgb.toRGBA().r + srgb.toRGBA().g + srgb.toRGBA().b;
@@ -773,23 +892,31 @@ describe('LINEAR_RGB robustness', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => mixColors([red, blue], { type: 'INVALID' as never })).toThrow("Invalid 'type'");
-    expect(() => mixColors([red, blue], { space: 'INVALID' as never })).toThrow("Invalid 'space'");
+    expect(() => mixColors([red, blue], { type: 'INVALID' as never }, createColor)).toThrow(
+      "Invalid 'type'",
+    );
+    expect(() => mixColors([red, blue], { space: 'INVALID' as never }, createColor)).toThrow(
+      "Invalid 'space'",
+    );
   });
 
   it('throws for invalid blend option values', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => blendColors(red, blue, { mode: 'INVALID' as never })).toThrow("Invalid 'mode'");
-    expect(() => blendColors(red, blue, { space: 'INVALID' as never })).toThrow("Invalid 'space'");
+    expect(() => blendColors(red, blue, { mode: 'INVALID' as never }, createColor)).toThrow(
+      "Invalid 'mode'",
+    );
+    expect(() => blendColors(red, blue, { space: 'INVALID' as never }, createColor)).toThrow(
+      "Invalid 'space'",
+    );
   });
 
   it('throws for invalid average option values', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => averageColors([red, blue], { space: 'INVALID' as never })).toThrow(
+    expect(() => averageColors([red, blue], { space: 'INVALID' as never }, createColor)).toThrow(
       "Invalid 'space'",
     );
   });

--- a/src/color/__test__/combinations.test.ts
+++ b/src/color/__test__/combinations.test.ts
@@ -1,7 +1,5 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import { averageColors, blendColors, mixColors } from '../combinations';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('mixColors', () => {
   it('mixes colors additively in RGB space', () => {
@@ -13,7 +11,7 @@ describe('mixColors', () => {
         type: 'ADDITIVE',
         space: 'RGB',
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#ffff00');
   });
@@ -28,7 +26,7 @@ describe('mixColors', () => {
         type: 'ADDITIVE',
         space: 'RGB',
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#ffffff');
   });
@@ -36,7 +34,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in CMYK space', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColor);
+    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColorInstance);
     expect(result.toHex()).toBe('#00ff00');
   });
 
@@ -49,7 +47,7 @@ describe('mixColors', () => {
       {
         type: 'SUBTRACTIVE',
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#000000');
   });
@@ -63,7 +61,7 @@ describe('mixColors', () => {
         space: 'HSL',
         weights: [1, 3],
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#5100ff');
     const { h, s, l } = result.toHSL();
@@ -75,10 +73,10 @@ describe('mixColors', () => {
   it('accepts mixed case mix space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const mix1 = mixColors([c1, c2], { space: 'RGB' }, createColor);
-    const mix2 = mixColors([c1, c2], { space: 'rgb' }, createColor);
+    const mix1 = mixColors([c1, c2], { space: 'RGB' }, createColorInstance);
+    const mix2 = mixColors([c1, c2], { space: 'rgb' }, createColorInstance);
     // @ts-expect-error - testing mixed casing not covered by type but valid runtime
-    const mix3 = mixColors([c1, c2], { space: 'rGb' }, createColor);
+    const mix3 = mixColors([c1, c2], { space: 'rGb' }, createColorInstance);
 
     expect(mix1.toHex()).toBe(mix2.toHex());
     expect(mix1.toHex()).toBe(mix3.toHex());
@@ -87,8 +85,8 @@ describe('mixColors', () => {
   it('accepts mixed case mix type', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const sub1 = mixColors([c1, c2], { type: 'SUBTRACTIVE' }, createColor);
-    const sub2 = mixColors([c1, c2], { type: 'subtractive' }, createColor);
+    const sub1 = mixColors([c1, c2], { type: 'SUBTRACTIVE' }, createColorInstance);
+    const sub2 = mixColors([c1, c2], { type: 'subtractive' }, createColorInstance);
 
     expect(sub1.toHex()).toBe(sub2.toHex());
   });
@@ -96,7 +94,7 @@ describe('mixColors', () => {
   it('defaults to additive Linear RGB mixing', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = mixColors([red, green], createColor);
+    const result = mixColors([red, green], {}, createColorInstance);
     expect(result.toHex()).toBe('#bcbc00');
   });
 
@@ -114,7 +112,7 @@ describe('mixColors', () => {
     const result = mixColors(
       [red, green],
       { space: 'LINEAR_RGB', weights: [0.5, 0.5] },
-      createColor,
+      createColorInstance,
     );
     // sRGB Avg: 102, 102, 0 -> #666600
     // Linear Avg: 0.6*0.5 + 0 = 0.3. sRGB(0.3) -> ~150 (#96)
@@ -127,7 +125,7 @@ describe('mixColors', () => {
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => mixColors([red], createColor)).toThrow(
+    expect(() => mixColors([red], undefined, createColorInstance)).toThrow(
       'at least two colors are required for mixing',
     );
   });
@@ -135,14 +133,18 @@ describe('mixColors', () => {
   it('defaults weights to 1 when provided weights sum to 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [1, -1] }, createColor);
+    const result = mixColors([red, blue], { weights: [1, -1] }, createColorInstance);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('mixes colors with alpha channel in RGB space', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 1 });
-    const result = mixColors([semiRed, blue], { type: 'ADDITIVE', space: 'RGB' }, createColor);
+    const result = mixColors(
+      [semiRed, blue],
+      { type: 'ADDITIVE', space: 'RGB' },
+      createColorInstance,
+    );
     expect(result.toHex()).toBe('#ff00ff');
     expect(result.toRGBA().a).toBe(0.75);
   });
@@ -150,21 +152,21 @@ describe('mixColors', () => {
   it('mixes colors in LCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { space: 'LCH' }, createColor);
+    const result = mixColors([black, white], { space: 'LCH' }, createColorInstance);
     expect(result.toHex()).toBe('#777777');
   });
 
   it('mixes colors in OKLCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { space: 'OKLCH' }, createColor);
+    const result = mixColors([black, white], { space: 'OKLCH' }, createColorInstance);
     expect(result.toHex()).toBe('#636363');
   });
 
   it('mixes colors across the red hue boundary using linear addition', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'HSL' }, createColor);
+    const result = mixColors([h1, h2], { space: 'HSL' }, createColorInstance);
     expect(result.toHex()).toBe('#ff0000');
   });
 
@@ -187,7 +189,7 @@ describe('mixColors', () => {
         space: 'HSL',
         weights: [2, 1],
       },
-      createColor,
+      createColorInstance,
     );
 
     const { r, b } = result.toRGBA();
@@ -200,7 +202,7 @@ describe('mixColors', () => {
   it('handles hue wrap-around in LCH space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'LCH' }, createColor);
+    const result = mixColors([h1, h2], { space: 'LCH' }, createColorInstance);
     const hue = result.toLCH().h;
     const distanceFromZero = Math.min(hue, 360 - hue);
     expect(distanceFromZero).toBeLessThan(45);
@@ -210,7 +212,7 @@ describe('mixColors', () => {
   it('handles hue wrap-around in OKLCH space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { space: 'OKLCH' }, createColor);
+    const result = mixColors([h1, h2], { space: 'OKLCH' }, createColorInstance);
     const hue = result.toOKLCH().h;
     const distanceFromZero = Math.min(hue, 360 - hue);
     expect(distanceFromZero).toBeLessThan(45);
@@ -220,20 +222,20 @@ describe('mixColors', () => {
   it('defaults to equal weights when weights length mismatches', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [2] }, createColor);
+    const result = mixColors([red, blue], { weights: [2] }, createColorInstance);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('ignores colors with zero weight', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { weights: [0, 1] }, createColor);
+    const result = mixColors([red, blue], { weights: [0, 1] }, createColorInstance);
     expect(result.toHex()).toBe('#0000ff');
   });
 
   it('accumulates light when mixing identical colors in HSL space', () => {
     const darkRed = new Color('#800000');
-    const result = mixColors([darkRed, darkRed], { space: 'HSL' }, createColor);
+    const result = mixColors([darkRed, darkRed], { space: 'HSL' }, createColorInstance);
     expect(result.toHex()).toBe('#800000');
   });
 
@@ -241,9 +243,9 @@ describe('mixColors', () => {
     const red = new Color('#ff0000');
     const cyan = new Color('#00ffff');
 
-    const hslMix = mixColors([red, cyan], { space: 'HSL' }, createColor);
-    const lchMix = mixColors([red, cyan], { space: 'LCH' }, createColor);
-    const oklchMix = mixColors([red, cyan], { space: 'OKLCH' }, createColor);
+    const hslMix = mixColors([red, cyan], { space: 'HSL' }, createColorInstance);
+    const lchMix = mixColors([red, cyan], { space: 'LCH' }, createColorInstance);
+    const oklchMix = mixColors([red, cyan], { space: 'OKLCH' }, createColorInstance);
 
     expect(hslMix.toHex()).toBe('#80ff00');
     expect(lchMix.toHex()).toBe('#dda581');
@@ -253,7 +255,11 @@ describe('mixColors', () => {
   it('mixes colors subtractively in RGB space using normalized absorption', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE', space: 'RGB' }, createColor);
+    const result = mixColors(
+      [cyan, yellow],
+      { type: 'SUBTRACTIVE', space: 'RGB' },
+      createColorInstance,
+    );
 
     expect(result.toHex()).toBe('#00ff00');
     expect(result.toRGBA().a).toBe(1);
@@ -269,7 +275,7 @@ describe('mixColors', () => {
         space: 'LINEAR_RGB',
         weights: [2, 1],
       },
-      createColor,
+      createColorInstance,
     );
     const mixB = mixColors(
       [green, blue],
@@ -278,7 +284,7 @@ describe('mixColors', () => {
         space: 'LINEAR_RGB',
         weights: [200, 100],
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(mixA.toHex()).toBe(mixB.toHex());
@@ -287,7 +293,7 @@ describe('mixColors', () => {
   it('mixes colors subtractively in HSL space while handling hue wrap-around', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = mixColors([h1, h2], { type: 'SUBTRACTIVE', space: 'HSL' }, createColor);
+    const result = mixColors([h1, h2], { type: 'SUBTRACTIVE', space: 'HSL' }, createColorInstance);
 
     expect(result.toHex()).toBe('#ff0000');
     expect(result.toHSL().h).toBe(0);
@@ -296,7 +302,11 @@ describe('mixColors', () => {
   it('mixes colors subtractively in LCH space with chroma-driven hue', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = mixColors([red, blue], { type: 'SUBTRACTIVE', space: 'LCH' }, createColor);
+    const result = mixColors(
+      [red, blue],
+      { type: 'SUBTRACTIVE', space: 'LCH' },
+      createColorInstance,
+    );
 
     const { h, c } = result.toLCH();
     expect(c).toBeGreaterThan(0);
@@ -312,7 +322,11 @@ describe('mixColors', () => {
   it('mixes colors subtractively in OKLCH space with clamped lightness', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = mixColors([black, white], { type: 'SUBTRACTIVE', space: 'OKLCH' }, createColor);
+    const result = mixColors(
+      [black, white],
+      { type: 'SUBTRACTIVE', space: 'OKLCH' },
+      createColorInstance,
+    );
 
     expect(result.toHex()).toBe('#000000');
     expect(result.toRGBA().a).toBe(1);
@@ -321,7 +335,11 @@ describe('mixColors', () => {
   it('handles alpha when mixing subtractively', () => {
     const yellow = new Color({ r: 255, g: 255, b: 0, a: 0.5 });
     const magenta = new Color({ r: 255, g: 0, b: 255, a: 1 });
-    const result = mixColors([yellow, magenta], { type: 'SUBTRACTIVE', space: 'RGB' }, createColor);
+    const result = mixColors(
+      [yellow, magenta],
+      { type: 'SUBTRACTIVE', space: 'RGB' },
+      createColorInstance,
+    );
 
     expect(result.toHex()).toBe('#ff0000');
     expect(result.toRGBA().a).toBe(0.75);
@@ -330,7 +348,7 @@ describe('mixColors', () => {
   it('defaults to Linear RGB subtractive mixing when type is subtractive but space omitted', () => {
     const cyan = new Color('#00ffff');
     const yellow = new Color('#ffff00');
-    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColor);
+    const result = mixColors([cyan, yellow], { type: 'SUBTRACTIVE' }, createColorInstance);
 
     expect(result.toHex()).toBe('#00ff00');
   });
@@ -340,14 +358,14 @@ describe('averageColors', () => {
   it('averages colors in RGB space', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { space: 'RGB' }, createColor);
+    const result = averageColors([red, blue], { space: 'RGB' }, createColorInstance);
     expect(result.toHex()).toBe('#800080');
   });
 
   it('averages colors in Linear RGB space (brighter purple)', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { space: 'LINEAR_RGB' }, createColor);
+    const result = averageColors([red, blue], { space: 'LINEAR_RGB' }, createColorInstance);
     // RGB avg: 128, 0, 128 -> #800080
     // Linear avg: #bc00bc
     expect(result.toHex()).toBe('#bc00bc');
@@ -357,7 +375,7 @@ describe('averageColors', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, green, blue], { space: 'RGB' }, createColor);
+    const result = averageColors([red, green, blue], { space: 'RGB' }, createColorInstance);
     expect(result.toHex()).toBe('#555555');
   });
 
@@ -370,7 +388,7 @@ describe('averageColors', () => {
         space: 'HSL',
         weights: [1, 2],
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#80c936');
   });
@@ -378,14 +396,14 @@ describe('averageColors', () => {
   it('defaults to Linear RGB averaging', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
-    const result = averageColors([red, green], createColor);
+    const result = averageColors([red, green], undefined, createColorInstance);
     // Expect brighter yellow than #808000
     expect(result.toHex()).toBe('#bcbc00');
   });
 
   it('throws when fewer than two colors are provided', () => {
     const red = new Color('#ff0000');
-    expect(() => averageColors([red], createColor)).toThrow(
+    expect(() => averageColors([red], {}, createColorInstance)).toThrow(
       'at least two colors are required for averaging',
     );
   });
@@ -393,7 +411,7 @@ describe('averageColors', () => {
   it('averages colors with alpha channel', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 1 });
-    const result = averageColors([semiRed, blue], { space: 'RGB' }, createColor);
+    const result = averageColors([semiRed, blue], { space: 'RGB' }, createColorInstance);
     expect(result.toHex()).toBe('#800080');
     expect(result.toRGBA().a).toBe(0.75);
   });
@@ -401,21 +419,21 @@ describe('averageColors', () => {
   it('averages black and white in LCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'LCH' }, createColor);
+    const result = averageColors([black, white], { space: 'LCH' }, createColorInstance);
     expect(result.toHex()).toBe('#777777');
   });
 
   it('averages black and white in OKLCH space', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'OKLCH' }, createColor);
+    const result = averageColors([black, white], { space: 'OKLCH' }, createColorInstance);
     expect(result.toHex()).toBe('#636363');
   });
 
   it('averages hues correctly across the 360° boundary', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = averageColors([h1, h2], { space: 'HSL' }, createColor);
+    const result = averageColors([h1, h2], { space: 'HSL' }, createColorInstance);
     expect(result.toHex()).toBe('#fc0303');
     expect(result.toHSL().h).toBe(0);
   });
@@ -424,7 +442,7 @@ describe('averageColors', () => {
     const h1 = new Color({ h: 0, s: 100, l: 50 });
     const h2 = new Color({ h: 180, s: 100, l: 50 });
 
-    const result = averageColors([h1, h2], { space: 'HSL' }, createColor);
+    const result = averageColors([h1, h2], { space: 'HSL' }, createColorInstance);
     const hsl = result.toHSL();
 
     expect(Number.isNaN(hsl.h)).toBe(false);
@@ -437,7 +455,7 @@ describe('averageColors', () => {
     const warmGray = new Color({ h: 30, s: 40, l: 60 });
     const coolGray = new Color({ h: 210, s: 40, l: 40 });
 
-    const result = averageColors([warmGray, coolGray], { space: 'HSL' }, createColor);
+    const result = averageColors([warmGray, coolGray], { space: 'HSL' }, createColorInstance);
     const hsl = result.toHSL();
 
     expect(hsl.h).toBe(0);
@@ -449,7 +467,7 @@ describe('averageColors', () => {
   it('averages LCH hues correctly across 360 boundary', () => {
     const h1 = new Color({ l: 50, c: 50, h: 350 });
     const h2 = new Color({ l: 50, c: 50, h: 10 });
-    const result = averageColors([h1, h2], { space: 'LCH' }, createColor);
+    const result = averageColors([h1, h2], { space: 'LCH' }, createColorInstance);
     const h = result.toLCH().h;
     const distTo0 = Math.min(h, 360 - h);
     expect(distTo0).toBeLessThan(10);
@@ -459,7 +477,7 @@ describe('averageColors', () => {
     const h1 = new Color({ l: 60, c: 40, h: 0 });
     const h2 = new Color({ l: 60, c: 40, h: 180 });
 
-    const result = averageColors([h1, h2], { space: 'LCH' }, createColor);
+    const result = averageColors([h1, h2], { space: 'LCH' }, createColorInstance);
     const lch = result.toLCH();
     const { r, g, b } = result.toRGBA();
 
@@ -470,7 +488,7 @@ describe('averageColors', () => {
   it('averages OKLCH hues correctly across 360 boundary', () => {
     const h1 = new Color({ l: 0.5, c: 0.1, h: 350 });
     const h2 = new Color({ l: 0.5, c: 0.1, h: 10 });
-    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColor);
+    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColorInstance);
     const h = result.toOKLCH().h;
     const distTo0 = Math.min(h, 360 - h);
     expect(distTo0).toBeLessThan(10);
@@ -480,7 +498,7 @@ describe('averageColors', () => {
     const h1 = new Color({ l: 0.6, c: 0.05, h: 0 });
     const h2 = new Color({ l: 0.6, c: 0.05, h: 180 });
 
-    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColor);
+    const result = averageColors([h1, h2], { space: 'OKLCH' }, createColorInstance);
     const oklch = result.toOKLCH();
 
     expect(oklch.c).toBeLessThan(0.001);
@@ -491,7 +509,11 @@ describe('averageColors', () => {
     const saturated = new Color({ l: 60, c: 40, h: 0 });
     const desaturatedOpponent = new Color({ l: 60, c: 39, h: 180 });
 
-    const result = averageColors([saturated, desaturatedOpponent], { space: 'LCH' }, createColor);
+    const result = averageColors(
+      [saturated, desaturatedOpponent],
+      { space: 'LCH' },
+      createColorInstance,
+    );
     const lch = result.toLCH();
 
     expect(lch.c).toBeLessThan(1);
@@ -502,7 +524,11 @@ describe('averageColors', () => {
     const saturated = new Color({ l: 0.6, c: 0.05, h: 0 });
     const desaturatedOpponent = new Color({ l: 0.6, c: 0.045, h: 180 });
 
-    const result = averageColors([saturated, desaturatedOpponent], { space: 'OKLCH' }, createColor);
+    const result = averageColors(
+      [saturated, desaturatedOpponent],
+      { space: 'OKLCH' },
+      createColorInstance,
+    );
     const oklch = result.toOKLCH();
 
     expect(oklch.c).toBeLessThan(0.005);
@@ -516,17 +542,17 @@ describe('averageColors', () => {
     const hslAverage = averageColors(
       [translucentRed, translucentBlue],
       { space: 'HSL' },
-      createColor,
+      createColorInstance,
     );
     const lchAverage = averageColors(
       [translucentRed, translucentBlue],
       { space: 'LCH' },
-      createColor,
+      createColorInstance,
     );
     const oklchAverage = averageColors(
       [translucentRed, translucentBlue],
       { space: 'OKLCH' },
-      createColor,
+      createColorInstance,
     );
 
     expect(hslAverage.toRGBA().a).toBeCloseTo(0.5, 5);
@@ -541,18 +567,30 @@ describe('averageColors', () => {
     const weights = [1, 3];
     const expectedAlpha = 0.25 * 0.25 + 1 * 0.75;
 
-    const rgb = averageColors([lowAlphaRed, opaqueBlue], { space: 'RGB', weights }, createColor);
+    const rgb = averageColors(
+      [lowAlphaRed, opaqueBlue],
+      { space: 'RGB', weights },
+      createColorInstance,
+    );
     const linearRgb = averageColors(
       [lowAlphaRed, opaqueBlue],
       { space: 'LINEAR_RGB', weights },
-      createColor,
+      createColorInstance,
     );
-    const hsl = averageColors([lowAlphaRed, opaqueBlue], { space: 'HSL', weights }, createColor);
-    const lch = averageColors([lowAlphaRed, opaqueBlue], { space: 'LCH', weights }, createColor);
+    const hsl = averageColors(
+      [lowAlphaRed, opaqueBlue],
+      { space: 'HSL', weights },
+      createColorInstance,
+    );
+    const lch = averageColors(
+      [lowAlphaRed, opaqueBlue],
+      { space: 'LCH', weights },
+      createColorInstance,
+    );
     const oklch = averageColors(
       [lowAlphaRed, opaqueBlue],
       { space: 'OKLCH', weights },
-      createColor,
+      createColorInstance,
     );
 
     expect(rgb.toRGBA().a).toBeCloseTo(expectedAlpha, 3);
@@ -565,14 +603,14 @@ describe('averageColors', () => {
   it('defaults to equal weights when weights length mismatches', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { weights: [2] }, createColor);
+    const result = averageColors([red, blue], { weights: [2] }, createColorInstance);
     expect(result.toHex()).toBe('#bc00bc');
   });
 
   it('defaults weights to equal when provided weights sum to 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = averageColors([red, blue], { weights: [1, -1] }, createColor);
+    const result = averageColors([red, blue], { weights: [1, -1] }, createColorInstance);
     expect(result.toHex()).toBe('#bc00bc');
   });
 });
@@ -581,15 +619,15 @@ describe('blendColors', () => {
   it('blends using multiply mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'MULTIPLY', ratio: 1 }, createColor);
+    const result = blendColors(red, blue, { mode: 'MULTIPLY', ratio: 1 }, createColorInstance);
     expect(result.toHex()).toBe('#000000');
   });
 
   it('accepts mixed case blend mode', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const b1 = blendColors(c1, c2, { mode: 'MULTIPLY' }, createColor);
-    const b2 = blendColors(c1, c2, { mode: 'multiply' }, createColor);
+    const b1 = blendColors(c1, c2, { mode: 'MULTIPLY' }, createColorInstance);
+    const b2 = blendColors(c1, c2, { mode: 'multiply' }, createColorInstance);
 
     expect(b1.toHex()).toBe(b2.toHex());
   });
@@ -597,8 +635,8 @@ describe('blendColors', () => {
   it('accepts mixed case blend space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const b1 = blendColors(c1, c2, { space: 'HSL' }, createColor);
-    const b2 = blendColors(c1, c2, { space: 'hsl' }, createColor);
+    const b1 = blendColors(c1, c2, { space: 'HSL' }, createColorInstance);
+    const b2 = blendColors(c1, c2, { space: 'hsl' }, createColorInstance);
 
     expect(b1.toHex()).toBe(b2.toHex());
   });
@@ -613,7 +651,7 @@ describe('blendColors', () => {
         mode: 'MULTIPLY',
         ratio: 0.5,
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#800000');
   });
@@ -621,7 +659,7 @@ describe('blendColors', () => {
   it('blends using screen mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'SCREEN', ratio: 1 }, createColor);
+    const result = blendColors(red, blue, { mode: 'SCREEN', ratio: 1 }, createColorInstance);
     expect(result.toHex()).toBe('#ff00ff');
   });
 
@@ -635,7 +673,7 @@ describe('blendColors', () => {
         mode: 'SCREEN',
         ratio: 0.5,
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#ff0080');
   });
@@ -643,21 +681,21 @@ describe('blendColors', () => {
   it('blends using overlay mode', () => {
     const gray = new Color('#808080');
     const white = new Color('#ffffff');
-    const result = blendColors(gray, white, { mode: 'OVERLAY', ratio: 1 }, createColor);
+    const result = blendColors(gray, white, { mode: 'OVERLAY', ratio: 1 }, createColorInstance);
     expect(result.toHex()).toBe('#ffffff');
   });
 
   it('returns base color when ratio is 0', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { ratio: 0 }, createColor);
+    const result = blendColors(red, blue, { ratio: 0 }, createColorInstance);
     expect(result.toHex()).toBe('#ff0000');
   });
 
   it('returns blend color when ratio is 1 in normal mode', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    const result = blendColors(red, blue, { mode: 'NORMAL', ratio: 1 }, createColor);
+    const result = blendColors(red, blue, { mode: 'NORMAL', ratio: 1 }, createColorInstance);
     expect(result.toHex()).toBe('#0000ff');
   });
 
@@ -671,7 +709,7 @@ describe('blendColors', () => {
         space: 'HSL',
         ratio: 0.5,
       },
-      createColor,
+      createColorInstance,
     );
     expect(result.toHex()).toBe('#ff00ff');
   });
@@ -679,14 +717,14 @@ describe('blendColors', () => {
   it('clamps ratio outside of range 0-1', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
-    expect(blendColors(red, blue, { ratio: -1 }, createColor).toHex()).toBe('#ff0000');
-    expect(blendColors(red, blue, { ratio: 2 }, createColor).toHex()).toBe('#0000ff');
+    expect(blendColors(red, blue, { ratio: -1 }, createColorInstance).toHex()).toBe('#ff0000');
+    expect(blendColors(red, blue, { ratio: 2 }, createColorInstance).toHex()).toBe('#0000ff');
   });
 
   it('blends colors with alpha channel in RGB space', () => {
     const semiRed = new Color({ r: 255, g: 0, b: 0, a: 0.5 });
     const blue = new Color({ r: 0, g: 0, b: 255, a: 0.2 });
-    const result = blendColors(semiRed, blue, { ratio: 0.5 }, createColor);
+    const result = blendColors(semiRed, blue, { ratio: 0.5 }, createColorInstance);
     expect(result.toHex()).toBe('#800080');
     expect(result.toRGBA().a).toBe(0.35);
   });
@@ -694,14 +732,14 @@ describe('blendColors', () => {
   it('handles hue wrap-around when blending in HSL space', () => {
     const h1 = new Color({ h: 350, s: 100, l: 50 });
     const h2 = new Color({ h: 10, s: 100, l: 50 });
-    const result = blendColors(h1, h2, { space: 'HSL', ratio: 0.5 }, createColor);
+    const result = blendColors(h1, h2, { space: 'HSL', ratio: 0.5 }, createColorInstance);
     expect(result.toHex()).toBe('#ff0000');
   });
 
   it('blends using overlay mode with dark base color', () => {
     const darkGray = new Color('#404040');
     const red = new Color('#ff0000');
-    const result = blendColors(darkGray, red, { mode: 'OVERLAY', ratio: 1 }, createColor);
+    const result = blendColors(darkGray, red, { mode: 'OVERLAY', ratio: 1 }, createColorInstance);
     expect(result.toHex()).toBe('#800000');
   });
 
@@ -712,25 +750,25 @@ describe('blendColors', () => {
       red,
       blue,
       { space: 'HSL', mode: 'NORMAL', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
     const multiply = blendColors(
       red,
       blue,
       { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
     const screen = blendColors(
       red,
       blue,
       { space: 'HSL', mode: 'SCREEN', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
     const overlay = blendColors(
       red,
       blue,
       { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
 
     expect(normal.toHex()).toBe('#ff00ff');
@@ -749,10 +787,20 @@ describe('blendColors', () => {
       h1,
       h2,
       { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
-    const screen = blendColors(h1, h2, { space: 'HSL', mode: 'SCREEN', ratio: 0.5 }, createColor);
-    const overlay = blendColors(h1, h2, { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 }, createColor);
+    const screen = blendColors(
+      h1,
+      h2,
+      { space: 'HSL', mode: 'SCREEN', ratio: 0.5 },
+      createColorInstance,
+    );
+    const overlay = blendColors(
+      h1,
+      h2,
+      { space: 'HSL', mode: 'OVERLAY', ratio: 0.5 },
+      createColorInstance,
+    );
 
     expect(multiply.toHex()).toBe('#bf003e');
     expect(screen.toHex()).toBe('#ff5f40');
@@ -768,7 +816,7 @@ describe('blendColors', () => {
       semiRed,
       blue,
       { space: 'HSL', mode: 'MULTIPLY', ratio: 0.5 },
-      createColor,
+      createColorInstance,
     );
 
     expect(result.toHex()).toBe('#b900bf');
@@ -780,7 +828,7 @@ describe('LINEAR_RGB robustness', () => {
   it('produces physically accurate middle gray from black and white', () => {
     const black = new Color('#000000');
     const white = new Color('#ffffff');
-    const result = averageColors([black, white], { space: 'LINEAR_RGB' }, createColor);
+    const result = averageColors([black, white], { space: 'LINEAR_RGB' }, createColorInstance);
     // In sRGB averaging, (0+255)/2 = 127.5 -> #808080
     // In Linear averaging, light intensity is averaged.
     // 0 + 1 = 1. / 2 = 0.5 intensity.
@@ -792,10 +840,14 @@ describe('LINEAR_RGB robustness', () => {
     const blue = new Color('#0000ff');
     const yellow = new Color('#ffff00');
 
-    const srgbResult = averageColors([blue, yellow], { space: 'RGB' }, createColor);
+    const srgbResult = averageColors([blue, yellow], { space: 'RGB' }, createColorInstance);
     expect(srgbResult.toHex()).toBe('#808080'); // Dark gray
 
-    const linearResult = averageColors([blue, yellow], { space: 'LINEAR_RGB' }, createColor);
+    const linearResult = averageColors(
+      [blue, yellow],
+      { space: 'LINEAR_RGB' },
+      createColorInstance,
+    );
     expect(linearResult.toHex()).toBe('#bcbcbc'); // Lighter gray (physically correct)
   });
 
@@ -803,11 +855,15 @@ describe('LINEAR_RGB robustness', () => {
     const red = new Color('#ff0000');
     const green = new Color('#00ff00');
 
-    const srgbMix = mixColors([red, green], { space: 'RGB', weights: [0.5, 0.5] }, createColor);
+    const srgbMix = mixColors(
+      [red, green],
+      { space: 'RGB', weights: [0.5, 0.5] },
+      createColorInstance,
+    );
     const linearMix = mixColors(
       [red, green],
       { space: 'LINEAR_RGB', weights: [0.5, 0.5] },
-      createColor,
+      createColorInstance,
     );
 
     expect(srgbMix.toHex()).toBe('#808000');
@@ -826,7 +882,7 @@ describe('LINEAR_RGB robustness', () => {
         space: 'LINEAR_RGB',
         weights: [0.75, 0.25],
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(result.toHex()).toBe('#e10089');
@@ -842,7 +898,7 @@ describe('LINEAR_RGB robustness', () => {
     const result = averageColors(
       [transparentRed, opaqueGreen],
       { space: 'LINEAR_RGB' },
-      createColor,
+      createColorInstance,
     );
 
     // Alpha should be 0.5
@@ -864,8 +920,8 @@ describe('LINEAR_RGB robustness', () => {
       const c1 = Color.random();
       const c2 = Color.random();
 
-      const linear = averageColors([c1, c2], { space: 'LINEAR_RGB' }, createColor);
-      const srgb = averageColors([c1, c2], { space: 'RGB' }, createColor);
+      const linear = averageColors([c1, c2], { space: 'LINEAR_RGB' }, createColorInstance);
+      const srgb = averageColors([c1, c2], { space: 'RGB' }, createColorInstance);
 
       const lLum = linear.toRGBA().r + linear.toRGBA().g + linear.toRGBA().b;
       const sLum = srgb.toRGBA().r + srgb.toRGBA().g + srgb.toRGBA().b;
@@ -892,32 +948,32 @@ describe('LINEAR_RGB robustness', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => mixColors([red, blue], { type: 'INVALID' as never }, createColor)).toThrow(
+    expect(() => mixColors([red, blue], { type: 'INVALID' as never }, createColorInstance)).toThrow(
       "Invalid 'type'",
     );
-    expect(() => mixColors([red, blue], { space: 'INVALID' as never }, createColor)).toThrow(
-      "Invalid 'space'",
-    );
+    expect(() =>
+      mixColors([red, blue], { space: 'INVALID' as never }, createColorInstance),
+    ).toThrow("Invalid 'space'");
   });
 
   it('throws for invalid blend option values', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => blendColors(red, blue, { mode: 'INVALID' as never }, createColor)).toThrow(
+    expect(() => blendColors(red, blue, { mode: 'INVALID' as never }, createColorInstance)).toThrow(
       "Invalid 'mode'",
     );
-    expect(() => blendColors(red, blue, { space: 'INVALID' as never }, createColor)).toThrow(
-      "Invalid 'space'",
-    );
+    expect(() =>
+      blendColors(red, blue, { space: 'INVALID' as never }, createColorInstance),
+    ).toThrow("Invalid 'space'");
   });
 
   it('throws for invalid average option values', () => {
     const red = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => averageColors([red, blue], { space: 'INVALID' as never }, createColor)).toThrow(
-      "Invalid 'space'",
-    );
+    expect(() =>
+      averageColors([red, blue], { space: 'INVALID' as never }, createColorInstance),
+    ).toThrow("Invalid 'space'");
   });
 });

--- a/src/color/__test__/gradients.test.ts
+++ b/src/color/__test__/gradients.test.ts
@@ -1,12 +1,18 @@
 import { Color } from '../color';
 import { createColorGradient } from '../gradients';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('createColorGradient', () => {
   it('builds linear RGB gradients with evenly spaced stops', () => {
-    const gradient = createColorGradient([new Color('#ff0000'), new Color('#0000ff')], {
-      stops: 5,
-      space: 'RGB',
-    });
+    const gradient = createColorGradient(
+      [new Color('#ff0000'), new Color('#0000ff')],
+      {
+        stops: 5,
+        space: 'RGB',
+      },
+      createColor,
+    );
 
     expect(gradient.map((color) => color.toHex())).toEqual([
       '#ff0000',
@@ -18,7 +24,7 @@ describe('createColorGradient', () => {
   });
 
   it('defaults to 5 evenly spaced gradient stops', () => {
-    const gradient = createColorGradient([new Color('#000000'), new Color('#ffffff')]);
+    const gradient = createColorGradient([new Color('#000000'), new Color('#ffffff')], createColor);
 
     expect(gradient).toHaveLength(5);
     expect(gradient[0].toHex()).toBe('#000000');
@@ -26,9 +32,13 @@ describe('createColorGradient', () => {
   });
 
   it('rounds non-integer stop counts and enforces a minimum of two anchors', () => {
-    const twoStopGradient = createColorGradient([new Color('#000000'), new Color('#ffffff')], {
-      stops: 1.7,
-    });
+    const twoStopGradient = createColorGradient(
+      [new Color('#000000'), new Color('#ffffff')],
+      {
+        stops: 1.7,
+      },
+      createColor,
+    );
     expect(twoStopGradient).toHaveLength(2);
     expect(twoStopGradient[0].toHex()).toBe('#000000');
     expect(twoStopGradient[1].toHex()).toBe('#ffffff');
@@ -36,12 +46,16 @@ describe('createColorGradient', () => {
 
   it('supports bezier interpolation with easing while preserving anchors', () => {
     const anchors = [new Color('#f43f5e'), new Color('#fbbf24'), new Color('#22d3ee')];
-    const gradient = createColorGradient(anchors, {
-      stops: 4,
-      interpolation: 'BEZIER',
-      space: 'HSL',
-      easing: 'EASE_IN_OUT',
-    });
+    const gradient = createColorGradient(
+      anchors,
+      {
+        stops: 4,
+        interpolation: 'BEZIER',
+        space: 'HSL',
+        easing: 'EASE_IN_OUT',
+      },
+      createColor,
+    );
 
     // Bezier curve in Polar space (hue unwound)
     expect(gradient.map((color) => color.toHex())).toEqual([
@@ -58,6 +72,7 @@ describe('createColorGradient', () => {
     const gradient = createColorGradient(
       [new Color({ h: 350, s: 100, l: 50 }), new Color({ h: 10, s: 100, l: 50 })],
       { stops: 5, space: 'HSL' },
+      createColor,
     );
 
     expect(gradient.map((color) => color.toHex())).toEqual([
@@ -78,6 +93,7 @@ describe('createColorGradient', () => {
         stops: 3,
         space: 'RGB',
       },
+      createColor,
     );
 
     expect(gradient[0].toRGBA()).toEqual({ r: 255, g: 0, b: 0, a: 0.2 });
@@ -86,16 +102,24 @@ describe('createColorGradient', () => {
   });
 
   it('clamps eased stops inside OKLCH and LCH gamuts', () => {
-    const oklchGradient = createColorGradient([new Color('#111111'), new Color('#eeeeee')], {
-      stops: 3,
-      space: 'OKLCH',
-      easing: (t: number) => 1.2 * t - 0.1,
-    });
-    const lchGradient = createColorGradient([new Color('#2d2c7a'), new Color('#f4f0ff')], {
-      stops: 4,
-      space: 'LCH',
-      easing: 'EASE_OUT',
-    });
+    const oklchGradient = createColorGradient(
+      [new Color('#111111'), new Color('#eeeeee')],
+      {
+        stops: 3,
+        space: 'OKLCH',
+        easing: (t: number) => 1.2 * t - 0.1,
+      },
+      createColor,
+    );
+    const lchGradient = createColorGradient(
+      [new Color('#2d2c7a'), new Color('#f4f0ff')],
+      {
+        stops: 4,
+        space: 'LCH',
+        easing: 'EASE_OUT',
+      },
+      createColor,
+    );
 
     expect(oklchGradient[1].toOKLCH().c).toBeGreaterThanOrEqual(0);
     expect(oklchGradient[1].toOKLCH().c).toBeLessThanOrEqual(0.5);
@@ -105,7 +129,7 @@ describe('createColorGradient', () => {
   });
 
   it('throws when fewer than two colors are provided', () => {
-    expect(() => createColorGradient([new Color('#ff0000')], { stops: 2 })).toThrow(
+    expect(() => createColorGradient([new Color('#ff0000')], { stops: 2 }, createColor)).toThrow(
       'at least two colors are required to build a gradient',
     );
   });
@@ -113,7 +137,7 @@ describe('createColorGradient', () => {
   it('accepts readonly anchor arrays', () => {
     const anchors = [new Color('#14213d'), new Color('#fca311')] as const;
 
-    const gradient = createColorGradient(anchors, { stops: 3, space: 'RGB' });
+    const gradient = createColorGradient(anchors, { stops: 3, space: 'RGB' }, createColor);
 
     expect(gradient.map((color) => color.toHex())).toEqual(['#14213d', '#886227', '#fca311']);
   });
@@ -121,17 +145,17 @@ describe('createColorGradient', () => {
   it('throws for invalid option values', () => {
     const anchors = [new Color('#ff0000'), new Color('#0000ff')];
 
-    expect(() => createColorGradient(anchors, { space: 'INVALID' as never })).toThrow(
+    expect(() => createColorGradient(anchors, { space: 'INVALID' as never }, createColor)).toThrow(
       "Invalid 'space'",
     );
-    expect(() => createColorGradient(anchors, { interpolation: 'INVALID' as never })).toThrow(
-      "Invalid 'interpolation'",
-    );
-    expect(() => createColorGradient(anchors, { easing: 'INVALID' as never })).toThrow(
+    expect(() =>
+      createColorGradient(anchors, { interpolation: 'INVALID' as never }, createColor),
+    ).toThrow("Invalid 'interpolation'");
+    expect(() => createColorGradient(anchors, { easing: 'INVALID' as never }, createColor)).toThrow(
       "Invalid 'easing'",
     );
     expect(() =>
-      createColorGradient(anchors, { hueInterpolationMode: 'INVALID' as never }),
+      createColorGradient(anchors, { hueInterpolationMode: 'INVALID' as never }, createColor),
     ).toThrow("Invalid 'hueInterpolationMode'");
   });
 });
@@ -139,11 +163,15 @@ describe('createColorGradient', () => {
 describe('Color gradient helpers', () => {
   it('maintains anchors when easing between multiple colors', () => {
     const anchors = [new Color('#ff0000'), new Color('#00ff00'), new Color('#0000ff')];
-    const gradient = createColorGradient(anchors, {
-      stops: 5,
-      easing: 'EASE_IN_OUT',
-      space: 'RGB',
-    });
+    const gradient = createColorGradient(
+      anchors,
+      {
+        stops: 5,
+        easing: 'EASE_IN_OUT',
+        space: 'RGB',
+      },
+      createColor,
+    );
 
     expect(gradient[0].toHex()).toBe('#ff0000');
     expect(gradient[2].toHex()).toBe('#00ff00');
@@ -157,11 +185,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   const green = new Color('hsl(120, 100%, 50%)');
 
   it('reproduces current Cartesian desaturation behavior when explicitly requested', () => {
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'CARTESIAN',
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'CARTESIAN',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     const hsl = mid.toHSL();
 
@@ -171,11 +203,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   });
 
   it('defaults to Shortest Polar interpolation (preserving saturation)', () => {
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      // No mode specified -> defaults to Shortest
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        // No mode specified -> defaults to Shortest
+      },
+      createColor,
+    );
     const mid = gradient[1];
     const hsl = mid.toHSL();
 
@@ -199,11 +235,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     // Longest mode condition: if (abs(diff) < 180).
     // So here it does nothing.
     // 0 -> 240. Midpoint 120. Green.
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'LONGEST',
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'LONGEST',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(120, 0);
     expect(mid.toHSL().s).toBe(100);
@@ -212,11 +252,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('supports Increasing mode (0 -> 240)', () => {
     // 0 -> 240. 240 > 0. Stays 240.
     // Midpoint 120.
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'INCREASING',
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'INCREASING',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(120, 0);
   });
@@ -227,11 +271,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
 
     // 350 -> 10. 10 < 350. Add 360 -> 370.
     // 350 -> 370. Midpoint 360 (0).
-    const gradient = createColorGradient([start, end], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'INCREASING',
-    });
+    const gradient = createColorGradient(
+      [start, end],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'INCREASING',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     const hue = mid.toHSL().h;
     expect(Math.min(hue, 360 - hue)).toBeCloseTo(0, 0);
@@ -240,11 +288,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('supports Decreasing mode (0 -> 240)', () => {
     // 0 -> 240. 240 > 0. Sub 360 -> -120.
     // 0 -> -120. Mid -60 (300).
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'DECREASING',
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'DECREASING',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(300, 0);
   });
@@ -255,11 +307,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
 
     // 10 -> 350. 350 > 10. Sub 360 -> -10.
     // 10 -> -10. Mid 0.
-    const gradient = createColorGradient([start, end], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'DECREASING',
-    });
+    const gradient = createColorGradient(
+      [start, end],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'DECREASING',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     const hue = mid.toHSL().h;
     expect(Math.min(hue, 360 - hue)).toBeCloseTo(0, 0);
@@ -270,11 +326,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     // Midpoint (350+10)/2 = 180.
     const start = new Color('hsl(350, 100%, 50%)');
     const end = new Color('hsl(10, 100%, 50%)');
-    const gradient = createColorGradient([start, end], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'RAW',
-    });
+    const gradient = createColorGradient(
+      [start, end],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'RAW',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(180, 0);
   });
@@ -285,11 +345,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     // 180 is not > 180. So it stays 180.
     // 0 -> 180. Mid 90.
     const cyan = new Color('hsl(180, 100%, 50%)');
-    const gradient = createColorGradient([red, cyan], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'SHORTEST',
-    });
+    const gradient = createColorGradient(
+      [red, cyan],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'SHORTEST',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(90, 0);
   });
@@ -301,31 +365,43 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     // So it stays 180.
     // 0 -> 180. Mid 90.
     const cyan = new Color('hsl(180, 100%, 50%)');
-    const gradient = createColorGradient([red, cyan], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'LONGEST',
-    });
+    const gradient = createColorGradient(
+      [red, cyan],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'LONGEST',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(90, 0);
   });
 
   it('handles exact 0 degree difference', () => {
-    const gradient = createColorGradient([red, red], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'SHORTEST',
-    });
+    const gradient = createColorGradient(
+      [red, red],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'SHORTEST',
+      },
+      createColor,
+    );
     expect(gradient[1].toHSL().h).toBeCloseTo(0, 0);
   });
 
   it('works with OKLCH space (Default)', () => {
     // Red (#ff0000) -> Blue (#0000ff) in OKLCH.
     // Shortest path.
-    const gradient = createColorGradient([new Color('#ff0000'), new Color('#0000ff')], {
-      stops: 3,
-      space: 'OKLCH',
-    });
+    const gradient = createColorGradient(
+      [new Color('#ff0000'), new Color('#0000ff')],
+      {
+        stops: 3,
+        space: 'OKLCH',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     // Check it's not gray.
     expect(mid.toOKLCH().c).toBeGreaterThan(0.1);
@@ -335,7 +411,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     const start = new Color('#ff0000');
     const end = new Color('#0000ff');
 
-    const gradient = createColorGradient([start, end], { stops: 3, space: 'OKLAB' });
+    const gradient = createColorGradient([start, end], { stops: 3, space: 'OKLAB' }, createColor);
     const mid = gradient[1].toOKLAB();
 
     expect(mid.l).toBeCloseTo(0.539339, 6);
@@ -344,19 +420,27 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   });
 
   it('works with LCH space', () => {
-    const gradient = createColorGradient([new Color('#ff0000'), new Color('#0000ff')], {
-      stops: 3,
-      space: 'LCH',
-    });
+    const gradient = createColorGradient(
+      [new Color('#ff0000'), new Color('#0000ff')],
+      {
+        stops: 3,
+        space: 'LCH',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toLCH().c).toBeGreaterThan(10);
   });
 
   it('works with HSV space', () => {
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSV',
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSV',
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHSV().s).toBeCloseTo(100, 0);
   });
@@ -364,11 +448,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('ignores hueInterpolationMode in RGB space', () => {
     // RGB interpolation Red -> Blue is #800080 (Purple).
     // Even if we say 'Increasing' or 'Longest', RGB doesn't use hue.
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'RGB',
-      hueInterpolationMode: 'LONGEST', // Should be ignored
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'RGB',
+        hueInterpolationMode: 'LONGEST', // Should be ignored
+      },
+      createColor,
+    );
     const mid = gradient[1];
     expect(mid.toHex()).toBe('#800080');
   });
@@ -376,11 +464,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('applies hue unwinding to multiple stops correctly', () => {
     // 0 -> 90 -> 180.
     // Shortest: 0->90 (diff 90), 90->180 (diff 90). No adjustments.
-    const gradient = createColorGradient([red, green, blue], {
-      stops: 5,
-      space: 'HSL',
-      hueInterpolationMode: 'SHORTEST',
-    });
+    const gradient = createColorGradient(
+      [red, green, blue],
+      {
+        stops: 5,
+        space: 'HSL',
+        hueInterpolationMode: 'SHORTEST',
+      },
+      createColor,
+    );
     // Stops: 0, 90, 180.
     // 5 stops: 0, 45, 90, 135 (approx), 180 (approx).
     // Wait, anchors are 0, 120 (Green), 240 (Blue).
@@ -400,11 +492,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     const mid = new Color('hsl(10, 100%, 50%)');
     const end = new Color('hsl(350, 100%, 50%)');
 
-    const gradient = createColorGradient([start, mid, end], {
-      stops: 5, // 0, 5, 10, 0, -10 (350).
-      space: 'HSL',
-      hueInterpolationMode: 'SHORTEST',
-    });
+    const gradient = createColorGradient(
+      [start, mid, end],
+      {
+        stops: 5, // 0, 5, 10, 0, -10 (350).
+        space: 'HSL',
+        hueInterpolationMode: 'SHORTEST',
+      },
+      createColor,
+    );
     // Segment 1: 0 -> 10. 3 stops. 0, 5, 10.
     // Segment 2: 10 -> 350 (adj -10). 3 stops. 10, 0, -10.
     // Total 5 stops.
@@ -423,12 +519,16 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('works with clamping disabled', () => {
     // Red -> Blue via Longest (0 -> 120 -> 240).
     // Mid is 120.
-    const gradient = createColorGradient([red, blue], {
-      stops: 3,
-      space: 'HSL',
-      hueInterpolationMode: 'LONGEST',
-      clamp: false,
-    });
+    const gradient = createColorGradient(
+      [red, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        hueInterpolationMode: 'LONGEST',
+        clamp: false,
+      },
+      createColor,
+    );
     expect(gradient[1].toHSL().h).toBeCloseTo(120, 0);
   });
 
@@ -441,11 +541,15 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     // L2 = lerp(120, 240, 0.5) = 180.
     // L3 = lerp(60, 180, 0.5) = 120.
     // Should be Green.
-    const gradient = createColorGradient([red, green, blue], {
-      stops: 3,
-      space: 'HSL',
-      interpolation: 'BEZIER',
-    });
+    const gradient = createColorGradient(
+      [red, green, blue],
+      {
+        stops: 3,
+        space: 'HSL',
+        interpolation: 'BEZIER',
+      },
+      createColor,
+    );
     // Bezier with 3 anchors -> 0 -> 120.
     // stops=3. 0, 0.5, 1.
     expect(gradient[1].toHSL().h).toBeCloseTo(120, 1);
@@ -454,8 +558,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case gradient space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { space: 'HSL' });
-    const g2 = createColorGradient([c1, c2], { space: 'hsl' });
+    const g1 = createColorGradient([c1, c2], { space: 'HSL' }, createColor);
+    const g2 = createColorGradient([c1, c2], { space: 'hsl' }, createColor);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -463,8 +567,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case interpolation', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { interpolation: 'BEZIER' });
-    const g2 = createColorGradient([c1, c2], { interpolation: 'bezier' });
+    const g1 = createColorGradient([c1, c2], { interpolation: 'BEZIER' }, createColor);
+    const g2 = createColorGradient([c1, c2], { interpolation: 'bezier' }, createColor);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -472,8 +576,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case easing', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { easing: 'EASE_IN' });
-    const g2 = createColorGradient([c1, c2], { easing: 'ease_in' });
+    const g1 = createColorGradient([c1, c2], { easing: 'EASE_IN' }, createColor);
+    const g2 = createColorGradient([c1, c2], { easing: 'ease_in' }, createColor);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -481,8 +585,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case hue interpolation mode', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { hueInterpolationMode: 'LONGEST' });
-    const g2 = createColorGradient([c1, c2], { hueInterpolationMode: 'longest' });
+    const g1 = createColorGradient([c1, c2], { hueInterpolationMode: 'LONGEST' }, createColor);
+    const g2 = createColorGradient([c1, c2], { hueInterpolationMode: 'longest' }, createColor);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });

--- a/src/color/__test__/gradients.test.ts
+++ b/src/color/__test__/gradients.test.ts
@@ -1,7 +1,5 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import { createColorGradient } from '../gradients';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('createColorGradient', () => {
   it('builds linear RGB gradients with evenly spaced stops', () => {
@@ -11,7 +9,7 @@ describe('createColorGradient', () => {
         stops: 5,
         space: 'RGB',
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(gradient.map((color) => color.toHex())).toEqual([
@@ -24,7 +22,11 @@ describe('createColorGradient', () => {
   });
 
   it('defaults to 5 evenly spaced gradient stops', () => {
-    const gradient = createColorGradient([new Color('#000000'), new Color('#ffffff')], createColor);
+    const gradient = createColorGradient(
+      [new Color('#000000'), new Color('#ffffff')],
+      undefined,
+      createColorInstance,
+    );
 
     expect(gradient).toHaveLength(5);
     expect(gradient[0].toHex()).toBe('#000000');
@@ -37,7 +39,7 @@ describe('createColorGradient', () => {
       {
         stops: 1.7,
       },
-      createColor,
+      createColorInstance,
     );
     expect(twoStopGradient).toHaveLength(2);
     expect(twoStopGradient[0].toHex()).toBe('#000000');
@@ -54,7 +56,7 @@ describe('createColorGradient', () => {
         space: 'HSL',
         easing: 'EASE_IN_OUT',
       },
-      createColor,
+      createColorInstance,
     );
 
     // Bezier curve in Polar space (hue unwound)
@@ -72,7 +74,7 @@ describe('createColorGradient', () => {
     const gradient = createColorGradient(
       [new Color({ h: 350, s: 100, l: 50 }), new Color({ h: 10, s: 100, l: 50 })],
       { stops: 5, space: 'HSL' },
-      createColor,
+      createColorInstance,
     );
 
     expect(gradient.map((color) => color.toHex())).toEqual([
@@ -93,7 +95,7 @@ describe('createColorGradient', () => {
         stops: 3,
         space: 'RGB',
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(gradient[0].toRGBA()).toEqual({ r: 255, g: 0, b: 0, a: 0.2 });
@@ -109,7 +111,7 @@ describe('createColorGradient', () => {
         space: 'OKLCH',
         easing: (t: number) => 1.2 * t - 0.1,
       },
-      createColor,
+      createColorInstance,
     );
     const lchGradient = createColorGradient(
       [new Color('#2d2c7a'), new Color('#f4f0ff')],
@@ -118,7 +120,7 @@ describe('createColorGradient', () => {
         space: 'LCH',
         easing: 'EASE_OUT',
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(oklchGradient[1].toOKLCH().c).toBeGreaterThanOrEqual(0);
@@ -129,15 +131,15 @@ describe('createColorGradient', () => {
   });
 
   it('throws when fewer than two colors are provided', () => {
-    expect(() => createColorGradient([new Color('#ff0000')], { stops: 2 }, createColor)).toThrow(
-      'at least two colors are required to build a gradient',
-    );
+    expect(() =>
+      createColorGradient([new Color('#ff0000')], { stops: 2 }, createColorInstance),
+    ).toThrow('at least two colors are required to build a gradient');
   });
 
   it('accepts readonly anchor arrays', () => {
     const anchors = [new Color('#14213d'), new Color('#fca311')] as const;
 
-    const gradient = createColorGradient(anchors, { stops: 3, space: 'RGB' }, createColor);
+    const gradient = createColorGradient(anchors, { stops: 3, space: 'RGB' }, createColorInstance);
 
     expect(gradient.map((color) => color.toHex())).toEqual(['#14213d', '#886227', '#fca311']);
   });
@@ -145,17 +147,21 @@ describe('createColorGradient', () => {
   it('throws for invalid option values', () => {
     const anchors = [new Color('#ff0000'), new Color('#0000ff')];
 
-    expect(() => createColorGradient(anchors, { space: 'INVALID' as never }, createColor)).toThrow(
-      "Invalid 'space'",
-    );
     expect(() =>
-      createColorGradient(anchors, { interpolation: 'INVALID' as never }, createColor),
+      createColorGradient(anchors, { space: 'INVALID' as never }, createColorInstance),
+    ).toThrow("Invalid 'space'");
+    expect(() =>
+      createColorGradient(anchors, { interpolation: 'INVALID' as never }, createColorInstance),
     ).toThrow("Invalid 'interpolation'");
-    expect(() => createColorGradient(anchors, { easing: 'INVALID' as never }, createColor)).toThrow(
-      "Invalid 'easing'",
-    );
     expect(() =>
-      createColorGradient(anchors, { hueInterpolationMode: 'INVALID' as never }, createColor),
+      createColorGradient(anchors, { easing: 'INVALID' as never }, createColorInstance),
+    ).toThrow("Invalid 'easing'");
+    expect(() =>
+      createColorGradient(
+        anchors,
+        { hueInterpolationMode: 'INVALID' as never },
+        createColorInstance,
+      ),
     ).toThrow("Invalid 'hueInterpolationMode'");
   });
 });
@@ -170,7 +176,7 @@ describe('Color gradient helpers', () => {
         easing: 'EASE_IN_OUT',
         space: 'RGB',
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(gradient[0].toHex()).toBe('#ff0000');
@@ -192,7 +198,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'CARTESIAN',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     const hsl = mid.toHSL();
@@ -210,7 +216,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         // No mode specified -> defaults to Shortest
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     const hsl = mid.toHSL();
@@ -242,7 +248,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'LONGEST',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(120, 0);
@@ -259,7 +265,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'INCREASING',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(120, 0);
@@ -278,7 +284,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'INCREASING',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     const hue = mid.toHSL().h;
@@ -295,7 +301,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'DECREASING',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(300, 0);
@@ -314,7 +320,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'DECREASING',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     const hue = mid.toHSL().h;
@@ -333,7 +339,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'RAW',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(180, 0);
@@ -352,7 +358,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'SHORTEST',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(90, 0);
@@ -372,7 +378,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'LONGEST',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSL().h).toBeCloseTo(90, 0);
@@ -386,7 +392,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'SHORTEST',
       },
-      createColor,
+      createColorInstance,
     );
     expect(gradient[1].toHSL().h).toBeCloseTo(0, 0);
   });
@@ -400,7 +406,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         stops: 3,
         space: 'OKLCH',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     // Check it's not gray.
@@ -411,7 +417,11 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
     const start = new Color('#ff0000');
     const end = new Color('#0000ff');
 
-    const gradient = createColorGradient([start, end], { stops: 3, space: 'OKLAB' }, createColor);
+    const gradient = createColorGradient(
+      [start, end],
+      { stops: 3, space: 'OKLAB' },
+      createColorInstance,
+    );
     const mid = gradient[1].toOKLAB();
 
     expect(mid.l).toBeCloseTo(0.539339, 6);
@@ -426,7 +436,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         stops: 3,
         space: 'LCH',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toLCH().c).toBeGreaterThan(10);
@@ -439,7 +449,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         stops: 3,
         space: 'HSV',
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHSV().s).toBeCloseTo(100, 0);
@@ -455,7 +465,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'RGB',
         hueInterpolationMode: 'LONGEST', // Should be ignored
       },
-      createColor,
+      createColorInstance,
     );
     const mid = gradient[1];
     expect(mid.toHex()).toBe('#800080');
@@ -471,7 +481,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'SHORTEST',
       },
-      createColor,
+      createColorInstance,
     );
     // Stops: 0, 90, 180.
     // 5 stops: 0, 45, 90, 135 (approx), 180 (approx).
@@ -499,7 +509,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         hueInterpolationMode: 'SHORTEST',
       },
-      createColor,
+      createColorInstance,
     );
     // Segment 1: 0 -> 10. 3 stops. 0, 5, 10.
     // Segment 2: 10 -> 350 (adj -10). 3 stops. 10, 0, -10.
@@ -527,7 +537,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         hueInterpolationMode: 'LONGEST',
         clamp: false,
       },
-      createColor,
+      createColorInstance,
     );
     expect(gradient[1].toHSL().h).toBeCloseTo(120, 0);
   });
@@ -548,7 +558,7 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
         space: 'HSL',
         interpolation: 'BEZIER',
       },
-      createColor,
+      createColorInstance,
     );
     // Bezier with 3 anchors -> 0 -> 120.
     // stops=3. 0, 0.5, 1.
@@ -558,8 +568,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case gradient space', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { space: 'HSL' }, createColor);
-    const g2 = createColorGradient([c1, c2], { space: 'hsl' }, createColor);
+    const g1 = createColorGradient([c1, c2], { space: 'HSL' }, createColorInstance);
+    const g2 = createColorGradient([c1, c2], { space: 'hsl' }, createColorInstance);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -567,8 +577,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case interpolation', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { interpolation: 'BEZIER' }, createColor);
-    const g2 = createColorGradient([c1, c2], { interpolation: 'bezier' }, createColor);
+    const g1 = createColorGradient([c1, c2], { interpolation: 'BEZIER' }, createColorInstance);
+    const g2 = createColorGradient([c1, c2], { interpolation: 'bezier' }, createColorInstance);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -576,8 +586,8 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case easing', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { easing: 'EASE_IN' }, createColor);
-    const g2 = createColorGradient([c1, c2], { easing: 'ease_in' }, createColor);
+    const g1 = createColorGradient([c1, c2], { easing: 'EASE_IN' }, createColorInstance);
+    const g2 = createColorGradient([c1, c2], { easing: 'ease_in' }, createColorInstance);
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });
@@ -585,8 +595,16 @@ describe('Polar Hue Interpolation (createColorGradient)', () => {
   it('accepts mixed case hue interpolation mode', () => {
     const c1 = new Color('red');
     const c2 = new Color('blue');
-    const g1 = createColorGradient([c1, c2], { hueInterpolationMode: 'LONGEST' }, createColor);
-    const g2 = createColorGradient([c1, c2], { hueInterpolationMode: 'longest' }, createColor);
+    const g1 = createColorGradient(
+      [c1, c2],
+      { hueInterpolationMode: 'LONGEST' },
+      createColorInstance,
+    );
+    const g2 = createColorGradient(
+      [c1, c2],
+      { hueInterpolationMode: 'longest' },
+      createColorInstance,
+    );
 
     expect(g1[1].toHex()).toBe(g2[1].toHex());
   });

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import type { ColorHarmony } from '../harmonies';
 import {
   getAnalogousHarmonyColors,
@@ -11,70 +11,121 @@ import {
   getTriadicHarmonyColors,
 } from '../harmonies';
 
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
-
 describe('getComplementaryColors', () => {
   it('returns complementary pairs for primary colors', () => {
-    const [redOrig, redComp] = getComplementaryColors(new Color('#ff0000'), createColor);
+    const [redOrig, redComp] = getComplementaryColors(
+      new Color('#ff0000'),
+      {},
+      createColorInstance,
+    );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redComp.toHex()).toBe('#00ffff');
 
-    const [greenOrig, greenComp] = getComplementaryColors(new Color('#00ff00'), createColor);
+    const [greenOrig, greenComp] = getComplementaryColors(
+      new Color('#00ff00'),
+      undefined,
+      createColorInstance,
+    );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenComp.toHex()).toBe('#ff00ff');
 
-    const [blueOrig, blueComp] = getComplementaryColors(new Color('#0000ff'), createColor);
+    const [blueOrig, blueComp] = getComplementaryColors(
+      new Color('#0000ff'),
+      {},
+      createColorInstance,
+    );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueComp.toHex()).toBe('#ffff00');
   });
 
   it('returns complementary pairs for brand colors', () => {
-    const [purpleOrig, purpleComp] = getComplementaryColors(new Color('#ee6ffc'), createColor);
+    const [purpleOrig, purpleComp] = getComplementaryColors(
+      new Color('#ee6ffc'),
+      {},
+      createColorInstance,
+    );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleComp.toHex()).toBe('#7dfc6f');
 
-    const [blueOrig, blueComp] = getComplementaryColors(new Color('#2e3575'), createColor);
+    const [blueOrig, blueComp] = getComplementaryColors(
+      new Color('#2e3575'),
+      undefined,
+      createColorInstance,
+    );
     expect(blueOrig.toHex()).toBe('#2e3575');
     expect(blueComp.toHex()).toBe('#756e2e');
 
-    const [yellowOrig, yellowComp] = getComplementaryColors(new Color('#d3e204'), createColor);
+    const [yellowOrig, yellowComp] = getComplementaryColors(
+      new Color('#d3e204'),
+      undefined,
+      createColorInstance,
+    );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowComp.toHex()).toBe('#1304e2');
 
-    const [greenOrig, greenComp] = getComplementaryColors(new Color('#29cc53'), createColor);
+    const [greenOrig, greenComp] = getComplementaryColors(
+      new Color('#29cc53'),
+      {},
+      createColorInstance,
+    );
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenComp.toHex()).toBe('#cc29a2');
 
-    const [pinkOrig, pinkComp] = getComplementaryColors(new Color('#811242'), createColor);
+    const [pinkOrig, pinkComp] = getComplementaryColors(
+      new Color('#811242'),
+      {},
+      createColorInstance,
+    );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkComp.toHex()).toBe('#128151');
 
-    const [brandRedOrig, brandRedComp] = getComplementaryColors(new Color('#de0d14'), createColor);
+    const [brandRedOrig, brandRedComp] = getComplementaryColors(
+      new Color('#de0d14'),
+      undefined,
+      createColorInstance,
+    );
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedComp.toHex()).toBe('#0dded7');
   });
 
   it('returns complementary pairs for grayscale colors', () => {
-    const [blackOrig, blackComp] = getComplementaryColors(new Color('#000000'), createColor);
+    const [blackOrig, blackComp] = getComplementaryColors(
+      new Color('#000000'),
+      {},
+      createColorInstance,
+    );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackComp.toHex()).toBe('#ffffff');
 
-    const [whiteOrig, whiteComp] = getComplementaryColors(new Color('#ffffff'), createColor);
+    const [whiteOrig, whiteComp] = getComplementaryColors(
+      new Color('#ffffff'),
+      undefined,
+      createColorInstance,
+    );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteComp.toHex()).toBe('#000000');
 
     const [lightGrayOrig, lightGrayComp] = getComplementaryColors(
       new Color('#d3d3d3'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayComp.toHex()).toBe('#2b2b2b');
 
-    const [grayOrig, grayComp] = getComplementaryColors(new Color('#808080'), createColor);
+    const [grayOrig, grayComp] = getComplementaryColors(
+      new Color('#808080'),
+      undefined,
+      createColorInstance,
+    );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayComp.toHex()).toBe('#808080');
 
-    const [darkGrayOrig, darkGrayComp] = getComplementaryColors(new Color('#333333'), createColor);
+    const [darkGrayOrig, darkGrayComp] = getComplementaryColors(
+      new Color('#333333'),
+      {},
+      createColorInstance,
+    );
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayComp.toHex()).toBe('#cccccc');
   });
@@ -85,7 +136,7 @@ describe('getComplementaryColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#ffffff']);
 
@@ -94,7 +145,7 @@ describe('getComplementaryColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000']);
   });
@@ -102,7 +153,8 @@ describe('getComplementaryColors', () => {
   it('preserves alpha when creating complements', () => {
     const [base, complement] = getComplementaryColors(
       new Color('rgba(255, 0, 0, 0.4)'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(base.toRGBA().a).toBeCloseTo(0.4, 5);
     expect(complement.toRGBA().a).toBeCloseTo(0.4, 5);
@@ -114,7 +166,8 @@ describe('getSplitComplementaryColors', () => {
   it('returns split complement colors for primary colors', () => {
     const [redOrig, redComp2, redComp3] = getSplitComplementaryColors(
       new Color('#ff0000'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redComp2.toHex()).toBe('#0080ff');
@@ -122,7 +175,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(
       new Color('#00ff00'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenComp2.toHex()).toBe('#ff0080');
@@ -130,7 +184,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [blueOrig, blueComp2, blueComp3] = getSplitComplementaryColors(
       new Color('#0000ff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueComp2.toHex()).toBe('#80ff00');
@@ -140,7 +195,8 @@ describe('getSplitComplementaryColors', () => {
   it('returns split complement colors for brand colors', () => {
     const [purpleOrig, purpleComp2, purpleComp3] = getSplitComplementaryColors(
       new Color('#ee6ffc'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleComp2.toHex()).toBe('#6ffca7');
@@ -148,7 +204,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [brandBlueOrig, brandBlueComp2, brandBlueComp3] = getSplitComplementaryColors(
       new Color('#2e3575'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlueComp2.toHex()).toBe('#58752e');
@@ -156,7 +213,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [yellowOrig, yellowComp2, yellowComp3] = getSplitComplementaryColors(
       new Color('#d3e204'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowComp2.toHex()).toBe('#8204e2');
@@ -164,7 +222,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(
       new Color('#29cc53'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenComp2.toHex()).toBe('#cc2951');
@@ -172,7 +231,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [pinkOrig, pinkComp2, pinkComp3] = getSplitComplementaryColors(
       new Color('#811242'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkComp2.toHex()).toBe('#127a81');
@@ -180,7 +240,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [brandRedOrig, brandRedComp2, brandRedComp3] = getSplitComplementaryColors(
       new Color('#de0d14'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedComp2.toHex()).toBe('#0d7cde');
@@ -190,7 +251,8 @@ describe('getSplitComplementaryColors', () => {
   it('returns split complement colors for grayscale colors', () => {
     const [blackOrig, blackComp2, blackComp3] = getSplitComplementaryColors(
       new Color('#000000'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackComp2.toHex()).toBe('#d4d4d4');
@@ -198,7 +260,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [whiteOrig, whiteComp2, whiteComp3] = getSplitComplementaryColors(
       new Color('#ffffff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteComp2.toHex()).toBe('#2b2b2b');
@@ -206,7 +269,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [lightGrayOrig, lightGrayComp2, lightGrayComp3] = getSplitComplementaryColors(
       new Color('#d3d3d3'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayComp2.toHex()).toBe('#474747');
@@ -214,7 +278,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [grayOrig, grayComp2, grayComp3] = getSplitComplementaryColors(
       new Color('#808080'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayComp2.toHex()).toBe('#808080');
@@ -222,7 +287,8 @@ describe('getSplitComplementaryColors', () => {
 
     const [darkGrayOrig, darkGrayComp2, darkGrayComp3] = getSplitComplementaryColors(
       new Color('#333333'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayComp2.toHex()).toBe('#b3b3b3');
@@ -235,7 +301,7 @@ describe('getSplitComplementaryColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#d4d4d4', '#d4d4d4']);
 
@@ -244,7 +310,7 @@ describe('getSplitComplementaryColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000']);
   });
@@ -254,7 +320,8 @@ describe('getTriadicHarmonyColors', () => {
   it('returns triadic harmony colors for primary colors', () => {
     const [redOrig, redTriad2, redTriad3] = getTriadicHarmonyColors(
       new Color('#ff0000'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redTriad2.toHex()).toBe('#0000ff');
@@ -262,7 +329,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(
       new Color('#00ff00'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenTriad2.toHex()).toBe('#ff0000');
@@ -270,7 +338,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [blueOrig, blueTriad2, blueTriad3] = getTriadicHarmonyColors(
       new Color('#0000ff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueTriad2.toHex()).toBe('#00ff00');
@@ -280,7 +349,8 @@ describe('getTriadicHarmonyColors', () => {
   it('returns triadic harmony colors for brand colors', () => {
     const [purpleOrig, purpleTriad2, purpleTriad3] = getTriadicHarmonyColors(
       new Color('#ee6ffc'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleTriad2.toHex()).toBe('#6ffcee');
@@ -288,7 +358,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [brandBlueOrig, brandBlueTriad2, brandBlueTriad3] = getTriadicHarmonyColors(
       new Color('#2e3575'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlueTriad2.toHex()).toBe('#35752e');
@@ -296,7 +367,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [yellowOrig, yellowTriad2, yellowTriad3] = getTriadicHarmonyColors(
       new Color('#d3e204'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowTriad2.toHex()).toBe('#e204d3');
@@ -304,7 +376,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(
       new Color('#29cc53'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenTriad2.toHex()).toBe('#cc5329');
@@ -312,7 +385,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [pinkOrig, pinkTriad2, pinkTriad3] = getTriadicHarmonyColors(
       new Color('#811242'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkTriad2.toHex()).toBe('#124281');
@@ -320,7 +394,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [brandRedOrig, brandRedTriad2, brandRedTriad3] = getTriadicHarmonyColors(
       new Color('#de0d14'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedTriad2.toHex()).toBe('#0d14de');
@@ -330,7 +405,8 @@ describe('getTriadicHarmonyColors', () => {
   it('returns triadic harmony colors for grayscale colors', () => {
     const [blackOrig, blackTriad2, blackTriad3] = getTriadicHarmonyColors(
       new Color('#000000'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackTriad2.toHex()).toBe('#ababab');
@@ -338,7 +414,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [whiteOrig, whiteTriad2, whiteTriad3] = getTriadicHarmonyColors(
       new Color('#ffffff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteTriad2.toHex()).toBe('#545454');
@@ -346,7 +423,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [lightGrayOrig, lightGrayTriad2, lightGrayTriad3] = getTriadicHarmonyColors(
       new Color('#d3d3d3'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayTriad2.toHex()).toBe('#636363');
@@ -354,7 +432,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [grayOrig, grayTriad2, grayTriad3] = getTriadicHarmonyColors(
       new Color('#808080'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayTriad2.toHex()).toBe('#808080');
@@ -362,7 +441,8 @@ describe('getTriadicHarmonyColors', () => {
 
     const [darkGrayOrig, darkGrayTriad2, darkGrayTriad3] = getTriadicHarmonyColors(
       new Color('#333333'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayTriad2.toHex()).toBe('#999999');
@@ -375,7 +455,7 @@ describe('getTriadicHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#ababab', '#ababab']);
 
@@ -384,7 +464,7 @@ describe('getTriadicHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000']);
   });
@@ -392,7 +472,11 @@ describe('getTriadicHarmonyColors', () => {
 
 describe('getSquareHarmonyColors', () => {
   it('returns square harmony colors for primary colors', () => {
-    const [red1, red2, red3, red4] = getSquareHarmonyColors(new Color('#ff0000'), createColor);
+    const [red1, red2, red3, red4] = getSquareHarmonyColors(
+      new Color('#ff0000'),
+      {},
+      createColorInstance,
+    );
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#80ff00');
     expect(red3.toHex()).toBe('#00ffff');
@@ -400,14 +484,19 @@ describe('getSquareHarmonyColors', () => {
 
     const [green1, green2, green3, green4] = getSquareHarmonyColors(
       new Color('#00ff00'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#0080ff');
     expect(green3.toHex()).toBe('#ff00ff');
     expect(green4.toHex()).toBe('#ff8000');
 
-    const [blue1, blue2, blue3, blue4] = getSquareHarmonyColors(new Color('#0000ff'), createColor);
+    const [blue1, blue2, blue3, blue4] = getSquareHarmonyColors(
+      new Color('#0000ff'),
+      {},
+      createColorInstance,
+    );
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#ff0080');
     expect(blue3.toHex()).toBe('#ffff00');
@@ -417,7 +506,8 @@ describe('getSquareHarmonyColors', () => {
   it('returns square harmony colors for brand colors', () => {
     const [purple1, purple2, purple3, purple4] = getSquareHarmonyColors(
       new Color('#ee6ffc'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fca76f');
@@ -426,7 +516,8 @@ describe('getSquareHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4] = getSquareHarmonyColors(
       new Color('#2e3575'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#752e58');
@@ -435,7 +526,8 @@ describe('getSquareHarmonyColors', () => {
 
     const [yellow1, yellow2, yellow3, yellow4] = getSquareHarmonyColors(
       new Color('#d3e204'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#04e282');
@@ -444,14 +536,19 @@ describe('getSquareHarmonyColors', () => {
 
     const [green1, green2b, green3b, green4b] = getSquareHarmonyColors(
       new Color('#29cc53'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(green1.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#2950cc');
     expect(green3b.toHex()).toBe('#cc29a2');
     expect(green4b.toHex()).toBe('#cca429');
 
-    const [pink1, pink2, pink3, pink4] = getSquareHarmonyColors(new Color('#811242'), createColor);
+    const [pink1, pink2, pink3, pink4] = getSquareHarmonyColors(
+      new Color('#811242'),
+      undefined,
+      createColorInstance,
+    );
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#7a8112');
     expect(pink3.toHex()).toBe('#128151');
@@ -459,7 +556,8 @@ describe('getSquareHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4] = getSquareHarmonyColors(
       new Color('#de0d14'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#7cde0d');
@@ -470,7 +568,8 @@ describe('getSquareHarmonyColors', () => {
   it('returns square harmony colors for grayscale colors', () => {
     const [black1, black2, black3, black4] = getSquareHarmonyColors(
       new Color('#000000'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#808080');
@@ -479,7 +578,8 @@ describe('getSquareHarmonyColors', () => {
 
     const [white1, white2, white3, white4] = getSquareHarmonyColors(
       new Color('#ffffff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#808080');
@@ -488,14 +588,19 @@ describe('getSquareHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4] = getSquareHarmonyColors(
       new Color('#d3d3d3'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#808080');
     expect(lightGray3.toHex()).toBe('#2b2b2b');
     expect(lightGray4.toHex()).toBe('#808080');
 
-    const [gray1, gray2, gray3, gray4] = getSquareHarmonyColors(new Color('#808080'), createColor);
+    const [gray1, gray2, gray3, gray4] = getSquareHarmonyColors(
+      new Color('#808080'),
+      {},
+      createColorInstance,
+    );
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
     expect(gray3.toHex()).toBe('#808080');
@@ -503,7 +608,8 @@ describe('getSquareHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4] = getSquareHarmonyColors(
       new Color('#333333'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#808080');
@@ -517,7 +623,7 @@ describe('getSquareHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#808080', '#ffffff', '#808080']);
 
@@ -526,7 +632,7 @@ describe('getSquareHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000']);
   });
@@ -534,7 +640,11 @@ describe('getSquareHarmonyColors', () => {
 
 describe('getTetradicHarmonyColors', () => {
   it('returns tetradic harmony colors for primary colors', () => {
-    const [red1, red2, red3, red4] = getTetradicHarmonyColors(new Color('#ff0000'), createColor);
+    const [red1, red2, red3, red4] = getTetradicHarmonyColors(
+      new Color('#ff0000'),
+      {},
+      createColorInstance,
+    );
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ffff00');
     expect(red3.toHex()).toBe('#00ffff');
@@ -542,7 +652,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [green1, green2, green3, green4] = getTetradicHarmonyColors(
       new Color('#00ff00'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#00ffff');
@@ -551,7 +662,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [blue1, blue2, blue3, blue4] = getTetradicHarmonyColors(
       new Color('#0000ff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#ff00ff');
@@ -562,7 +674,8 @@ describe('getTetradicHarmonyColors', () => {
   it('returns tetradic harmony colors for brand colors', () => {
     const [purple1, purple2, purple3, purple4] = getTetradicHarmonyColors(
       new Color('#ee6ffc'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fc6f7d');
@@ -571,7 +684,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4] = getTetradicHarmonyColors(
       new Color('#2e3575'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#6e2e75');
@@ -580,7 +694,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [yellow1, yellow2, yellow3, yellow4] = getTetradicHarmonyColors(
       new Color('#d3e204'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#04e213');
@@ -589,7 +704,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [green1b, green2b, green3b, green4b] = getTetradicHarmonyColors(
       new Color('#29cc53'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(green1b.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#29a2cc');
@@ -598,7 +714,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [pink1, pink2, pink3, pink4] = getTetradicHarmonyColors(
       new Color('#811242'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#815112');
@@ -607,7 +724,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4] = getTetradicHarmonyColors(
       new Color('#de0d14'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#ded70d');
@@ -618,7 +736,8 @@ describe('getTetradicHarmonyColors', () => {
   it('returns tetradic harmony colors for grayscale colors', () => {
     const [black1, black2, black3, black4] = getTetradicHarmonyColors(
       new Color('#000000'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#545454');
@@ -627,7 +746,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [white1, white2, white3, white4] = getTetradicHarmonyColors(
       new Color('#ffffff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#ababab');
@@ -636,7 +756,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4] = getTetradicHarmonyColors(
       new Color('#d3d3d3'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#9c9c9c');
@@ -645,7 +766,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [gray1, gray2, gray3, gray4] = getTetradicHarmonyColors(
       new Color('#808080'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
@@ -654,7 +776,8 @@ describe('getTetradicHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4] = getTetradicHarmonyColors(
       new Color('#333333'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#666666');
@@ -668,7 +791,7 @@ describe('getTetradicHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#545454', '#ffffff', '#ababab']);
 
@@ -677,7 +800,7 @@ describe('getTetradicHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000']);
   });
@@ -687,7 +810,8 @@ describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for primary colors', () => {
     const [red1, red2, red3, red4, red5] = getAnalogousHarmonyColors(
       new Color('#ff0000'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ff0080');
@@ -697,7 +821,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [green1, green2, green3, green4, green5] = getAnalogousHarmonyColors(
       new Color('#00ff00'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#80ff00');
@@ -707,7 +832,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [blue1, blue2, blue3, blue4, blue5] = getAnalogousHarmonyColors(
       new Color('#0000ff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#0080ff');
@@ -719,7 +845,8 @@ describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for brand colors', () => {
     const [purple1, purple2, purple3, purple4, purple5] = getAnalogousHarmonyColors(
       new Color('#ee6ffc'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#a76ffc');
@@ -729,7 +856,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4, brandBlue5] = getAnalogousHarmonyColors(
       new Color('#2e3575'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#2e5875');
@@ -739,7 +867,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [yellow1, yellow2, yellow3, yellow4, yellow5] = getAnalogousHarmonyColors(
       new Color('#d3e204'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#e28204');
@@ -749,7 +878,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [green1b, green2b, green3b, green4b, green5b] = getAnalogousHarmonyColors(
       new Color('#29cc53'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(green1b.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#51cc29');
@@ -759,7 +889,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [pink1, pink2, pink3, pink4, pink5] = getAnalogousHarmonyColors(
       new Color('#811242'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#81127a');
@@ -769,7 +900,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4, brandRed5] = getAnalogousHarmonyColors(
       new Color('#de0d14'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#de0d7c');
@@ -781,7 +913,8 @@ describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for grayscale colors', () => {
     const [black1, black2, black3, black4, black5] = getAnalogousHarmonyColors(
       new Color('#000000'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#2b2b2b');
@@ -791,7 +924,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [white1, white2, white3, white4, white5] = getAnalogousHarmonyColors(
       new Color('#ffffff'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#d4d4d4');
@@ -801,7 +935,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4, lightGray5] = getAnalogousHarmonyColors(
       new Color('#d3d3d3'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#b8b8b8');
@@ -811,7 +946,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [gray1, gray2, gray3, gray4, gray5] = getAnalogousHarmonyColors(
       new Color('#808080'),
-      createColor,
+      {},
+      createColorInstance,
     );
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
@@ -821,7 +957,8 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4, darkGray5] = getAnalogousHarmonyColors(
       new Color('#333333'),
-      createColor,
+      undefined,
+      createColorInstance,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#4d4d4d');
@@ -836,7 +973,7 @@ describe('getAnalogousHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'SPIN_LIGHTNESS',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#2b2b2b', '#2b2b2b', '#545454', '#545454']);
 
@@ -845,7 +982,7 @@ describe('getAnalogousHarmonyColors', () => {
       {
         grayscaleHandlingMode: 'IGNORE',
       },
-      createColor,
+      createColorInstance,
     ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000', '#000000']);
   });
@@ -856,7 +993,7 @@ describe('getMonochromaticHarmonyColors', () => {
     const start = new Color({ h: 210, s: 60, l: 50 });
     const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
       start,
-      createColor,
+      createColorInstance,
     );
     const [baseHsl, lighterHsl, darkerHsl, saturatedHsl, desaturatedHsl] = [
       base.toHSL(),
@@ -885,7 +1022,7 @@ describe('getMonochromaticHarmonyColors', () => {
   it('clamps saturation and lightness', () => {
     const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
       new Color({ h: 10, s: 5, l: 95 }),
-      createColor,
+      createColorInstance,
     );
     const [baseHsl, lighterHsl, darkerHsl, saturatedHsl, desaturatedHsl] = [
       base.toHSL(),
@@ -914,7 +1051,7 @@ describe('getMonochromaticHarmonyColors', () => {
   it('returns monochromatic harmony colors for diverse inputs', () => {
     const [redOrig, red2, red3, red4, red5] = getMonochromaticHarmonyColors(
       new Color('#ff0000'),
-      createColor,
+      createColorInstance,
     );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ff6666');
@@ -924,7 +1061,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [greenOrig, green2, green3, green4, green5] = getMonochromaticHarmonyColors(
       new Color('#00ff00'),
-      createColor,
+      createColorInstance,
     );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#66ff66');
@@ -934,7 +1071,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [blueOrig, blue2, blue3, blue4, blue5] = getMonochromaticHarmonyColors(
       new Color('#0000ff'),
-      createColor,
+      createColorInstance,
     );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#6666ff');
@@ -944,7 +1081,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [purpleOrig, purple2, purple3, purple4, purple5] = getMonochromaticHarmonyColors(
       new Color('#ee6ffc'),
-      createColor,
+      createColorInstance,
     );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fad3fe');
@@ -953,7 +1090,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(purple5.toHex()).toBe('#e27eed');
 
     const [brandBlueOrig, brandBlue2, brandBlue3, brandBlue4, brandBlue5] =
-      getMonochromaticHarmonyColors(new Color('#2e3575'), createColor);
+      getMonochromaticHarmonyColors(new Color('#2e3575'), createColorInstance);
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#4f5aba');
     expect(brandBlue3.toHex()).toBe('#11142c');
@@ -962,7 +1099,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [yellowOrig, yellow2, yellow3, yellow4, yellow5] = getMonochromaticHarmonyColors(
       new Color('#d3e204'),
-      createColor,
+      createColorInstance,
     );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#f0fc50');
@@ -971,7 +1108,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(yellow5.toHex()).toBe('#bfcb1b');
 
     const [brandGreenOrig, brandGreen2, brandGreen3, brandGreen4, brandGreen5] =
-      getMonochromaticHarmonyColors(new Color('#29cc53'), createColor);
+      getMonochromaticHarmonyColors(new Color('#29cc53'), createColorInstance);
     expect(brandGreenOrig.toHex()).toBe('#29cc53');
     expect(brandGreen2.toHex()).toBe('#77e493');
     expect(brandGreen3.toHex()).toBe('#187730');
@@ -980,7 +1117,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [pinkOrig, pink2, pink3, pink4, pink5] = getMonochromaticHarmonyColors(
       new Color('#811242'),
-      createColor,
+      createColorInstance,
     );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#db1e70');
@@ -989,7 +1126,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(pink5.toHex()).toBe('#722144');
 
     const [brandRedOrig, brandRed2, brandRed3, brandRed4, brandRed5] =
-      getMonochromaticHarmonyColors(new Color('#de0d14'), createColor);
+      getMonochromaticHarmonyColors(new Color('#de0d14'), createColorInstance);
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#f55c61');
     expect(brandRed3.toHex()).toBe('#7e070b');
@@ -998,7 +1135,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [blackOrig, black2, black3, black4, black5] = getMonochromaticHarmonyColors(
       new Color('#000000'),
-      createColor,
+      createColorInstance,
     );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#333333');
@@ -1008,7 +1145,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [whiteOrig, white2, white3, white4, white5] = getMonochromaticHarmonyColors(
       new Color('#ffffff'),
-      createColor,
+      createColorInstance,
     );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#ffffff');
@@ -1017,7 +1154,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(white5.toHex()).toBe('#ffffff');
 
     const [lightGrayOrig, lightGray2, lightGray3, lightGray4, lightGray5] =
-      getMonochromaticHarmonyColors(new Color('#d3d3d3'), createColor);
+      getMonochromaticHarmonyColors(new Color('#d3d3d3'), createColorInstance);
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#ffffff');
     expect(lightGray3.toHex()).toBe('#a0a0a0');
@@ -1026,7 +1163,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [grayOrig, gray2, gray3, gray4, gray5] = getMonochromaticHarmonyColors(
       new Color('#808080'),
-      createColor,
+      createColorInstance,
     );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#b3b3b3');
@@ -1035,7 +1172,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(gray5.toHex()).toBe('#808080');
 
     const [darkGrayOrig, darkGray2, darkGray3, darkGray4, darkGray5] =
-      getMonochromaticHarmonyColors(new Color('#333333'), createColor);
+      getMonochromaticHarmonyColors(new Color('#333333'), createColorInstance);
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#666666');
     expect(darkGray3.toHex()).toBe('#000000');
@@ -1046,7 +1183,7 @@ describe('getMonochromaticHarmonyColors', () => {
   it('keeps alpha across monochromatic variants', () => {
     const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
       new Color('rgba(20, 40, 60, 0.25)'),
-      createColor,
+      createColorInstance,
     );
 
     expect(base.toRGBA().a).toBeCloseTo(0.25, 5);
@@ -1060,40 +1197,55 @@ describe('getMonochromaticHarmonyColors', () => {
 describe('getHarmonyColors', () => {
   it('delegates to individual harmony functions', () => {
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'COMPLEMENTARY', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'COMPLEMENTARY', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#00ffff']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'SPLIT_COMPLEMENTARY', createColor).map((c) =>
-        c.toHex(),
-      ),
+      getHarmonyColors(
+        new Color('#ff0000'),
+        'SPLIT_COMPLEMENTARY',
+        undefined,
+        createColorInstance,
+      ).map((c) => c.toHex()),
     ).toEqual(['#ff0000', '#0080ff', '#00ff80']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'TRIADIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'TRIADIC', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#0000ff', '#00ff00']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'SQUARE', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'SQUARE', undefined, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#80ff00', '#00ffff', '#8000ff']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'TETRADIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'TETRADIC', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#ffff00', '#00ffff', '#0000ff']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'ANALOGOUS', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'ANALOGOUS', undefined, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#ff0080', '#ff8000', '#ff00ff', '#ffff00']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'MONOCHROMATIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'MONOCHROMATIC', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#ff6666', '#990000', '#ff0000', '#e61919']);
   });
 
   it('accepts mixed case harmony', () => {
     const c = new Color('red');
-    const h1 = getHarmonyColors(c, 'TRIADIC', createColor);
-    const h2 = getHarmonyColors(c, 'triadic', createColor);
+    const h1 = getHarmonyColors(c, 'TRIADIC', undefined, createColorInstance);
+    const h2 = getHarmonyColors(c, 'triadic', {}, createColorInstance);
 
     expect(h1.length).toBe(h2.length);
     expect(h1[1].toHex()).toBe(h2[1].toHex());
@@ -1101,39 +1253,51 @@ describe('getHarmonyColors', () => {
 
   it('delegates for brand purple as well', () => {
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'COMPLEMENTARY', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'COMPLEMENTARY', undefined, createColorInstance).map(
+        (c) => c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#7dfc6f']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'SPLIT_COMPLEMENTARY', createColor).map((c) =>
-        c.toHex(),
+      getHarmonyColors(new Color('#ee6ffc'), 'SPLIT_COMPLEMENTARY', {}, createColorInstance).map(
+        (c) => c.toHex(),
       ),
     ).toEqual(['#ee6ffc', '#6ffca7', '#c4fc6f']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'TRIADIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'TRIADIC', undefined, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#6ffcee', '#fcee6f']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'SQUARE', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'SQUARE', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#fca76f', '#7dfc6f', '#6fc4fc']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'TETRADIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'TETRADIC', undefined, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#fc6f7d', '#7dfc6f', '#6ffcee']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'ANALOGOUS', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'ANALOGOUS', {}, createColorInstance).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#a76ffc', '#fc6fc4', '#6f7dfc', '#fc6f7d']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'MONOCHROMATIC', createColor).map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'MONOCHROMATIC', undefined, createColorInstance).map(
+        (c) => c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#fad3fe', '#e20bfa', '#f06cff', '#e27eed']);
   });
 
   it('throws for unknown harmony type', () => {
     expect(() =>
-      getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony, createColor),
+      getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony, {}, createColorInstance),
     ).toThrow("Invalid 'harmony'");
   });
 
@@ -1144,7 +1308,7 @@ describe('getHarmonyColors', () => {
         {
           grayscaleHandlingMode: 'unknown' as never,
         },
-        createColor,
+        createColorInstance,
       ),
     ).toThrow("Invalid 'grayscaleHandlingMode'");
   });

--- a/src/color/__test__/harmonies.test.ts
+++ b/src/color/__test__/harmonies.test.ts
@@ -11,83 +11,99 @@ import {
   getTriadicHarmonyColors,
 } from '../harmonies';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('getComplementaryColors', () => {
   it('returns complementary pairs for primary colors', () => {
-    const [redOrig, redComp] = getComplementaryColors(new Color('#ff0000'));
+    const [redOrig, redComp] = getComplementaryColors(new Color('#ff0000'), createColor);
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redComp.toHex()).toBe('#00ffff');
 
-    const [greenOrig, greenComp] = getComplementaryColors(new Color('#00ff00'));
+    const [greenOrig, greenComp] = getComplementaryColors(new Color('#00ff00'), createColor);
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenComp.toHex()).toBe('#ff00ff');
 
-    const [blueOrig, blueComp] = getComplementaryColors(new Color('#0000ff'));
+    const [blueOrig, blueComp] = getComplementaryColors(new Color('#0000ff'), createColor);
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueComp.toHex()).toBe('#ffff00');
   });
 
   it('returns complementary pairs for brand colors', () => {
-    const [purpleOrig, purpleComp] = getComplementaryColors(new Color('#ee6ffc'));
+    const [purpleOrig, purpleComp] = getComplementaryColors(new Color('#ee6ffc'), createColor);
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleComp.toHex()).toBe('#7dfc6f');
 
-    const [blueOrig, blueComp] = getComplementaryColors(new Color('#2e3575'));
+    const [blueOrig, blueComp] = getComplementaryColors(new Color('#2e3575'), createColor);
     expect(blueOrig.toHex()).toBe('#2e3575');
     expect(blueComp.toHex()).toBe('#756e2e');
 
-    const [yellowOrig, yellowComp] = getComplementaryColors(new Color('#d3e204'));
+    const [yellowOrig, yellowComp] = getComplementaryColors(new Color('#d3e204'), createColor);
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowComp.toHex()).toBe('#1304e2');
 
-    const [greenOrig, greenComp] = getComplementaryColors(new Color('#29cc53'));
+    const [greenOrig, greenComp] = getComplementaryColors(new Color('#29cc53'), createColor);
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenComp.toHex()).toBe('#cc29a2');
 
-    const [pinkOrig, pinkComp] = getComplementaryColors(new Color('#811242'));
+    const [pinkOrig, pinkComp] = getComplementaryColors(new Color('#811242'), createColor);
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkComp.toHex()).toBe('#128151');
 
-    const [brandRedOrig, brandRedComp] = getComplementaryColors(new Color('#de0d14'));
+    const [brandRedOrig, brandRedComp] = getComplementaryColors(new Color('#de0d14'), createColor);
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedComp.toHex()).toBe('#0dded7');
   });
 
   it('returns complementary pairs for grayscale colors', () => {
-    const [blackOrig, blackComp] = getComplementaryColors(new Color('#000000'));
+    const [blackOrig, blackComp] = getComplementaryColors(new Color('#000000'), createColor);
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackComp.toHex()).toBe('#ffffff');
 
-    const [whiteOrig, whiteComp] = getComplementaryColors(new Color('#ffffff'));
+    const [whiteOrig, whiteComp] = getComplementaryColors(new Color('#ffffff'), createColor);
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteComp.toHex()).toBe('#000000');
 
-    const [lightGrayOrig, lightGrayComp] = getComplementaryColors(new Color('#d3d3d3'));
+    const [lightGrayOrig, lightGrayComp] = getComplementaryColors(
+      new Color('#d3d3d3'),
+      createColor,
+    );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayComp.toHex()).toBe('#2b2b2b');
 
-    const [grayOrig, grayComp] = getComplementaryColors(new Color('#808080'));
+    const [grayOrig, grayComp] = getComplementaryColors(new Color('#808080'), createColor);
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayComp.toHex()).toBe('#808080');
 
-    const [darkGrayOrig, darkGrayComp] = getComplementaryColors(new Color('#333333'));
+    const [darkGrayOrig, darkGrayComp] = getComplementaryColors(new Color('#333333'), createColor);
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayComp.toHex()).toBe('#cccccc');
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getComplementaryColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getComplementaryColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#ffffff']);
 
-    const ignore = getComplementaryColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getComplementaryColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000']);
   });
 
   it('preserves alpha when creating complements', () => {
-    const [base, complement] = getComplementaryColors(new Color('rgba(255, 0, 0, 0.4)'));
+    const [base, complement] = getComplementaryColors(
+      new Color('rgba(255, 0, 0, 0.4)'),
+      createColor,
+    );
     expect(base.toRGBA().a).toBeCloseTo(0.4, 5);
     expect(complement.toRGBA().a).toBeCloseTo(0.4, 5);
     expect(complement.toHex8()).toBe('#00ffff66');
@@ -96,17 +112,26 @@ describe('getComplementaryColors', () => {
 
 describe('getSplitComplementaryColors', () => {
   it('returns split complement colors for primary colors', () => {
-    const [redOrig, redComp2, redComp3] = getSplitComplementaryColors(new Color('#ff0000'));
+    const [redOrig, redComp2, redComp3] = getSplitComplementaryColors(
+      new Color('#ff0000'),
+      createColor,
+    );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redComp2.toHex()).toBe('#0080ff');
     expect(redComp3.toHex()).toBe('#00ff80');
 
-    const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(new Color('#00ff00'));
+    const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(
+      new Color('#00ff00'),
+      createColor,
+    );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenComp2.toHex()).toBe('#ff0080');
     expect(greenComp3.toHex()).toBe('#8000ff');
 
-    const [blueOrig, blueComp2, blueComp3] = getSplitComplementaryColors(new Color('#0000ff'));
+    const [blueOrig, blueComp2, blueComp3] = getSplitComplementaryColors(
+      new Color('#0000ff'),
+      createColor,
+    );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueComp2.toHex()).toBe('#80ff00');
     expect(blueComp3.toHex()).toBe('#ff8000');
@@ -115,6 +140,7 @@ describe('getSplitComplementaryColors', () => {
   it('returns split complement colors for brand colors', () => {
     const [purpleOrig, purpleComp2, purpleComp3] = getSplitComplementaryColors(
       new Color('#ee6ffc'),
+      createColor,
     );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleComp2.toHex()).toBe('#6ffca7');
@@ -122,6 +148,7 @@ describe('getSplitComplementaryColors', () => {
 
     const [brandBlueOrig, brandBlueComp2, brandBlueComp3] = getSplitComplementaryColors(
       new Color('#2e3575'),
+      createColor,
     );
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlueComp2.toHex()).toBe('#58752e');
@@ -129,23 +156,31 @@ describe('getSplitComplementaryColors', () => {
 
     const [yellowOrig, yellowComp2, yellowComp3] = getSplitComplementaryColors(
       new Color('#d3e204'),
+      createColor,
     );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowComp2.toHex()).toBe('#8204e2');
     expect(yellowComp3.toHex()).toBe('#0464e2');
 
-    const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(new Color('#29cc53'));
+    const [greenOrig, greenComp2, greenComp3] = getSplitComplementaryColors(
+      new Color('#29cc53'),
+      createColor,
+    );
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenComp2.toHex()).toBe('#cc2951');
     expect(greenComp3.toHex()).toBe('#a429cc');
 
-    const [pinkOrig, pinkComp2, pinkComp3] = getSplitComplementaryColors(new Color('#811242'));
+    const [pinkOrig, pinkComp2, pinkComp3] = getSplitComplementaryColors(
+      new Color('#811242'),
+      createColor,
+    );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkComp2.toHex()).toBe('#127a81');
     expect(pinkComp3.toHex()).toBe('#128119');
 
     const [brandRedOrig, brandRedComp2, brandRedComp3] = getSplitComplementaryColors(
       new Color('#de0d14'),
+      createColor,
     );
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedComp2.toHex()).toBe('#0d7cde');
@@ -153,30 +188,41 @@ describe('getSplitComplementaryColors', () => {
   });
 
   it('returns split complement colors for grayscale colors', () => {
-    const [blackOrig, blackComp2, blackComp3] = getSplitComplementaryColors(new Color('#000000'));
+    const [blackOrig, blackComp2, blackComp3] = getSplitComplementaryColors(
+      new Color('#000000'),
+      createColor,
+    );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackComp2.toHex()).toBe('#d4d4d4');
     expect(blackComp3.toHex()).toBe('#d4d4d4');
 
-    const [whiteOrig, whiteComp2, whiteComp3] = getSplitComplementaryColors(new Color('#ffffff'));
+    const [whiteOrig, whiteComp2, whiteComp3] = getSplitComplementaryColors(
+      new Color('#ffffff'),
+      createColor,
+    );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteComp2.toHex()).toBe('#2b2b2b');
     expect(whiteComp3.toHex()).toBe('#2b2b2b');
 
     const [lightGrayOrig, lightGrayComp2, lightGrayComp3] = getSplitComplementaryColors(
       new Color('#d3d3d3'),
+      createColor,
     );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayComp2.toHex()).toBe('#474747');
     expect(lightGrayComp3.toHex()).toBe('#474747');
 
-    const [grayOrig, grayComp2, grayComp3] = getSplitComplementaryColors(new Color('#808080'));
+    const [grayOrig, grayComp2, grayComp3] = getSplitComplementaryColors(
+      new Color('#808080'),
+      createColor,
+    );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayComp2.toHex()).toBe('#808080');
     expect(grayComp3.toHex()).toBe('#808080');
 
     const [darkGrayOrig, darkGrayComp2, darkGrayComp3] = getSplitComplementaryColors(
       new Color('#333333'),
+      createColor,
     );
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayComp2.toHex()).toBe('#b3b3b3');
@@ -184,66 +230,97 @@ describe('getSplitComplementaryColors', () => {
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getSplitComplementaryColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getSplitComplementaryColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#d4d4d4', '#d4d4d4']);
 
-    const ignore = getSplitComplementaryColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getSplitComplementaryColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000']);
   });
 });
 
 describe('getTriadicHarmonyColors', () => {
   it('returns triadic harmony colors for primary colors', () => {
-    const [redOrig, redTriad2, redTriad3] = getTriadicHarmonyColors(new Color('#ff0000'));
+    const [redOrig, redTriad2, redTriad3] = getTriadicHarmonyColors(
+      new Color('#ff0000'),
+      createColor,
+    );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(redTriad2.toHex()).toBe('#0000ff');
     expect(redTriad3.toHex()).toBe('#00ff00');
 
-    const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(new Color('#00ff00'));
+    const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(
+      new Color('#00ff00'),
+      createColor,
+    );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(greenTriad2.toHex()).toBe('#ff0000');
     expect(greenTriad3.toHex()).toBe('#0000ff');
 
-    const [blueOrig, blueTriad2, blueTriad3] = getTriadicHarmonyColors(new Color('#0000ff'));
+    const [blueOrig, blueTriad2, blueTriad3] = getTriadicHarmonyColors(
+      new Color('#0000ff'),
+      createColor,
+    );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blueTriad2.toHex()).toBe('#00ff00');
     expect(blueTriad3.toHex()).toBe('#ff0000');
   });
 
   it('returns triadic harmony colors for brand colors', () => {
-    const [purpleOrig, purpleTriad2, purpleTriad3] = getTriadicHarmonyColors(new Color('#ee6ffc'));
+    const [purpleOrig, purpleTriad2, purpleTriad3] = getTriadicHarmonyColors(
+      new Color('#ee6ffc'),
+      createColor,
+    );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purpleTriad2.toHex()).toBe('#6ffcee');
     expect(purpleTriad3.toHex()).toBe('#fcee6f');
 
     const [brandBlueOrig, brandBlueTriad2, brandBlueTriad3] = getTriadicHarmonyColors(
       new Color('#2e3575'),
+      createColor,
     );
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlueTriad2.toHex()).toBe('#35752e');
     expect(brandBlueTriad3.toHex()).toBe('#752e35');
 
-    const [yellowOrig, yellowTriad2, yellowTriad3] = getTriadicHarmonyColors(new Color('#d3e204'));
+    const [yellowOrig, yellowTriad2, yellowTriad3] = getTriadicHarmonyColors(
+      new Color('#d3e204'),
+      createColor,
+    );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellowTriad2.toHex()).toBe('#e204d3');
     expect(yellowTriad3.toHex()).toBe('#04d3e2');
 
-    const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(new Color('#29cc53'));
+    const [greenOrig, greenTriad2, greenTriad3] = getTriadicHarmonyColors(
+      new Color('#29cc53'),
+      createColor,
+    );
     expect(greenOrig.toHex()).toBe('#29cc53');
     expect(greenTriad2.toHex()).toBe('#cc5329');
     expect(greenTriad3.toHex()).toBe('#5329cc');
 
-    const [pinkOrig, pinkTriad2, pinkTriad3] = getTriadicHarmonyColors(new Color('#811242'));
+    const [pinkOrig, pinkTriad2, pinkTriad3] = getTriadicHarmonyColors(
+      new Color('#811242'),
+      createColor,
+    );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pinkTriad2.toHex()).toBe('#124281');
     expect(pinkTriad3.toHex()).toBe('#428112');
 
     const [brandRedOrig, brandRedTriad2, brandRedTriad3] = getTriadicHarmonyColors(
       new Color('#de0d14'),
+      createColor,
     );
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRedTriad2.toHex()).toBe('#0d14de');
@@ -251,30 +328,41 @@ describe('getTriadicHarmonyColors', () => {
   });
 
   it('returns triadic harmony colors for grayscale colors', () => {
-    const [blackOrig, blackTriad2, blackTriad3] = getTriadicHarmonyColors(new Color('#000000'));
+    const [blackOrig, blackTriad2, blackTriad3] = getTriadicHarmonyColors(
+      new Color('#000000'),
+      createColor,
+    );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(blackTriad2.toHex()).toBe('#ababab');
     expect(blackTriad3.toHex()).toBe('#ababab');
 
-    const [whiteOrig, whiteTriad2, whiteTriad3] = getTriadicHarmonyColors(new Color('#ffffff'));
+    const [whiteOrig, whiteTriad2, whiteTriad3] = getTriadicHarmonyColors(
+      new Color('#ffffff'),
+      createColor,
+    );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(whiteTriad2.toHex()).toBe('#545454');
     expect(whiteTriad3.toHex()).toBe('#545454');
 
     const [lightGrayOrig, lightGrayTriad2, lightGrayTriad3] = getTriadicHarmonyColors(
       new Color('#d3d3d3'),
+      createColor,
     );
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGrayTriad2.toHex()).toBe('#636363');
     expect(lightGrayTriad3.toHex()).toBe('#636363');
 
-    const [grayOrig, grayTriad2, grayTriad3] = getTriadicHarmonyColors(new Color('#808080'));
+    const [grayOrig, grayTriad2, grayTriad3] = getTriadicHarmonyColors(
+      new Color('#808080'),
+      createColor,
+    );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(grayTriad2.toHex()).toBe('#808080');
     expect(grayTriad3.toHex()).toBe('#808080');
 
     const [darkGrayOrig, darkGrayTriad2, darkGrayTriad3] = getTriadicHarmonyColors(
       new Color('#333333'),
+      createColor,
     );
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGrayTriad2.toHex()).toBe('#999999');
@@ -282,33 +370,44 @@ describe('getTriadicHarmonyColors', () => {
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getTriadicHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getTriadicHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#ababab', '#ababab']);
 
-    const ignore = getTriadicHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getTriadicHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000']);
   });
 });
 
 describe('getSquareHarmonyColors', () => {
   it('returns square harmony colors for primary colors', () => {
-    const [red1, red2, red3, red4] = getSquareHarmonyColors(new Color('#ff0000'));
+    const [red1, red2, red3, red4] = getSquareHarmonyColors(new Color('#ff0000'), createColor);
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#80ff00');
     expect(red3.toHex()).toBe('#00ffff');
     expect(red4.toHex()).toBe('#8000ff');
 
-    const [green1, green2, green3, green4] = getSquareHarmonyColors(new Color('#00ff00'));
+    const [green1, green2, green3, green4] = getSquareHarmonyColors(
+      new Color('#00ff00'),
+      createColor,
+    );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#0080ff');
     expect(green3.toHex()).toBe('#ff00ff');
     expect(green4.toHex()).toBe('#ff8000');
 
-    const [blue1, blue2, blue3, blue4] = getSquareHarmonyColors(new Color('#0000ff'));
+    const [blue1, blue2, blue3, blue4] = getSquareHarmonyColors(new Color('#0000ff'), createColor);
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#ff0080');
     expect(blue3.toHex()).toBe('#ffff00');
@@ -316,7 +415,10 @@ describe('getSquareHarmonyColors', () => {
   });
 
   it('returns square harmony colors for brand colors', () => {
-    const [purple1, purple2, purple3, purple4] = getSquareHarmonyColors(new Color('#ee6ffc'));
+    const [purple1, purple2, purple3, purple4] = getSquareHarmonyColors(
+      new Color('#ee6ffc'),
+      createColor,
+    );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fca76f');
     expect(purple3.toHex()).toBe('#7dfc6f');
@@ -324,25 +426,32 @@ describe('getSquareHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4] = getSquareHarmonyColors(
       new Color('#2e3575'),
+      createColor,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#752e58');
     expect(brandBlue3.toHex()).toBe('#756e2e');
     expect(brandBlue4.toHex()).toBe('#2e754b');
 
-    const [yellow1, yellow2, yellow3, yellow4] = getSquareHarmonyColors(new Color('#d3e204'));
+    const [yellow1, yellow2, yellow3, yellow4] = getSquareHarmonyColors(
+      new Color('#d3e204'),
+      createColor,
+    );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#04e282');
     expect(yellow3.toHex()).toBe('#1304e2');
     expect(yellow4.toHex()).toBe('#e20464');
 
-    const [green1, green2b, green3b, green4b] = getSquareHarmonyColors(new Color('#29cc53'));
+    const [green1, green2b, green3b, green4b] = getSquareHarmonyColors(
+      new Color('#29cc53'),
+      createColor,
+    );
     expect(green1.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#2950cc');
     expect(green3b.toHex()).toBe('#cc29a2');
     expect(green4b.toHex()).toBe('#cca429');
 
-    const [pink1, pink2, pink3, pink4] = getSquareHarmonyColors(new Color('#811242'));
+    const [pink1, pink2, pink3, pink4] = getSquareHarmonyColors(new Color('#811242'), createColor);
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#7a8112');
     expect(pink3.toHex()).toBe('#128151');
@@ -350,6 +459,7 @@ describe('getSquareHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4] = getSquareHarmonyColors(
       new Color('#de0d14'),
+      createColor,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#7cde0d');
@@ -358,13 +468,19 @@ describe('getSquareHarmonyColors', () => {
   });
 
   it('returns square harmony colors for grayscale colors', () => {
-    const [black1, black2, black3, black4] = getSquareHarmonyColors(new Color('#000000'));
+    const [black1, black2, black3, black4] = getSquareHarmonyColors(
+      new Color('#000000'),
+      createColor,
+    );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#808080');
     expect(black3.toHex()).toBe('#ffffff');
     expect(black4.toHex()).toBe('#808080');
 
-    const [white1, white2, white3, white4] = getSquareHarmonyColors(new Color('#ffffff'));
+    const [white1, white2, white3, white4] = getSquareHarmonyColors(
+      new Color('#ffffff'),
+      createColor,
+    );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#808080');
     expect(white3.toHex()).toBe('#000000');
@@ -372,13 +488,14 @@ describe('getSquareHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4] = getSquareHarmonyColors(
       new Color('#d3d3d3'),
+      createColor,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#808080');
     expect(lightGray3.toHex()).toBe('#2b2b2b');
     expect(lightGray4.toHex()).toBe('#808080');
 
-    const [gray1, gray2, gray3, gray4] = getSquareHarmonyColors(new Color('#808080'));
+    const [gray1, gray2, gray3, gray4] = getSquareHarmonyColors(new Color('#808080'), createColor);
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
     expect(gray3.toHex()).toBe('#808080');
@@ -386,6 +503,7 @@ describe('getSquareHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4] = getSquareHarmonyColors(
       new Color('#333333'),
+      createColor,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#808080');
@@ -394,33 +512,47 @@ describe('getSquareHarmonyColors', () => {
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getSquareHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getSquareHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#808080', '#ffffff', '#808080']);
 
-    const ignore = getSquareHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getSquareHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000']);
   });
 });
 
 describe('getTetradicHarmonyColors', () => {
   it('returns tetradic harmony colors for primary colors', () => {
-    const [red1, red2, red3, red4] = getTetradicHarmonyColors(new Color('#ff0000'));
+    const [red1, red2, red3, red4] = getTetradicHarmonyColors(new Color('#ff0000'), createColor);
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ffff00');
     expect(red3.toHex()).toBe('#00ffff');
     expect(red4.toHex()).toBe('#0000ff');
 
-    const [green1, green2, green3, green4] = getTetradicHarmonyColors(new Color('#00ff00'));
+    const [green1, green2, green3, green4] = getTetradicHarmonyColors(
+      new Color('#00ff00'),
+      createColor,
+    );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#00ffff');
     expect(green3.toHex()).toBe('#ff00ff');
     expect(green4.toHex()).toBe('#ff0000');
 
-    const [blue1, blue2, blue3, blue4] = getTetradicHarmonyColors(new Color('#0000ff'));
+    const [blue1, blue2, blue3, blue4] = getTetradicHarmonyColors(
+      new Color('#0000ff'),
+      createColor,
+    );
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#ff00ff');
     expect(blue3.toHex()).toBe('#ffff00');
@@ -428,7 +560,10 @@ describe('getTetradicHarmonyColors', () => {
   });
 
   it('returns tetradic harmony colors for brand colors', () => {
-    const [purple1, purple2, purple3, purple4] = getTetradicHarmonyColors(new Color('#ee6ffc'));
+    const [purple1, purple2, purple3, purple4] = getTetradicHarmonyColors(
+      new Color('#ee6ffc'),
+      createColor,
+    );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fc6f7d');
     expect(purple3.toHex()).toBe('#7dfc6f');
@@ -436,25 +571,35 @@ describe('getTetradicHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4] = getTetradicHarmonyColors(
       new Color('#2e3575'),
+      createColor,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#6e2e75');
     expect(brandBlue3.toHex()).toBe('#756e2e');
     expect(brandBlue4.toHex()).toBe('#35752e');
 
-    const [yellow1, yellow2, yellow3, yellow4] = getTetradicHarmonyColors(new Color('#d3e204'));
+    const [yellow1, yellow2, yellow3, yellow4] = getTetradicHarmonyColors(
+      new Color('#d3e204'),
+      createColor,
+    );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#04e213');
     expect(yellow3.toHex()).toBe('#1304e2');
     expect(yellow4.toHex()).toBe('#e204d3');
 
-    const [green1b, green2b, green3b, green4b] = getTetradicHarmonyColors(new Color('#29cc53'));
+    const [green1b, green2b, green3b, green4b] = getTetradicHarmonyColors(
+      new Color('#29cc53'),
+      createColor,
+    );
     expect(green1b.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#29a2cc');
     expect(green3b.toHex()).toBe('#cc29a2');
     expect(green4b.toHex()).toBe('#cc5329');
 
-    const [pink1, pink2, pink3, pink4] = getTetradicHarmonyColors(new Color('#811242'));
+    const [pink1, pink2, pink3, pink4] = getTetradicHarmonyColors(
+      new Color('#811242'),
+      createColor,
+    );
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#815112');
     expect(pink3.toHex()).toBe('#128151');
@@ -462,6 +607,7 @@ describe('getTetradicHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4] = getTetradicHarmonyColors(
       new Color('#de0d14'),
+      createColor,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#ded70d');
@@ -470,13 +616,19 @@ describe('getTetradicHarmonyColors', () => {
   });
 
   it('returns tetradic harmony colors for grayscale colors', () => {
-    const [black1, black2, black3, black4] = getTetradicHarmonyColors(new Color('#000000'));
+    const [black1, black2, black3, black4] = getTetradicHarmonyColors(
+      new Color('#000000'),
+      createColor,
+    );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#545454');
     expect(black3.toHex()).toBe('#ffffff');
     expect(black4.toHex()).toBe('#ababab');
 
-    const [white1, white2, white3, white4] = getTetradicHarmonyColors(new Color('#ffffff'));
+    const [white1, white2, white3, white4] = getTetradicHarmonyColors(
+      new Color('#ffffff'),
+      createColor,
+    );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#ababab');
     expect(white3.toHex()).toBe('#000000');
@@ -484,13 +636,17 @@ describe('getTetradicHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4] = getTetradicHarmonyColors(
       new Color('#d3d3d3'),
+      createColor,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#9c9c9c');
     expect(lightGray3.toHex()).toBe('#2b2b2b');
     expect(lightGray4.toHex()).toBe('#636363');
 
-    const [gray1, gray2, gray3, gray4] = getTetradicHarmonyColors(new Color('#808080'));
+    const [gray1, gray2, gray3, gray4] = getTetradicHarmonyColors(
+      new Color('#808080'),
+      createColor,
+    );
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
     expect(gray3.toHex()).toBe('#808080');
@@ -498,6 +654,7 @@ describe('getTetradicHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4] = getTetradicHarmonyColors(
       new Color('#333333'),
+      createColor,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#666666');
@@ -506,21 +663,32 @@ describe('getTetradicHarmonyColors', () => {
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getTetradicHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getTetradicHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#545454', '#ffffff', '#ababab']);
 
-    const ignore = getTetradicHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getTetradicHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000']);
   });
 });
 
 describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for primary colors', () => {
-    const [red1, red2, red3, red4, red5] = getAnalogousHarmonyColors(new Color('#ff0000'));
+    const [red1, red2, red3, red4, red5] = getAnalogousHarmonyColors(
+      new Color('#ff0000'),
+      createColor,
+    );
     expect(red1.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ff0080');
     expect(red3.toHex()).toBe('#ff8000');
@@ -529,6 +697,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [green1, green2, green3, green4, green5] = getAnalogousHarmonyColors(
       new Color('#00ff00'),
+      createColor,
     );
     expect(green1.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#80ff00');
@@ -536,7 +705,10 @@ describe('getAnalogousHarmonyColors', () => {
     expect(green4.toHex()).toBe('#ffff00');
     expect(green5.toHex()).toBe('#00ffff');
 
-    const [blue1, blue2, blue3, blue4, blue5] = getAnalogousHarmonyColors(new Color('#0000ff'));
+    const [blue1, blue2, blue3, blue4, blue5] = getAnalogousHarmonyColors(
+      new Color('#0000ff'),
+      createColor,
+    );
     expect(blue1.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#0080ff');
     expect(blue3.toHex()).toBe('#8000ff');
@@ -547,6 +719,7 @@ describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for brand colors', () => {
     const [purple1, purple2, purple3, purple4, purple5] = getAnalogousHarmonyColors(
       new Color('#ee6ffc'),
+      createColor,
     );
     expect(purple1.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#a76ffc');
@@ -556,6 +729,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [brandBlue1, brandBlue2, brandBlue3, brandBlue4, brandBlue5] = getAnalogousHarmonyColors(
       new Color('#2e3575'),
+      createColor,
     );
     expect(brandBlue1.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#2e5875');
@@ -565,6 +739,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [yellow1, yellow2, yellow3, yellow4, yellow5] = getAnalogousHarmonyColors(
       new Color('#d3e204'),
+      createColor,
     );
     expect(yellow1.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#e28204');
@@ -574,6 +749,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [green1b, green2b, green3b, green4b, green5b] = getAnalogousHarmonyColors(
       new Color('#29cc53'),
+      createColor,
     );
     expect(green1b.toHex()).toBe('#29cc53');
     expect(green2b.toHex()).toBe('#51cc29');
@@ -581,7 +757,10 @@ describe('getAnalogousHarmonyColors', () => {
     expect(green4b.toHex()).toBe('#a2cc29');
     expect(green5b.toHex()).toBe('#29a2cc');
 
-    const [pink1, pink2, pink3, pink4, pink5] = getAnalogousHarmonyColors(new Color('#811242'));
+    const [pink1, pink2, pink3, pink4, pink5] = getAnalogousHarmonyColors(
+      new Color('#811242'),
+      createColor,
+    );
     expect(pink1.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#81127a');
     expect(pink3.toHex()).toBe('#811a12');
@@ -590,6 +769,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [brandRed1, brandRed2, brandRed3, brandRed4, brandRed5] = getAnalogousHarmonyColors(
       new Color('#de0d14'),
+      createColor,
     );
     expect(brandRed1.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#de0d7c');
@@ -601,6 +781,7 @@ describe('getAnalogousHarmonyColors', () => {
   it('returns analogous harmony colors for grayscale colors', () => {
     const [black1, black2, black3, black4, black5] = getAnalogousHarmonyColors(
       new Color('#000000'),
+      createColor,
     );
     expect(black1.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#2b2b2b');
@@ -610,6 +791,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [white1, white2, white3, white4, white5] = getAnalogousHarmonyColors(
       new Color('#ffffff'),
+      createColor,
     );
     expect(white1.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#d4d4d4');
@@ -619,6 +801,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [lightGray1, lightGray2, lightGray3, lightGray4, lightGray5] = getAnalogousHarmonyColors(
       new Color('#d3d3d3'),
+      createColor,
     );
     expect(lightGray1.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#b8b8b8');
@@ -626,7 +809,10 @@ describe('getAnalogousHarmonyColors', () => {
     expect(lightGray4.toHex()).toBe('#9c9c9c');
     expect(lightGray5.toHex()).toBe('#9c9c9c');
 
-    const [gray1, gray2, gray3, gray4, gray5] = getAnalogousHarmonyColors(new Color('#808080'));
+    const [gray1, gray2, gray3, gray4, gray5] = getAnalogousHarmonyColors(
+      new Color('#808080'),
+      createColor,
+    );
     expect(gray1.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#808080');
     expect(gray3.toHex()).toBe('#808080');
@@ -635,6 +821,7 @@ describe('getAnalogousHarmonyColors', () => {
 
     const [darkGray1, darkGray2, darkGray3, darkGray4, darkGray5] = getAnalogousHarmonyColors(
       new Color('#333333'),
+      createColor,
     );
     expect(darkGray1.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#4d4d4d');
@@ -644,14 +831,22 @@ describe('getAnalogousHarmonyColors', () => {
   });
 
   it('handles grayscale color modes', () => {
-    const spin = getAnalogousHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'SPIN_LIGHTNESS',
-    }).map((c) => c.toHex());
+    const spin = getAnalogousHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'SPIN_LIGHTNESS',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(spin).toEqual(['#000000', '#2b2b2b', '#2b2b2b', '#545454', '#545454']);
 
-    const ignore = getAnalogousHarmonyColors(new Color('#000000'), {
-      grayscaleHandlingMode: 'IGNORE',
-    }).map((c) => c.toHex());
+    const ignore = getAnalogousHarmonyColors(
+      new Color('#000000'),
+      {
+        grayscaleHandlingMode: 'IGNORE',
+      },
+      createColor,
+    ).map((c) => c.toHex());
     expect(ignore).toEqual(['#000000', '#000000', '#000000', '#000000', '#000000']);
   });
 });
@@ -659,7 +854,10 @@ describe('getAnalogousHarmonyColors', () => {
 describe('getMonochromaticHarmonyColors', () => {
   it('returns monochromatic harmony colors', () => {
     const start = new Color({ h: 210, s: 60, l: 50 });
-    const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(start);
+    const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
+      start,
+      createColor,
+    );
     const [baseHsl, lighterHsl, darkerHsl, saturatedHsl, desaturatedHsl] = [
       base.toHSL(),
       lighter.toHSL(),
@@ -687,6 +885,7 @@ describe('getMonochromaticHarmonyColors', () => {
   it('clamps saturation and lightness', () => {
     const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
       new Color({ h: 10, s: 5, l: 95 }),
+      createColor,
     );
     const [baseHsl, lighterHsl, darkerHsl, saturatedHsl, desaturatedHsl] = [
       base.toHSL(),
@@ -713,7 +912,10 @@ describe('getMonochromaticHarmonyColors', () => {
   });
 
   it('returns monochromatic harmony colors for diverse inputs', () => {
-    const [redOrig, red2, red3, red4, red5] = getMonochromaticHarmonyColors(new Color('#ff0000'));
+    const [redOrig, red2, red3, red4, red5] = getMonochromaticHarmonyColors(
+      new Color('#ff0000'),
+      createColor,
+    );
     expect(redOrig.toHex()).toBe('#ff0000');
     expect(red2.toHex()).toBe('#ff6666');
     expect(red3.toHex()).toBe('#990000');
@@ -722,6 +924,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [greenOrig, green2, green3, green4, green5] = getMonochromaticHarmonyColors(
       new Color('#00ff00'),
+      createColor,
     );
     expect(greenOrig.toHex()).toBe('#00ff00');
     expect(green2.toHex()).toBe('#66ff66');
@@ -731,6 +934,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [blueOrig, blue2, blue3, blue4, blue5] = getMonochromaticHarmonyColors(
       new Color('#0000ff'),
+      createColor,
     );
     expect(blueOrig.toHex()).toBe('#0000ff');
     expect(blue2.toHex()).toBe('#6666ff');
@@ -740,6 +944,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [purpleOrig, purple2, purple3, purple4, purple5] = getMonochromaticHarmonyColors(
       new Color('#ee6ffc'),
+      createColor,
     );
     expect(purpleOrig.toHex()).toBe('#ee6ffc');
     expect(purple2.toHex()).toBe('#fad3fe');
@@ -748,7 +953,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(purple5.toHex()).toBe('#e27eed');
 
     const [brandBlueOrig, brandBlue2, brandBlue3, brandBlue4, brandBlue5] =
-      getMonochromaticHarmonyColors(new Color('#2e3575'));
+      getMonochromaticHarmonyColors(new Color('#2e3575'), createColor);
     expect(brandBlueOrig.toHex()).toBe('#2e3575');
     expect(brandBlue2.toHex()).toBe('#4f5aba');
     expect(brandBlue3.toHex()).toBe('#11142c');
@@ -757,6 +962,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [yellowOrig, yellow2, yellow3, yellow4, yellow5] = getMonochromaticHarmonyColors(
       new Color('#d3e204'),
+      createColor,
     );
     expect(yellowOrig.toHex()).toBe('#d3e204');
     expect(yellow2.toHex()).toBe('#f0fc50');
@@ -765,7 +971,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(yellow5.toHex()).toBe('#bfcb1b');
 
     const [brandGreenOrig, brandGreen2, brandGreen3, brandGreen4, brandGreen5] =
-      getMonochromaticHarmonyColors(new Color('#29cc53'));
+      getMonochromaticHarmonyColors(new Color('#29cc53'), createColor);
     expect(brandGreenOrig.toHex()).toBe('#29cc53');
     expect(brandGreen2.toHex()).toBe('#77e493');
     expect(brandGreen3.toHex()).toBe('#187730');
@@ -774,6 +980,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [pinkOrig, pink2, pink3, pink4, pink5] = getMonochromaticHarmonyColors(
       new Color('#811242'),
+      createColor,
     );
     expect(pinkOrig.toHex()).toBe('#811242');
     expect(pink2.toHex()).toBe('#db1e70');
@@ -782,7 +989,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(pink5.toHex()).toBe('#722144');
 
     const [brandRedOrig, brandRed2, brandRed3, brandRed4, brandRed5] =
-      getMonochromaticHarmonyColors(new Color('#de0d14'));
+      getMonochromaticHarmonyColors(new Color('#de0d14'), createColor);
     expect(brandRedOrig.toHex()).toBe('#de0d14');
     expect(brandRed2.toHex()).toBe('#f55c61');
     expect(brandRed3.toHex()).toBe('#7e070b');
@@ -791,6 +998,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [blackOrig, black2, black3, black4, black5] = getMonochromaticHarmonyColors(
       new Color('#000000'),
+      createColor,
     );
     expect(blackOrig.toHex()).toBe('#000000');
     expect(black2.toHex()).toBe('#333333');
@@ -800,6 +1008,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [whiteOrig, white2, white3, white4, white5] = getMonochromaticHarmonyColors(
       new Color('#ffffff'),
+      createColor,
     );
     expect(whiteOrig.toHex()).toBe('#ffffff');
     expect(white2.toHex()).toBe('#ffffff');
@@ -808,7 +1017,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(white5.toHex()).toBe('#ffffff');
 
     const [lightGrayOrig, lightGray2, lightGray3, lightGray4, lightGray5] =
-      getMonochromaticHarmonyColors(new Color('#d3d3d3'));
+      getMonochromaticHarmonyColors(new Color('#d3d3d3'), createColor);
     expect(lightGrayOrig.toHex()).toBe('#d3d3d3');
     expect(lightGray2.toHex()).toBe('#ffffff');
     expect(lightGray3.toHex()).toBe('#a0a0a0');
@@ -817,6 +1026,7 @@ describe('getMonochromaticHarmonyColors', () => {
 
     const [grayOrig, gray2, gray3, gray4, gray5] = getMonochromaticHarmonyColors(
       new Color('#808080'),
+      createColor,
     );
     expect(grayOrig.toHex()).toBe('#808080');
     expect(gray2.toHex()).toBe('#b3b3b3');
@@ -825,7 +1035,7 @@ describe('getMonochromaticHarmonyColors', () => {
     expect(gray5.toHex()).toBe('#808080');
 
     const [darkGrayOrig, darkGray2, darkGray3, darkGray4, darkGray5] =
-      getMonochromaticHarmonyColors(new Color('#333333'));
+      getMonochromaticHarmonyColors(new Color('#333333'), createColor);
     expect(darkGrayOrig.toHex()).toBe('#333333');
     expect(darkGray2.toHex()).toBe('#666666');
     expect(darkGray3.toHex()).toBe('#000000');
@@ -836,6 +1046,7 @@ describe('getMonochromaticHarmonyColors', () => {
   it('keeps alpha across monochromatic variants', () => {
     const [base, lighter, darker, saturated, desaturated] = getMonochromaticHarmonyColors(
       new Color('rgba(20, 40, 60, 0.25)'),
+      createColor,
     );
 
     expect(base.toRGBA().a).toBeCloseTo(0.25, 5);
@@ -848,119 +1059,93 @@ describe('getMonochromaticHarmonyColors', () => {
 
 describe('getHarmonyColors', () => {
   it('delegates to individual harmony functions', () => {
-    expect(getHarmonyColors(new Color('#ff0000'), 'COMPLEMENTARY').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#00ffff',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'COMPLEMENTARY', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#00ffff']);
 
     expect(
-      getHarmonyColors(new Color('#ff0000'), 'SPLIT_COMPLEMENTARY').map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ff0000'), 'SPLIT_COMPLEMENTARY', createColor).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ff0000', '#0080ff', '#00ff80']);
 
-    expect(getHarmonyColors(new Color('#ff0000'), 'TRIADIC').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#0000ff',
-      '#00ff00',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'TRIADIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#0000ff', '#00ff00']);
 
-    expect(getHarmonyColors(new Color('#ff0000'), 'SQUARE').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#80ff00',
-      '#00ffff',
-      '#8000ff',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'SQUARE', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#80ff00', '#00ffff', '#8000ff']);
 
-    expect(getHarmonyColors(new Color('#ff0000'), 'TETRADIC').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#ffff00',
-      '#00ffff',
-      '#0000ff',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'TETRADIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#ffff00', '#00ffff', '#0000ff']);
 
-    expect(getHarmonyColors(new Color('#ff0000'), 'ANALOGOUS').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#ff0080',
-      '#ff8000',
-      '#ff00ff',
-      '#ffff00',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'ANALOGOUS', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#ff0080', '#ff8000', '#ff00ff', '#ffff00']);
 
-    expect(getHarmonyColors(new Color('#ff0000'), 'MONOCHROMATIC').map((c) => c.toHex())).toEqual([
-      '#ff0000',
-      '#ff6666',
-      '#990000',
-      '#ff0000',
-      '#e61919',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ff0000'), 'MONOCHROMATIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ff0000', '#ff6666', '#990000', '#ff0000', '#e61919']);
   });
 
   it('accepts mixed case harmony', () => {
     const c = new Color('red');
-    const h1 = getHarmonyColors(c, 'TRIADIC');
-    const h2 = getHarmonyColors(c, 'triadic');
+    const h1 = getHarmonyColors(c, 'TRIADIC', createColor);
+    const h2 = getHarmonyColors(c, 'triadic', createColor);
 
     expect(h1.length).toBe(h2.length);
     expect(h1[1].toHex()).toBe(h2[1].toHex());
   });
 
   it('delegates for brand purple as well', () => {
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'COMPLEMENTARY').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#7dfc6f',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'COMPLEMENTARY', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#7dfc6f']);
 
     expect(
-      getHarmonyColors(new Color('#ee6ffc'), 'SPLIT_COMPLEMENTARY').map((c) => c.toHex()),
+      getHarmonyColors(new Color('#ee6ffc'), 'SPLIT_COMPLEMENTARY', createColor).map((c) =>
+        c.toHex(),
+      ),
     ).toEqual(['#ee6ffc', '#6ffca7', '#c4fc6f']);
 
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'TRIADIC').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#6ffcee',
-      '#fcee6f',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'TRIADIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#6ffcee', '#fcee6f']);
 
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'SQUARE').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#fca76f',
-      '#7dfc6f',
-      '#6fc4fc',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'SQUARE', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#fca76f', '#7dfc6f', '#6fc4fc']);
 
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'TETRADIC').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#fc6f7d',
-      '#7dfc6f',
-      '#6ffcee',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'TETRADIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#fc6f7d', '#7dfc6f', '#6ffcee']);
 
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'ANALOGOUS').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#a76ffc',
-      '#fc6fc4',
-      '#6f7dfc',
-      '#fc6f7d',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'ANALOGOUS', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#a76ffc', '#fc6fc4', '#6f7dfc', '#fc6f7d']);
 
-    expect(getHarmonyColors(new Color('#ee6ffc'), 'MONOCHROMATIC').map((c) => c.toHex())).toEqual([
-      '#ee6ffc',
-      '#fad3fe',
-      '#e20bfa',
-      '#f06cff',
-      '#e27eed',
-    ]);
+    expect(
+      getHarmonyColors(new Color('#ee6ffc'), 'MONOCHROMATIC', createColor).map((c) => c.toHex()),
+    ).toEqual(['#ee6ffc', '#fad3fe', '#e20bfa', '#f06cff', '#e27eed']);
   });
 
   it('throws for unknown harmony type', () => {
-    expect(() => getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony)).toThrow(
-      "Invalid 'harmony'",
-    );
+    expect(() =>
+      getHarmonyColors(new Color('#ff0000'), 'unknown' as ColorHarmony, createColor),
+    ).toThrow("Invalid 'harmony'");
   });
 
   it('throws for invalid grayscale handling mode', () => {
     expect(() =>
-      getComplementaryColors(new Color('#808080'), {
-        grayscaleHandlingMode: 'unknown' as never,
-      }),
+      getComplementaryColors(
+        new Color('#808080'),
+        {
+          grayscaleHandlingMode: 'unknown' as never,
+        },
+        createColor,
+      ),
     ).toThrow("Invalid 'grayscaleHandlingMode'");
   });
 });

--- a/src/color/__test__/manipulations.test.ts
+++ b/src/color/__test__/manipulations.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import {
   brightenColor,
   colorToGrayscale,
@@ -8,54 +8,52 @@ import {
   spinColorHue,
 } from '../manipulations';
 
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
-
 describe('spinColorHue', () => {
   it('rotates hue forward around the wheel', () => {
-    expect(spinColorHue(new Color('#ff0000'), 0, createColor).toHex()).toBe('#ff0000');
-    expect(spinColorHue(new Color('#ff0000'), 30, createColor).toHex()).toBe('#ff8000');
-    expect(spinColorHue(new Color('#ff0000'), 120, createColor).toHex()).toBe('#00ff00');
-    expect(spinColorHue(new Color('#ff0000'), 240, createColor).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#ff0000'), 0, createColorInstance).toHex()).toBe('#ff0000');
+    expect(spinColorHue(new Color('#ff0000'), 30, createColorInstance).toHex()).toBe('#ff8000');
+    expect(spinColorHue(new Color('#ff0000'), 120, createColorInstance).toHex()).toBe('#00ff00');
+    expect(spinColorHue(new Color('#ff0000'), 240, createColorInstance).toHex()).toBe('#0000ff');
   });
 
   it('wraps hue for large positive or negative rotations', () => {
-    expect(spinColorHue(new Color('#ff0000'), 400, createColor).toHex()).toBe('#ffaa00');
-    expect(spinColorHue(new Color('#ff0000'), 720, createColor).toHex()).toBe('#ff0000');
-    expect(spinColorHue(new Color('#ff0000'), -390, createColor).toHex()).toBe('#ff0080');
-    expect(spinColorHue(new Color('#ff0000'), -420, createColor).toHex()).toBe('#ff00ff');
+    expect(spinColorHue(new Color('#ff0000'), 400, createColorInstance).toHex()).toBe('#ffaa00');
+    expect(spinColorHue(new Color('#ff0000'), 720, createColorInstance).toHex()).toBe('#ff0000');
+    expect(spinColorHue(new Color('#ff0000'), -390, createColorInstance).toHex()).toBe('#ff0080');
+    expect(spinColorHue(new Color('#ff0000'), -420, createColorInstance).toHex()).toBe('#ff00ff');
   });
 
   it('preserves fractional degree values without truncating', () => {
-    expect(spinColorHue(new Color('#ff0000'), 30.5, createColor).toHex()).toBe('#ff8200');
-    expect(spinColorHue(new Color('#ff0000'), 12.34, createColor).toHex()).toBe('#ff3400');
-    expect(spinColorHue(new Color('#ff0000'), -30.7, createColor).toHex()).toBe('#ff0082');
+    expect(spinColorHue(new Color('#ff0000'), 30.5, createColorInstance).toHex()).toBe('#ff8200');
+    expect(spinColorHue(new Color('#ff0000'), 12.34, createColorInstance).toHex()).toBe('#ff3400');
+    expect(spinColorHue(new Color('#ff0000'), -30.7, createColorInstance).toHex()).toBe('#ff0082');
   });
 
   it('keeps hues in the expected range for negative fractional rotations', () => {
-    const rotated = spinColorHue(new Color('hsl(210, 70%, 60%)'), -420.25, createColor);
+    const rotated = spinColorHue(new Color('hsl(210, 70%, 60%)'), -420.25, createColorInstance);
     expect(rotated.toHex()).toBe('#52e098');
     expect(rotated.toHSL().h).toBeCloseTo(150, 0);
   });
 
   it('works with different base colors', () => {
-    expect(spinColorHue(new Color('#00ff00'), 120, createColor).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#00ff00'), -240, createColor).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#0000ff'), 240, createColor).toHex()).toBe('#00ff00');
-    expect(spinColorHue(new Color('#ffff00'), 450, createColor).toHex()).toBe('#00ff80');
-    expect(spinColorHue(new Color('#00ffff'), 60, createColor).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#ff00ff'), 120, createColor).toHex()).toBe('#ffff00');
+    expect(spinColorHue(new Color('#00ff00'), 120, createColorInstance).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#00ff00'), -240, createColorInstance).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#0000ff'), 240, createColorInstance).toHex()).toBe('#00ff00');
+    expect(spinColorHue(new Color('#ffff00'), 450, createColorInstance).toHex()).toBe('#00ff80');
+    expect(spinColorHue(new Color('#00ffff'), 60, createColorInstance).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#ff00ff'), 120, createColorInstance).toHex()).toBe('#ffff00');
   });
 
   it('does not mutate the original color', () => {
     const red = new Color('#ff0000');
-    const spun = spinColorHue(red, 120, createColor);
+    const spun = spinColorHue(red, 120, createColorInstance);
     expect(spun.toHex()).toBe('#00ff00');
     expect(red.toHex()).toBe('#ff0000');
   });
 
   it('preserves alpha while rotating hue', () => {
     const translucentRed = new Color('rgba(255, 0, 0, 0.42)');
-    const spun = spinColorHue(translucentRed, 60, createColor);
+    const spun = spinColorHue(translucentRed, 60, createColorInstance);
 
     expect(spun.toHex8()).toBe('#ffff006b');
     expect(spun.toRGBA().a).toBeCloseTo(0.42, 5);
@@ -66,37 +64,43 @@ describe('spinColorHue', () => {
 describe('brightenColor', () => {
   it('adjusts lightness relative to the base color', () => {
     const gray = new Color('#808080');
-    expect(brightenColor(gray, createColor).toHex()).toBe('#9a9a9a');
-    expect(brightenColor(gray, { amount: -10 }, createColor).toHex()).toBe('#676767');
+    expect(brightenColor(gray, {}, createColorInstance).toHex()).toBe('#9a9a9a');
+    expect(brightenColor(gray, { amount: -10 }, createColorInstance).toHex()).toBe('#676767');
     expect(gray.toHex()).toBe('#808080');
   });
 
   it('clamps at lightness bounds', () => {
-    expect(brightenColor(new Color('#ffffff'), { amount: 10 }, createColor).toHex()).toBe(
+    expect(brightenColor(new Color('#ffffff'), { amount: 10 }, createColorInstance).toHex()).toBe(
       '#ffffff',
     );
-    expect(brightenColor(new Color('#000000'), { amount: -10 }, createColor).toHex()).toBe(
+    expect(brightenColor(new Color('#000000'), { amount: -10 }, createColorInstance).toHex()).toBe(
       '#000000',
     );
-    expect(brightenColor(new Color('#000000'), { amount: 200 }, createColor).toHex()).toBe(
+    expect(brightenColor(new Color('#000000'), { amount: 200 }, createColorInstance).toHex()).toBe(
       '#ffffff',
     );
-    expect(brightenColor(new Color('#ffffff'), { amount: -200 }, createColor).toHex()).toBe(
+    expect(brightenColor(new Color('#ffffff'), { amount: -200 }, createColorInstance).toHex()).toBe(
       '#000000',
     );
   });
 
   it('uses the default 10% increase', () => {
-    expect(brightenColor(new Color('#000000'), createColor).toHex()).toBe('#1a1a1a');
+    expect(brightenColor(new Color('#000000'), undefined, createColorInstance).toHex()).toBe(
+      '#1a1a1a',
+    );
   });
 
   it('supports LAB adjustments with configurable LAB-like scaling', () => {
     const translucentTeal = new Color('rgba(0, 128, 128, 0.4)');
-    const defaultScale = brightenColor(translucentTeal, { space: 'LAB', amount: 30 }, createColor);
+    const defaultScale = brightenColor(
+      translucentTeal,
+      { space: 'LAB', amount: 30 },
+      createColorInstance,
+    );
     const smallerScale = brightenColor(
       translucentTeal,
       { space: 'LAB', amount: 30, labScale: 12 },
-      createColor,
+      createColorInstance,
     );
 
     expect(defaultScale.toHex()).toBe('#aeffff');
@@ -107,7 +111,7 @@ describe('brightenColor', () => {
 
   it('honors fractional HSL adjustments when options are explicitly provided', () => {
     const base = new Color('#123456');
-    const brightened = brightenColor(base, { amount: 7.5, space: 'HSL' }, createColor);
+    const brightened = brightenColor(base, { amount: 7.5, space: 'HSL' }, createColorInstance);
 
     expect(brightened.toHex()).toBe('#194776');
     expect(brightened).not.toBe(base);
@@ -116,7 +120,11 @@ describe('brightenColor', () => {
 
   it('applies LAB deltas scaled by labScale while keeping alpha intact', () => {
     const base = new Color({ l: 50, a: 0, b: 0 }).setAlpha(0.8);
-    const brightened = brightenColor(base, { space: 'LAB', amount: 5, labScale: 10 }, createColor);
+    const brightened = brightenColor(
+      base,
+      { space: 'LAB', amount: 5, labScale: 10 },
+      createColorInstance,
+    );
     const brightenedLAB = brightened.toLAB();
 
     expect(brightenedLAB.l).toBeCloseTo(55.148, 3);
@@ -127,7 +135,11 @@ describe('brightenColor', () => {
 
   it('supports LCH adjustments with custom LAB-like scaling', () => {
     const base = new Color({ l: 40, c: 20, h: 250 });
-    const brightened = brightenColor(base, { space: 'LCH', amount: 25, labScale: 8 }, createColor);
+    const brightened = brightenColor(
+      base,
+      { space: 'LCH', amount: 25, labScale: 8 },
+      createColorInstance,
+    );
     const brightenedLCH = brightened.toLCH();
 
     expect(brightened.toHex()).toBe('#6d96b1');
@@ -138,7 +150,7 @@ describe('brightenColor', () => {
 
   it('normalizes near-neutral inputs before brightening in LCH space', () => {
     const gray = new Color('#808080');
-    const brightened = brightenColor(gray, { space: 'LCH', amount: 10 }, createColor);
+    const brightened = brightenColor(gray, { space: 'LCH', amount: 10 }, createColorInstance);
     const lch = brightened.toLCH();
 
     expect(lch.c).toBeLessThan(0.02);
@@ -150,40 +162,46 @@ describe('brightenColor', () => {
 describe('darkenColor', () => {
   it('reduces lightness by the given percentage', () => {
     const gray = new Color('#808080');
-    expect(darkenColor(gray, createColor).toHex()).toBe('#676767');
-    expect(darkenColor(gray, { amount: -10 }, createColor).toHex()).toBe('#9a9a9a');
+    expect(darkenColor(gray, undefined, createColorInstance).toHex()).toBe('#676767');
+    expect(darkenColor(gray, { amount: -10 }, createColorInstance).toHex()).toBe('#9a9a9a');
     expect(gray.toHex()).toBe('#808080');
   });
 
   it('clamps at black', () => {
-    expect(darkenColor(new Color('#000000'), { amount: 10 }, createColor).toHex()).toBe('#000000');
-    expect(darkenColor(new Color('#ffffff'), { amount: 200 }, createColor).toHex()).toBe('#000000');
+    expect(darkenColor(new Color('#000000'), { amount: 10 }, createColorInstance).toHex()).toBe(
+      '#000000',
+    );
+    expect(darkenColor(new Color('#ffffff'), { amount: 200 }, createColorInstance).toHex()).toBe(
+      '#000000',
+    );
   });
 
   it('uses the default 10% decrease', () => {
-    expect(darkenColor(new Color('#ffffff'), createColor).toHex()).toBe('#e6e6e6');
+    expect(darkenColor(new Color('#ffffff'), {}, createColorInstance).toHex()).toBe('#e6e6e6');
   });
 
   it('accepts LAB options and clamps when approaching black', () => {
     expect(
-      darkenColor(new Color('#ffffff'), { amount: 200, space: 'LAB' }, createColor).toHex(),
+      darkenColor(new Color('#ffffff'), { amount: 200, space: 'LAB' }, createColorInstance).toHex(),
     ).toBe('#000000');
     expect(
-      darkenColor(new Color('#000000'), { amount: 25, space: 'LAB' }, createColor).toHex(),
+      darkenColor(new Color('#000000'), { amount: 25, space: 'LAB' }, createColorInstance).toHex(),
     ).toBe('#000000');
   });
 
   it('scales LAB/LCH deltas using the provided labScale', () => {
     const gray = new Color('#808080');
-    expect(darkenColor(gray, { space: 'LCH', amount: 20 }, createColor).toHex()).toBe('#2b2b2b');
-    expect(darkenColor(gray, { space: 'LCH', amount: 20, labScale: 10 }, createColor).toHex()).toBe(
-      '#4f4f4f',
+    expect(darkenColor(gray, { space: 'LCH', amount: 20 }, createColorInstance).toHex()).toBe(
+      '#2b2b2b',
     );
+    expect(
+      darkenColor(gray, { space: 'LCH', amount: 20, labScale: 10 }, createColorInstance).toHex(),
+    ).toBe('#4f4f4f');
   });
 
   it('handles fractional HSL adjustments without mutating the source color', () => {
     const parchment = new Color('#f0eedd');
-    const darkened = darkenColor(parchment, { amount: 12.5 }, createColor);
+    const darkened = darkenColor(parchment, { amount: 12.5 }, createColorInstance);
 
     expect(darkened.toHex()).toBe('#dcd8b1');
     expect(parchment.toHex()).toBe('#f0eedd');
@@ -191,7 +209,11 @@ describe('darkenColor', () => {
 
   it('applies LAB deltas with custom scaling and preserves transparency', () => {
     const base = new Color({ l: 45, a: -5, b: 15 }).setAlpha(0.65);
-    const darkened = darkenColor(base, { space: 'LAB', amount: 15, labScale: 5 }, createColor);
+    const darkened = darkenColor(
+      base,
+      { space: 'LAB', amount: 15, labScale: 5 },
+      createColorInstance,
+    );
     const darkenedLAB = darkened.toLAB();
 
     expect(darkenedLAB.l).toBeCloseTo(37.583, 3);
@@ -201,7 +223,7 @@ describe('darkenColor', () => {
 
   it('normalizes near-grayscale hues before darkening in LCH space', () => {
     const gray = new Color('#808080');
-    const darkened = darkenColor(gray, { space: 'LCH', amount: 25 }, createColor);
+    const darkened = darkenColor(gray, { space: 'LCH', amount: 25 }, createColorInstance);
     const lch = darkened.toLCH();
 
     expect(lch.c).toBeLessThan(0.01);
@@ -213,43 +235,49 @@ describe('darkenColor', () => {
 describe('saturateColor', () => {
   it('adjusts saturation by the requested amount', () => {
     const base = new Color('#6699cc');
-    expect(saturateColor(base, { amount: 20 }, createColor).toHex()).toBe('#5299e0');
-    expect(saturateColor(base, { amount: -20 }, createColor).toHex()).toBe('#7a99b8');
+    expect(saturateColor(base, { amount: 20 }, createColorInstance).toHex()).toBe('#5299e0');
+    expect(saturateColor(base, { amount: -20 }, createColorInstance).toHex()).toBe('#7a99b8');
     expect(base.toHex()).toBe('#6699cc');
   });
 
   it('clamps saturation between 0% and 100%', () => {
-    expect(saturateColor(new Color('#f90606'), { amount: 10 }, createColor).toHex()).toBe(
+    expect(saturateColor(new Color('#f90606'), { amount: 10 }, createColorInstance).toHex()).toBe(
       '#ff0000',
     );
-    expect(saturateColor(new Color('#867979'), { amount: -10 }, createColor).toHex()).toBe(
+    expect(saturateColor(new Color('#867979'), { amount: -10 }, createColorInstance).toHex()).toBe(
       '#808080',
     );
-    expect(saturateColor(new Color('#4080bf'), { amount: 300 }, createColor).toHex()).toBe(
+    expect(saturateColor(new Color('#4080bf'), { amount: 300 }, createColorInstance).toHex()).toBe(
       '#0081ff',
     );
-    expect(saturateColor(new Color('#808080'), { amount: 10 }, createColor).toHex()).toBe(
+    expect(saturateColor(new Color('#808080'), { amount: 10 }, createColorInstance).toHex()).toBe(
       '#8d7373',
     );
   });
 
   it('uses the default 10% increase', () => {
-    expect(saturateColor(new Color('#4080bf'), createColor).toHex()).toBe('#3380cc');
+    expect(saturateColor(new Color('#4080bf'), undefined, createColorInstance).toHex()).toBe(
+      '#3380cc',
+    );
   });
 
   it('supports LCH saturation with adjustable LAB-like scaling', () => {
     const mutedTeal = new Color('hsl(190, 25%, 55%)');
-    expect(saturateColor(mutedTeal, { space: 'LCH', amount: 40 }, createColor).toHex()).toBe(
-      '#00b8f7',
-    );
     expect(
-      saturateColor(mutedTeal, { space: 'LCH', amount: 40, labScale: 12 }, createColor).toHex(),
+      saturateColor(mutedTeal, { space: 'LCH', amount: 40 }, createColorInstance).toHex(),
+    ).toBe('#00b8f7');
+    expect(
+      saturateColor(
+        mutedTeal,
+        { space: 'LCH', amount: 40, labScale: 12 },
+        createColorInstance,
+      ).toHex(),
     ).toBe('#00b1dd');
   });
 
   it('returns a new color when the HSL delta is zero while keeping alpha', () => {
     const base = new Color('rgba(170, 119, 51, 0.4)');
-    const saturated = saturateColor(base, { amount: 0, space: 'HSL' }, createColor);
+    const saturated = saturateColor(base, { amount: 0, space: 'HSL' }, createColorInstance);
 
     expect(saturated.toHex8()).toBe('#aa773366');
     expect(base.toHex8()).toBe('#aa773366');
@@ -258,7 +286,7 @@ describe('saturateColor', () => {
 
   it('clamps LCH chroma to zero for large negative adjustments', () => {
     const paleGreen = new Color({ l: 60, c: 5, h: 120 });
-    const saturated = saturateColor(paleGreen, { space: 'LCH', amount: -60 }, createColor);
+    const saturated = saturateColor(paleGreen, { space: 'LCH', amount: -60 }, createColorInstance);
     const saturatedLCH = saturated.toLCH();
 
     expect(saturated.toHex()).toBe('#919191');
@@ -268,8 +296,12 @@ describe('saturateColor', () => {
 
   it('scales LCH chroma shifts based on labScale', () => {
     const base = new Color('hsl(200, 35%, 50%)');
-    const defaultScale = saturateColor(base, { space: 'LCH', amount: 30 }, createColor);
-    const smallScale = saturateColor(base, { space: 'LCH', amount: 30, labScale: 8 }, createColor);
+    const defaultScale = saturateColor(base, { space: 'LCH', amount: 30 }, createColorInstance);
+    const smallScale = saturateColor(
+      base,
+      { space: 'LCH', amount: 30, labScale: 8 },
+      createColorInstance,
+    );
 
     expect(defaultScale.toHex()).toBe('#009dff');
     expect(smallScale.toHex()).toBe('#0095d2');
@@ -280,16 +312,18 @@ describe('saturateColor', () => {
 describe('desaturateColor', () => {
   it('reduces saturation', () => {
     const base = new Color('#6699cc');
-    expect(desaturateColor(base, { amount: 20 }, createColor).toHex()).toBe('#7a99b8');
-    expect(desaturateColor(base, { amount: -20 }, createColor).toHex()).toBe('#5299e0');
+    expect(desaturateColor(base, { amount: 20 }, createColorInstance).toHex()).toBe('#7a99b8');
+    expect(desaturateColor(base, { amount: -20 }, createColorInstance).toHex()).toBe('#5299e0');
     expect(base.toHex()).toBe('#6699cc');
   });
 
   it('clamps at zero and uses default reduction', () => {
-    expect(desaturateColor(new Color('#867979'), { amount: 10 }, createColor).toHex()).toBe(
+    expect(desaturateColor(new Color('#867979'), { amount: 10 }, createColorInstance).toHex()).toBe(
       '#808080',
     );
-    expect(desaturateColor(new Color('#6699cc'), createColor).toHex()).toBe('#7099c2');
+    expect(desaturateColor(new Color('#6699cc'), undefined, createColorInstance).toHex()).toBe(
+      '#7099c2',
+    );
   });
 
   it('handles LCH desaturation with clamping, preserved alpha, and adjustable scaling', () => {
@@ -297,7 +331,7 @@ describe('desaturateColor', () => {
     const defaultDesaturation = desaturateColor(
       translucentViolet,
       { space: 'LCH', amount: 30 },
-      createColor,
+      createColorInstance,
     );
     const smallerScale = desaturateColor(
       translucentViolet,
@@ -306,7 +340,7 @@ describe('desaturateColor', () => {
         amount: 30,
         labScale: 8,
       },
-      createColor,
+      createColorInstance,
     );
 
     expect(defaultDesaturation.toHex()).toBe('#6f637f');
@@ -317,7 +351,7 @@ describe('desaturateColor', () => {
 
   it('clamps saturation to gray for extreme HSL reductions', () => {
     const vividOrange = new Color('#ff8800');
-    const desaturated = desaturateColor(vividOrange, { amount: 200 }, createColor);
+    const desaturated = desaturateColor(vividOrange, { amount: 200 }, createColorInstance);
 
     expect(desaturated.toHex()).toBe('#808080');
     expect(vividOrange.toHex()).toBe('#ff8800');
@@ -325,7 +359,11 @@ describe('desaturateColor', () => {
 
   it('normalizes hue after chroma collapses in LCH space', () => {
     const mutedCyan = new Color({ l: 55, c: 2, h: 180 });
-    const desaturated = desaturateColor(mutedCyan, { space: 'LCH', amount: 15 }, createColor);
+    const desaturated = desaturateColor(
+      mutedCyan,
+      { space: 'LCH', amount: 15 },
+      createColorInstance,
+    );
     const desaturatedLCH = desaturated.toLCH();
 
     expect(desaturated.toHex()).toBe('#848484');
@@ -335,7 +373,7 @@ describe('desaturateColor', () => {
 
   it('preserves alpha when desaturating translucent colors', () => {
     const translucentBrown = new Color('rgba(120, 60, 30, 0.2)');
-    const desaturated = desaturateColor(translucentBrown, { amount: 20 }, createColor);
+    const desaturated = desaturateColor(translucentBrown, { amount: 20 }, createColorInstance);
 
     expect(desaturated.toHex8()).toBe('#69412d33');
     expect(translucentBrown.toHex8()).toBe('#783c1e33');
@@ -344,23 +382,23 @@ describe('desaturateColor', () => {
 
 describe('colorToGrayscale', () => {
   it('converts different colors to grayscale', () => {
-    expect(colorToGrayscale(new Color('#ff0000'), createColor).toHex()).toBe('#808080');
-    expect(colorToGrayscale(new Color('#00ff00'), createColor).toHex()).toBe('#808080');
-    expect(colorToGrayscale(new Color('#0000ff'), createColor).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#ff0000'), createColorInstance).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#00ff00'), createColorInstance).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#0000ff'), createColorInstance).toHex()).toBe('#808080');
   });
 
   it('handles white and black and does not mutate the originals', () => {
     const white = new Color('#ffffff');
     const black = new Color('#000000');
-    expect(colorToGrayscale(white, createColor).toHex()).toBe('#ffffff');
-    expect(colorToGrayscale(black, createColor).toHex()).toBe('#000000');
+    expect(colorToGrayscale(white, createColorInstance).toHex()).toBe('#ffffff');
+    expect(colorToGrayscale(black, createColorInstance).toHex()).toBe('#000000');
     expect(white.toHex()).toBe('#ffffff');
     expect(black.toHex()).toBe('#000000');
   });
 
   it('preserves alpha while removing saturation', () => {
     const translucentBlue = new Color('rgba(50, 100, 150, 0.25)');
-    const gray = colorToGrayscale(translucentBlue, createColor);
+    const gray = colorToGrayscale(translucentBlue, createColorInstance);
 
     expect(gray.toHex()).toBe('#646464');
     expect(gray.toRGBA().a).toBeCloseTo(0.25, 5);

--- a/src/color/__test__/manipulations.test.ts
+++ b/src/color/__test__/manipulations.test.ts
@@ -8,52 +8,54 @@ import {
   spinColorHue,
 } from '../manipulations';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('spinColorHue', () => {
   it('rotates hue forward around the wheel', () => {
-    expect(spinColorHue(new Color('#ff0000'), 0).toHex()).toBe('#ff0000');
-    expect(spinColorHue(new Color('#ff0000'), 30).toHex()).toBe('#ff8000');
-    expect(spinColorHue(new Color('#ff0000'), 120).toHex()).toBe('#00ff00');
-    expect(spinColorHue(new Color('#ff0000'), 240).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#ff0000'), 0, createColor).toHex()).toBe('#ff0000');
+    expect(spinColorHue(new Color('#ff0000'), 30, createColor).toHex()).toBe('#ff8000');
+    expect(spinColorHue(new Color('#ff0000'), 120, createColor).toHex()).toBe('#00ff00');
+    expect(spinColorHue(new Color('#ff0000'), 240, createColor).toHex()).toBe('#0000ff');
   });
 
   it('wraps hue for large positive or negative rotations', () => {
-    expect(spinColorHue(new Color('#ff0000'), 400).toHex()).toBe('#ffaa00');
-    expect(spinColorHue(new Color('#ff0000'), 720).toHex()).toBe('#ff0000');
-    expect(spinColorHue(new Color('#ff0000'), -390).toHex()).toBe('#ff0080');
-    expect(spinColorHue(new Color('#ff0000'), -420).toHex()).toBe('#ff00ff');
+    expect(spinColorHue(new Color('#ff0000'), 400, createColor).toHex()).toBe('#ffaa00');
+    expect(spinColorHue(new Color('#ff0000'), 720, createColor).toHex()).toBe('#ff0000');
+    expect(spinColorHue(new Color('#ff0000'), -390, createColor).toHex()).toBe('#ff0080');
+    expect(spinColorHue(new Color('#ff0000'), -420, createColor).toHex()).toBe('#ff00ff');
   });
 
   it('preserves fractional degree values without truncating', () => {
-    expect(spinColorHue(new Color('#ff0000'), 30.5).toHex()).toBe('#ff8200');
-    expect(spinColorHue(new Color('#ff0000'), 12.34).toHex()).toBe('#ff3400');
-    expect(spinColorHue(new Color('#ff0000'), -30.7).toHex()).toBe('#ff0082');
+    expect(spinColorHue(new Color('#ff0000'), 30.5, createColor).toHex()).toBe('#ff8200');
+    expect(spinColorHue(new Color('#ff0000'), 12.34, createColor).toHex()).toBe('#ff3400');
+    expect(spinColorHue(new Color('#ff0000'), -30.7, createColor).toHex()).toBe('#ff0082');
   });
 
   it('keeps hues in the expected range for negative fractional rotations', () => {
-    const rotated = spinColorHue(new Color('hsl(210, 70%, 60%)'), -420.25);
+    const rotated = spinColorHue(new Color('hsl(210, 70%, 60%)'), -420.25, createColor);
     expect(rotated.toHex()).toBe('#52e098');
     expect(rotated.toHSL().h).toBeCloseTo(150, 0);
   });
 
   it('works with different base colors', () => {
-    expect(spinColorHue(new Color('#00ff00'), 120).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#00ff00'), -240).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#0000ff'), 240).toHex()).toBe('#00ff00');
-    expect(spinColorHue(new Color('#ffff00'), 450).toHex()).toBe('#00ff80');
-    expect(spinColorHue(new Color('#00ffff'), 60).toHex()).toBe('#0000ff');
-    expect(spinColorHue(new Color('#ff00ff'), 120).toHex()).toBe('#ffff00');
+    expect(spinColorHue(new Color('#00ff00'), 120, createColor).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#00ff00'), -240, createColor).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#0000ff'), 240, createColor).toHex()).toBe('#00ff00');
+    expect(spinColorHue(new Color('#ffff00'), 450, createColor).toHex()).toBe('#00ff80');
+    expect(spinColorHue(new Color('#00ffff'), 60, createColor).toHex()).toBe('#0000ff');
+    expect(spinColorHue(new Color('#ff00ff'), 120, createColor).toHex()).toBe('#ffff00');
   });
 
   it('does not mutate the original color', () => {
     const red = new Color('#ff0000');
-    const spun = spinColorHue(red, 120);
+    const spun = spinColorHue(red, 120, createColor);
     expect(spun.toHex()).toBe('#00ff00');
     expect(red.toHex()).toBe('#ff0000');
   });
 
   it('preserves alpha while rotating hue', () => {
     const translucentRed = new Color('rgba(255, 0, 0, 0.42)');
-    const spun = spinColorHue(translucentRed, 60);
+    const spun = spinColorHue(translucentRed, 60, createColor);
 
     expect(spun.toHex8()).toBe('#ffff006b');
     expect(spun.toRGBA().a).toBeCloseTo(0.42, 5);
@@ -64,26 +66,38 @@ describe('spinColorHue', () => {
 describe('brightenColor', () => {
   it('adjusts lightness relative to the base color', () => {
     const gray = new Color('#808080');
-    expect(brightenColor(gray).toHex()).toBe('#9a9a9a');
-    expect(brightenColor(gray, { amount: -10 }).toHex()).toBe('#676767');
+    expect(brightenColor(gray, createColor).toHex()).toBe('#9a9a9a');
+    expect(brightenColor(gray, { amount: -10 }, createColor).toHex()).toBe('#676767');
     expect(gray.toHex()).toBe('#808080');
   });
 
   it('clamps at lightness bounds', () => {
-    expect(brightenColor(new Color('#ffffff'), { amount: 10 }).toHex()).toBe('#ffffff');
-    expect(brightenColor(new Color('#000000'), { amount: -10 }).toHex()).toBe('#000000');
-    expect(brightenColor(new Color('#000000'), { amount: 200 }).toHex()).toBe('#ffffff');
-    expect(brightenColor(new Color('#ffffff'), { amount: -200 }).toHex()).toBe('#000000');
+    expect(brightenColor(new Color('#ffffff'), { amount: 10 }, createColor).toHex()).toBe(
+      '#ffffff',
+    );
+    expect(brightenColor(new Color('#000000'), { amount: -10 }, createColor).toHex()).toBe(
+      '#000000',
+    );
+    expect(brightenColor(new Color('#000000'), { amount: 200 }, createColor).toHex()).toBe(
+      '#ffffff',
+    );
+    expect(brightenColor(new Color('#ffffff'), { amount: -200 }, createColor).toHex()).toBe(
+      '#000000',
+    );
   });
 
   it('uses the default 10% increase', () => {
-    expect(brightenColor(new Color('#000000')).toHex()).toBe('#1a1a1a');
+    expect(brightenColor(new Color('#000000'), createColor).toHex()).toBe('#1a1a1a');
   });
 
   it('supports LAB adjustments with configurable LAB-like scaling', () => {
     const translucentTeal = new Color('rgba(0, 128, 128, 0.4)');
-    const defaultScale = brightenColor(translucentTeal, { space: 'LAB', amount: 30 });
-    const smallerScale = brightenColor(translucentTeal, { space: 'LAB', amount: 30, labScale: 12 });
+    const defaultScale = brightenColor(translucentTeal, { space: 'LAB', amount: 30 }, createColor);
+    const smallerScale = brightenColor(
+      translucentTeal,
+      { space: 'LAB', amount: 30, labScale: 12 },
+      createColor,
+    );
 
     expect(defaultScale.toHex()).toBe('#aeffff');
     expect(defaultScale.toRGBA().a).toBeCloseTo(0.4, 5);
@@ -93,7 +107,7 @@ describe('brightenColor', () => {
 
   it('honors fractional HSL adjustments when options are explicitly provided', () => {
     const base = new Color('#123456');
-    const brightened = brightenColor(base, { amount: 7.5, space: 'HSL' });
+    const brightened = brightenColor(base, { amount: 7.5, space: 'HSL' }, createColor);
 
     expect(brightened.toHex()).toBe('#194776');
     expect(brightened).not.toBe(base);
@@ -102,7 +116,7 @@ describe('brightenColor', () => {
 
   it('applies LAB deltas scaled by labScale while keeping alpha intact', () => {
     const base = new Color({ l: 50, a: 0, b: 0 }).setAlpha(0.8);
-    const brightened = brightenColor(base, { space: 'LAB', amount: 5, labScale: 10 });
+    const brightened = brightenColor(base, { space: 'LAB', amount: 5, labScale: 10 }, createColor);
     const brightenedLAB = brightened.toLAB();
 
     expect(brightenedLAB.l).toBeCloseTo(55.148, 3);
@@ -113,7 +127,7 @@ describe('brightenColor', () => {
 
   it('supports LCH adjustments with custom LAB-like scaling', () => {
     const base = new Color({ l: 40, c: 20, h: 250 });
-    const brightened = brightenColor(base, { space: 'LCH', amount: 25, labScale: 8 });
+    const brightened = brightenColor(base, { space: 'LCH', amount: 25, labScale: 8 }, createColor);
     const brightenedLCH = brightened.toLCH();
 
     expect(brightened.toHex()).toBe('#6d96b1');
@@ -124,7 +138,7 @@ describe('brightenColor', () => {
 
   it('normalizes near-neutral inputs before brightening in LCH space', () => {
     const gray = new Color('#808080');
-    const brightened = brightenColor(gray, { space: 'LCH', amount: 10 });
+    const brightened = brightenColor(gray, { space: 'LCH', amount: 10 }, createColor);
     const lch = brightened.toLCH();
 
     expect(lch.c).toBeLessThan(0.02);
@@ -136,36 +150,40 @@ describe('brightenColor', () => {
 describe('darkenColor', () => {
   it('reduces lightness by the given percentage', () => {
     const gray = new Color('#808080');
-    expect(darkenColor(gray).toHex()).toBe('#676767');
-    expect(darkenColor(gray, { amount: -10 }).toHex()).toBe('#9a9a9a');
+    expect(darkenColor(gray, createColor).toHex()).toBe('#676767');
+    expect(darkenColor(gray, { amount: -10 }, createColor).toHex()).toBe('#9a9a9a');
     expect(gray.toHex()).toBe('#808080');
   });
 
   it('clamps at black', () => {
-    expect(darkenColor(new Color('#000000'), { amount: 10 }).toHex()).toBe('#000000');
-    expect(darkenColor(new Color('#ffffff'), { amount: 200 }).toHex()).toBe('#000000');
+    expect(darkenColor(new Color('#000000'), { amount: 10 }, createColor).toHex()).toBe('#000000');
+    expect(darkenColor(new Color('#ffffff'), { amount: 200 }, createColor).toHex()).toBe('#000000');
   });
 
   it('uses the default 10% decrease', () => {
-    expect(darkenColor(new Color('#ffffff')).toHex()).toBe('#e6e6e6');
+    expect(darkenColor(new Color('#ffffff'), createColor).toHex()).toBe('#e6e6e6');
   });
 
   it('accepts LAB options and clamps when approaching black', () => {
-    expect(darkenColor(new Color('#ffffff'), { amount: 200, space: 'LAB' }).toHex()).toBe(
-      '#000000',
-    );
-    expect(darkenColor(new Color('#000000'), { amount: 25, space: 'LAB' }).toHex()).toBe('#000000');
+    expect(
+      darkenColor(new Color('#ffffff'), { amount: 200, space: 'LAB' }, createColor).toHex(),
+    ).toBe('#000000');
+    expect(
+      darkenColor(new Color('#000000'), { amount: 25, space: 'LAB' }, createColor).toHex(),
+    ).toBe('#000000');
   });
 
   it('scales LAB/LCH deltas using the provided labScale', () => {
     const gray = new Color('#808080');
-    expect(darkenColor(gray, { space: 'LCH', amount: 20 }).toHex()).toBe('#2b2b2b');
-    expect(darkenColor(gray, { space: 'LCH', amount: 20, labScale: 10 }).toHex()).toBe('#4f4f4f');
+    expect(darkenColor(gray, { space: 'LCH', amount: 20 }, createColor).toHex()).toBe('#2b2b2b');
+    expect(darkenColor(gray, { space: 'LCH', amount: 20, labScale: 10 }, createColor).toHex()).toBe(
+      '#4f4f4f',
+    );
   });
 
   it('handles fractional HSL adjustments without mutating the source color', () => {
     const parchment = new Color('#f0eedd');
-    const darkened = darkenColor(parchment, { amount: 12.5 });
+    const darkened = darkenColor(parchment, { amount: 12.5 }, createColor);
 
     expect(darkened.toHex()).toBe('#dcd8b1');
     expect(parchment.toHex()).toBe('#f0eedd');
@@ -173,7 +191,7 @@ describe('darkenColor', () => {
 
   it('applies LAB deltas with custom scaling and preserves transparency', () => {
     const base = new Color({ l: 45, a: -5, b: 15 }).setAlpha(0.65);
-    const darkened = darkenColor(base, { space: 'LAB', amount: 15, labScale: 5 });
+    const darkened = darkenColor(base, { space: 'LAB', amount: 15, labScale: 5 }, createColor);
     const darkenedLAB = darkened.toLAB();
 
     expect(darkenedLAB.l).toBeCloseTo(37.583, 3);
@@ -183,7 +201,7 @@ describe('darkenColor', () => {
 
   it('normalizes near-grayscale hues before darkening in LCH space', () => {
     const gray = new Color('#808080');
-    const darkened = darkenColor(gray, { space: 'LCH', amount: 25 });
+    const darkened = darkenColor(gray, { space: 'LCH', amount: 25 }, createColor);
     const lch = darkened.toLCH();
 
     expect(lch.c).toBeLessThan(0.01);
@@ -195,33 +213,43 @@ describe('darkenColor', () => {
 describe('saturateColor', () => {
   it('adjusts saturation by the requested amount', () => {
     const base = new Color('#6699cc');
-    expect(saturateColor(base, { amount: 20 }).toHex()).toBe('#5299e0');
-    expect(saturateColor(base, { amount: -20 }).toHex()).toBe('#7a99b8');
+    expect(saturateColor(base, { amount: 20 }, createColor).toHex()).toBe('#5299e0');
+    expect(saturateColor(base, { amount: -20 }, createColor).toHex()).toBe('#7a99b8');
     expect(base.toHex()).toBe('#6699cc');
   });
 
   it('clamps saturation between 0% and 100%', () => {
-    expect(saturateColor(new Color('#f90606'), { amount: 10 }).toHex()).toBe('#ff0000');
-    expect(saturateColor(new Color('#867979'), { amount: -10 }).toHex()).toBe('#808080');
-    expect(saturateColor(new Color('#4080bf'), { amount: 300 }).toHex()).toBe('#0081ff');
-    expect(saturateColor(new Color('#808080'), { amount: 10 }).toHex()).toBe('#8d7373');
+    expect(saturateColor(new Color('#f90606'), { amount: 10 }, createColor).toHex()).toBe(
+      '#ff0000',
+    );
+    expect(saturateColor(new Color('#867979'), { amount: -10 }, createColor).toHex()).toBe(
+      '#808080',
+    );
+    expect(saturateColor(new Color('#4080bf'), { amount: 300 }, createColor).toHex()).toBe(
+      '#0081ff',
+    );
+    expect(saturateColor(new Color('#808080'), { amount: 10 }, createColor).toHex()).toBe(
+      '#8d7373',
+    );
   });
 
   it('uses the default 10% increase', () => {
-    expect(saturateColor(new Color('#4080bf')).toHex()).toBe('#3380cc');
+    expect(saturateColor(new Color('#4080bf'), createColor).toHex()).toBe('#3380cc');
   });
 
   it('supports LCH saturation with adjustable LAB-like scaling', () => {
     const mutedTeal = new Color('hsl(190, 25%, 55%)');
-    expect(saturateColor(mutedTeal, { space: 'LCH', amount: 40 }).toHex()).toBe('#00b8f7');
-    expect(saturateColor(mutedTeal, { space: 'LCH', amount: 40, labScale: 12 }).toHex()).toBe(
-      '#00b1dd',
+    expect(saturateColor(mutedTeal, { space: 'LCH', amount: 40 }, createColor).toHex()).toBe(
+      '#00b8f7',
     );
+    expect(
+      saturateColor(mutedTeal, { space: 'LCH', amount: 40, labScale: 12 }, createColor).toHex(),
+    ).toBe('#00b1dd');
   });
 
   it('returns a new color when the HSL delta is zero while keeping alpha', () => {
     const base = new Color('rgba(170, 119, 51, 0.4)');
-    const saturated = saturateColor(base, { amount: 0, space: 'HSL' });
+    const saturated = saturateColor(base, { amount: 0, space: 'HSL' }, createColor);
 
     expect(saturated.toHex8()).toBe('#aa773366');
     expect(base.toHex8()).toBe('#aa773366');
@@ -230,7 +258,7 @@ describe('saturateColor', () => {
 
   it('clamps LCH chroma to zero for large negative adjustments', () => {
     const paleGreen = new Color({ l: 60, c: 5, h: 120 });
-    const saturated = saturateColor(paleGreen, { space: 'LCH', amount: -60 });
+    const saturated = saturateColor(paleGreen, { space: 'LCH', amount: -60 }, createColor);
     const saturatedLCH = saturated.toLCH();
 
     expect(saturated.toHex()).toBe('#919191');
@@ -240,8 +268,8 @@ describe('saturateColor', () => {
 
   it('scales LCH chroma shifts based on labScale', () => {
     const base = new Color('hsl(200, 35%, 50%)');
-    const defaultScale = saturateColor(base, { space: 'LCH', amount: 30 });
-    const smallScale = saturateColor(base, { space: 'LCH', amount: 30, labScale: 8 });
+    const defaultScale = saturateColor(base, { space: 'LCH', amount: 30 }, createColor);
+    const smallScale = saturateColor(base, { space: 'LCH', amount: 30, labScale: 8 }, createColor);
 
     expect(defaultScale.toHex()).toBe('#009dff');
     expect(smallScale.toHex()).toBe('#0095d2');
@@ -252,24 +280,34 @@ describe('saturateColor', () => {
 describe('desaturateColor', () => {
   it('reduces saturation', () => {
     const base = new Color('#6699cc');
-    expect(desaturateColor(base, { amount: 20 }).toHex()).toBe('#7a99b8');
-    expect(desaturateColor(base, { amount: -20 }).toHex()).toBe('#5299e0');
+    expect(desaturateColor(base, { amount: 20 }, createColor).toHex()).toBe('#7a99b8');
+    expect(desaturateColor(base, { amount: -20 }, createColor).toHex()).toBe('#5299e0');
     expect(base.toHex()).toBe('#6699cc');
   });
 
   it('clamps at zero and uses default reduction', () => {
-    expect(desaturateColor(new Color('#867979'), { amount: 10 }).toHex()).toBe('#808080');
-    expect(desaturateColor(new Color('#6699cc')).toHex()).toBe('#7099c2');
+    expect(desaturateColor(new Color('#867979'), { amount: 10 }, createColor).toHex()).toBe(
+      '#808080',
+    );
+    expect(desaturateColor(new Color('#6699cc'), createColor).toHex()).toBe('#7099c2');
   });
 
   it('handles LCH desaturation with clamping, preserved alpha, and adjustable scaling', () => {
     const translucentViolet = new Color('rgba(120, 80, 200, 0.5)');
-    const defaultDesaturation = desaturateColor(translucentViolet, { space: 'LCH', amount: 30 });
-    const smallerScale = desaturateColor(translucentViolet, {
-      space: 'LCH',
-      amount: 30,
-      labScale: 8,
-    });
+    const defaultDesaturation = desaturateColor(
+      translucentViolet,
+      { space: 'LCH', amount: 30 },
+      createColor,
+    );
+    const smallerScale = desaturateColor(
+      translucentViolet,
+      {
+        space: 'LCH',
+        amount: 30,
+        labScale: 8,
+      },
+      createColor,
+    );
 
     expect(defaultDesaturation.toHex()).toBe('#6f637f');
     expect(defaultDesaturation.toRGBA().a).toBeCloseTo(0.5, 5);
@@ -279,7 +317,7 @@ describe('desaturateColor', () => {
 
   it('clamps saturation to gray for extreme HSL reductions', () => {
     const vividOrange = new Color('#ff8800');
-    const desaturated = desaturateColor(vividOrange, { amount: 200 });
+    const desaturated = desaturateColor(vividOrange, { amount: 200 }, createColor);
 
     expect(desaturated.toHex()).toBe('#808080');
     expect(vividOrange.toHex()).toBe('#ff8800');
@@ -287,7 +325,7 @@ describe('desaturateColor', () => {
 
   it('normalizes hue after chroma collapses in LCH space', () => {
     const mutedCyan = new Color({ l: 55, c: 2, h: 180 });
-    const desaturated = desaturateColor(mutedCyan, { space: 'LCH', amount: 15 });
+    const desaturated = desaturateColor(mutedCyan, { space: 'LCH', amount: 15 }, createColor);
     const desaturatedLCH = desaturated.toLCH();
 
     expect(desaturated.toHex()).toBe('#848484');
@@ -297,7 +335,7 @@ describe('desaturateColor', () => {
 
   it('preserves alpha when desaturating translucent colors', () => {
     const translucentBrown = new Color('rgba(120, 60, 30, 0.2)');
-    const desaturated = desaturateColor(translucentBrown, { amount: 20 });
+    const desaturated = desaturateColor(translucentBrown, { amount: 20 }, createColor);
 
     expect(desaturated.toHex8()).toBe('#69412d33');
     expect(translucentBrown.toHex8()).toBe('#783c1e33');
@@ -306,23 +344,23 @@ describe('desaturateColor', () => {
 
 describe('colorToGrayscale', () => {
   it('converts different colors to grayscale', () => {
-    expect(colorToGrayscale(new Color('#ff0000')).toHex()).toBe('#808080');
-    expect(colorToGrayscale(new Color('#00ff00')).toHex()).toBe('#808080');
-    expect(colorToGrayscale(new Color('#0000ff')).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#ff0000'), createColor).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#00ff00'), createColor).toHex()).toBe('#808080');
+    expect(colorToGrayscale(new Color('#0000ff'), createColor).toHex()).toBe('#808080');
   });
 
   it('handles white and black and does not mutate the originals', () => {
     const white = new Color('#ffffff');
     const black = new Color('#000000');
-    expect(colorToGrayscale(white).toHex()).toBe('#ffffff');
-    expect(colorToGrayscale(black).toHex()).toBe('#000000');
+    expect(colorToGrayscale(white, createColor).toHex()).toBe('#ffffff');
+    expect(colorToGrayscale(black, createColor).toHex()).toBe('#000000');
     expect(white.toHex()).toBe('#ffffff');
     expect(black.toHex()).toBe('#000000');
   });
 
   it('preserves alpha while removing saturation', () => {
     const translucentBlue = new Color('rgba(50, 100, 150, 0.25)');
-    const gray = colorToGrayscale(translucentBlue);
+    const gray = colorToGrayscale(translucentBlue, createColor);
 
     expect(gray.toHex()).toBe('#646464');
     expect(gray.toRGBA().a).toBeCloseTo(0.25, 5);

--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -1,474 +1,603 @@
-import { Color } from '../color';
+import { createColorInstance } from '../color';
 import { parseCSSColorFormatString } from '../parse';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('parseCSSColorFormatString', () => {
   it('parses RGB inputs', () => {
-    expect(parseCSSColorFormatString('rgb(0, 0, 0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgb(255, 255, 255)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('rgb(128, 128, 128)', createColor)?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('rgb(255, 0, 0)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(0, 255, 0)', createColor)?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('rgb(0, 0, 255)', createColor)?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('rgb(255, 255, 0)', createColor)?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('rgb(0, 255, 255)', createColor)?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('rgb(255, 0, 255)', createColor)?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('rgb(0%, 0%, 0%)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgb(100%, 100%, 100%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('rgb(0, 0, 0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('rgb(255, 255, 255)', createColorInstance)?.toHex()).toBe(
       '#ffffff',
     );
-    expect(parseCSSColorFormatString('rgb(50%, 50%, 50%)', createColor)?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('rgb(100%, 0%, 0%)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(0%, 100%, 0%)', createColor)?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('rgb(0%, 0%, 100%)', createColor)?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('rgb(100%, 100%, 0%)', createColor)?.toHex()).toBe('#ffff00');
+    expect(parseCSSColorFormatString('rgb(128, 128, 128)', createColorInstance)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('rgb(255, 0, 0)', createColorInstance)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('rgb(0, 255, 0)', createColorInstance)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('rgb(0, 0, 255)', createColorInstance)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('rgb(255, 255, 0)', createColorInstance)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('rgb(0, 255, 255)', createColorInstance)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('rgb(255, 0, 255)', createColorInstance)?.toHex()).toBe(
+      '#ff00ff',
+    );
+    expect(parseCSSColorFormatString('rgb(0%, 0%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#000000',
+    );
+    expect(parseCSSColorFormatString('rgb(100%, 100%, 100%)', createColorInstance)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('rgb(50%, 50%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('rgb(100%, 0%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('rgb(0%, 100%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('rgb(0%, 0%, 100%)', createColorInstance)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('rgb(100%, 100%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#ffff00',
+    );
   });
 
   it('parses RGBA inputs', () => {
-    expect(parseCSSColorFormatString('rgba(0, 0, 0, 0)', createColor)?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('rgba(255, 255, 255, 1)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('rgba(0, 0, 0, 0)', createColorInstance)?.toHex8()).toBe(
+      '#00000000',
+    );
+    expect(parseCSSColorFormatString('rgba(255, 255, 255, 1)', createColorInstance)?.toHex8()).toBe(
       '#ffffffff',
     );
-    expect(parseCSSColorFormatString('rgba(128, 128, 128, 0.502)', createColor)?.toHex8()).toBe(
-      '#80808080',
-    );
-    expect(parseCSSColorFormatString('rgba(255, 0, 0, 0.502)', createColor)?.toHex8()).toBe(
+    expect(
+      parseCSSColorFormatString('rgba(128, 128, 128, 0.502)', createColorInstance)?.toHex8(),
+    ).toBe('#80808080');
+    expect(parseCSSColorFormatString('rgba(255, 0, 0, 0.502)', createColorInstance)?.toHex8()).toBe(
       '#ff000080',
     );
-    expect(parseCSSColorFormatString('rgba(0, 255, 0, 0.498)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('rgba(0, 255, 0, 0.498)', createColorInstance)?.toHex8()).toBe(
       '#00ff007f',
     );
-    expect(parseCSSColorFormatString('rgba(0, 0, 255, 0.251)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('rgba(0, 0, 255, 0.251)', createColorInstance)?.toHex8()).toBe(
       '#0000ff40',
     );
-    expect(parseCSSColorFormatString('rgba(255, 255, 0, 0.753)', createColor)?.toHex8()).toBe(
-      '#ffff00c0',
-    );
-    expect(parseCSSColorFormatString('rgba(0, 255, 255, 0.125)', createColor)?.toHex8()).toBe(
-      '#00ffff20',
-    );
-    expect(parseCSSColorFormatString('rgba(255, 0, 255, 0.6)', createColor)?.toHex8()).toBe(
+    expect(
+      parseCSSColorFormatString('rgba(255, 255, 0, 0.753)', createColorInstance)?.toHex8(),
+    ).toBe('#ffff00c0');
+    expect(
+      parseCSSColorFormatString('rgba(0, 255, 255, 0.125)', createColorInstance)?.toHex8(),
+    ).toBe('#00ffff20');
+    expect(parseCSSColorFormatString('rgba(255, 0, 255, 0.6)', createColorInstance)?.toHex8()).toBe(
       '#ff00ff99',
     );
-    expect(parseCSSColorFormatString('RGBA(255,0,0,50%)', createColor)?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('rgba(0,255,0,25%)', createColor)?.toHex8()).toBe('#00ff0040');
-    expect(parseCSSColorFormatString('rgba(0,0,255,0%)', createColor)?.toHex8()).toBe('#0000ff00');
+    expect(parseCSSColorFormatString('RGBA(255,0,0,50%)', createColorInstance)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('rgba(0,255,0,25%)', createColorInstance)?.toHex8()).toBe(
+      '#00ff0040',
+    );
+    expect(parseCSSColorFormatString('rgba(0,0,255,0%)', createColorInstance)?.toHex8()).toBe(
+      '#0000ff00',
+    );
   });
 
   it('parses flexible RGB-style inputs', () => {
-    expect(parseCSSColorFormatString('rgb(100 200 150)', createColor)?.toRGB()).toEqual({
+    expect(parseCSSColorFormatString('rgb(100 200 150)', createColorInstance)?.toRGB()).toEqual({
       r: 100,
       g: 200,
       b: 150,
     });
-    expect(parseCSSColorFormatString('rgb(100,200 150)', createColor)?.toRGB()).toEqual({
+    expect(parseCSSColorFormatString('rgb(100,200 150)', createColorInstance)?.toRGB()).toEqual({
       r: 100,
       g: 200,
       b: 150,
     });
-    expect(parseCSSColorFormatString('rgb(0 0 0.5)', createColor)?.toRGB()).toEqual({
+    expect(parseCSSColorFormatString('rgb(0 0 0.5)', createColorInstance)?.toRGB()).toEqual({
       r: 0,
       g: 0,
       b: 128,
     });
-    expect(parseCSSColorFormatString('rgb(10% 20% 30% / 50%)', createColor)?.toRGBA()).toEqual({
+    expect(
+      parseCSSColorFormatString('rgb(10% 20% 30% / 50%)', createColorInstance)?.toRGBA(),
+    ).toEqual({
       r: 26,
       g: 51,
       b: 77,
       a: 0.5,
     });
-    expect(parseCSSColorFormatString('rgba(0.1 0.2 0.3 / 0.4)', createColor)?.toRGBA()).toEqual({
+    expect(
+      parseCSSColorFormatString('rgba(0.1 0.2 0.3 / 0.4)', createColorInstance)?.toRGBA(),
+    ).toEqual({
       r: 26,
       g: 51,
       b: 77,
       a: 0.4,
     });
-    expect(parseCSSColorFormatString('rgba(5 10 15 / 25%)', createColor)?.toRGBA()).toEqual({
-      r: 5,
-      g: 10,
-      b: 15,
-      a: 0.25,
-    });
+    expect(parseCSSColorFormatString('rgba(5 10 15 / 25%)', createColorInstance)?.toRGBA()).toEqual(
+      {
+        r: 5,
+        g: 10,
+        b: 15,
+        a: 0.25,
+      },
+    );
   });
 
   it('parses color() inputs', () => {
-    expect(parseCSSColorFormatString('color(srgb 1 0 0)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('color(srgb 100% 0% 0% / 25%)', createColor)?.toHex8()).toBe(
-      '#ff000040',
-    );
-    expect(parseCSSColorFormatString('color(srgb, 1, 1, 1, 50%)', createColor)?.toHex8()).toBe(
-      '#ffffff80',
+    expect(parseCSSColorFormatString('color(srgb 1 0 0)', createColorInstance)?.toHex()).toBe(
+      '#ff0000',
     );
     expect(
-      parseCSSColorFormatString('color(display-p3 0 100% 0 / 75%)', createColor)?.toHex8(),
+      parseCSSColorFormatString('color(srgb 100% 0% 0% / 25%)', createColorInstance)?.toHex8(),
+    ).toBe('#ff000040');
+    expect(
+      parseCSSColorFormatString('color(srgb, 1, 1, 1, 50%)', createColorInstance)?.toHex8(),
+    ).toBe('#ffffff80');
+    expect(
+      parseCSSColorFormatString('color(display-p3 0 100% 0 / 75%)', createColorInstance)?.toHex8(),
     ).toBe('#00ff00bf');
     expect(
-      parseCSSColorFormatString('color(display-p3, 50%, 20%, 10% / 0.5)', createColor)?.toHex8(),
+      parseCSSColorFormatString(
+        'color(display-p3, 50%, 20%, 10% / 0.5)',
+        createColorInstance,
+      )?.toHex8(),
     ).toBe('#8a2c0d80');
-    expect(parseCSSColorFormatString('color(rec2020 25% 50% 75%)', createColor)?.toHex()).toBe(
-      '#0090cc',
-    );
-    expect(parseCSSColorFormatString('color(rec2020 0 0.5 1 / 0.25)', createColor)?.toHex8()).toBe(
-      '#0092ff40',
-    );
-    expect(parseCSSColorFormatString('color(REC2020 0% 0% 0% / 100%)', createColor)?.toHex()).toBe(
-      '#000000',
-    );
+    expect(
+      parseCSSColorFormatString('color(rec2020 25% 50% 75%)', createColorInstance)?.toHex(),
+    ).toBe('#0090cc');
+    expect(
+      parseCSSColorFormatString('color(rec2020 0 0.5 1 / 0.25)', createColorInstance)?.toHex8(),
+    ).toBe('#0092ff40');
+    expect(
+      parseCSSColorFormatString('color(REC2020 0% 0% 0% / 100%)', createColorInstance)?.toHex(),
+    ).toBe('#000000');
   });
 
   it('parses HSL inputs', () => {
-    expect(parseCSSColorFormatString('hsl(0, 0%, 0%)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('hsl(0, 0%, 100%)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('hsl(0, 0%, 50%)', createColor)?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('hsl(0, 100%, 50%)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hsl(120, 100%, 50%)', createColor)?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hsl(240, 100%, 50%)', createColor)?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('hsl(60, 100%, 50%)', createColor)?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('hsl(180, 100%, 50%)', createColor)?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(300, 100%, 50%)', createColor)?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('hsl(120deg, 100%, 25%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('hsl(0, 0%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#000000',
+    );
+    expect(parseCSSColorFormatString('hsl(0, 0%, 100%)', createColorInstance)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('hsl(0, 0%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('hsl(0, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('hsl(120, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('hsl(240, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('hsl(60, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('hsl(180, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('hsl(300, 100%, 50%)', createColorInstance)?.toHex()).toBe(
+      '#ff00ff',
+    );
+    expect(parseCSSColorFormatString('hsl(120deg, 100%, 25%)', createColorInstance)?.toHex()).toBe(
       '#008000',
     );
-    expect(parseCSSColorFormatString('hsl(0.5turn 100% 50%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('hsl(0.5turn 100% 50%)', createColorInstance)?.toHex()).toBe(
       '#00ffff',
     );
     expect(
-      parseCSSColorFormatString('hsl(3.141592653589793rad 100% 50%)', createColor)?.toHex(),
+      parseCSSColorFormatString('hsl(3.141592653589793rad 100% 50%)', createColorInstance)?.toHex(),
     ).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(200grad 100% 50%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('hsl(200grad 100% 50%)', createColorInstance)?.toHex()).toBe(
       '#00ffff',
     );
   });
 
   it('parses HSLA inputs', () => {
-    expect(parseCSSColorFormatString('hsla(0, 0%, 0%, 0)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hsla(0, 0%, 0%, 0)', createColorInstance)?.toHex8()).toBe(
       '#00000000',
     );
-    expect(parseCSSColorFormatString('hsla(0, 0%, 100%, 1)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hsla(0, 0%, 100%, 1)', createColorInstance)?.toHex8()).toBe(
       '#ffffffff',
     );
-    expect(parseCSSColorFormatString('hsla(0, 0%, 50%, 0.502)', createColor)?.toHex8()).toBe(
-      '#80808080',
-    );
-    expect(parseCSSColorFormatString('hsla(0, 100%, 50%, 0.502)', createColor)?.toHex8()).toBe(
+    expect(
+      parseCSSColorFormatString('hsla(0, 0%, 50%, 0.502)', createColorInstance)?.toHex8(),
+    ).toBe('#80808080');
+    expect(
+      parseCSSColorFormatString('hsla(0, 100%, 50%, 0.502)', createColorInstance)?.toHex8(),
+    ).toBe('#ff000080');
+    expect(
+      parseCSSColorFormatString('hsla(120, 100%, 50%, 0.498)', createColorInstance)?.toHex8(),
+    ).toBe('#00ff007f');
+    expect(
+      parseCSSColorFormatString('hsla(240, 100%, 50%, 0.251)', createColorInstance)?.toHex8(),
+    ).toBe('#0000ff40');
+    expect(
+      parseCSSColorFormatString('hsla(60, 100%, 50%, 0.753)', createColorInstance)?.toHex8(),
+    ).toBe('#ffff00c0');
+    expect(
+      parseCSSColorFormatString('hsla(180, 100%, 50%, 0.125)', createColorInstance)?.toHex8(),
+    ).toBe('#00ffff20');
+    expect(
+      parseCSSColorFormatString('hsla(300, 100%, 50%, 0.6)', createColorInstance)?.toHex8(),
+    ).toBe('#ff00ff99');
+    expect(parseCSSColorFormatString('hsla(0,100%,50%,50%)', createColorInstance)?.toHex8()).toBe(
       '#ff000080',
     );
-    expect(parseCSSColorFormatString('hsla(120, 100%, 50%, 0.498)', createColor)?.toHex8()).toBe(
-      '#00ff007f',
-    );
-    expect(parseCSSColorFormatString('hsla(240, 100%, 50%, 0.251)', createColor)?.toHex8()).toBe(
-      '#0000ff40',
-    );
-    expect(parseCSSColorFormatString('hsla(60, 100%, 50%, 0.753)', createColor)?.toHex8()).toBe(
-      '#ffff00c0',
-    );
-    expect(parseCSSColorFormatString('hsla(180, 100%, 50%, 0.125)', createColor)?.toHex8()).toBe(
-      '#00ffff20',
-    );
-    expect(parseCSSColorFormatString('hsla(300, 100%, 50%, 0.6)', createColor)?.toHex8()).toBe(
-      '#ff00ff99',
-    );
-    expect(parseCSSColorFormatString('hsla(0,100%,50%,50%)', createColor)?.toHex8()).toBe(
-      '#ff000080',
-    );
-    expect(parseCSSColorFormatString('hsla(120,100%,50%,25%)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hsla(120,100%,50%,25%)', createColorInstance)?.toHex8()).toBe(
       '#00ff0040',
     );
-    expect(parseCSSColorFormatString('hsla(240,100%,50%,0%)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hsla(240,100%,50%,0%)', createColorInstance)?.toHex8()).toBe(
       '#0000ff00',
     );
   });
 
   it('parses HSV inputs', () => {
-    expect(parseCSSColorFormatString('hsv(0,0%,0%)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('hsv(0,0%,100%)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('hsv(0,0%,50%)', createColor)?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('hsv(0,100%,100%)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hsv(120,100%,100%)', createColor)?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hsv(240,100%,100%)', createColor)?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('hsv(60,100%,100%)', createColor)?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('hsv(180,100%,100%)', createColor)?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsv(300,100%,100%)', createColor)?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('hsv(0,0%,0%)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('hsv(0,0%,100%)', createColorInstance)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('hsv(0,0%,50%)', createColorInstance)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('hsv(0,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('hsv(120,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('hsv(240,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('hsv(60,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('hsv(180,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('hsv(300,100%,100%)', createColorInstance)?.toHex()).toBe(
+      '#ff00ff',
+    );
   });
 
   it('parses HSVA inputs', () => {
-    expect(parseCSSColorFormatString('hsva(0,0%,0%,0)', createColor)?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('hsva(0,0%,100%,1)', createColor)?.toHex8()).toBe('#ffffffff');
-    expect(parseCSSColorFormatString('hsva(0,0%,50%,0.502)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hsva(0,0%,0%,0)', createColorInstance)?.toHex8()).toBe(
+      '#00000000',
+    );
+    expect(parseCSSColorFormatString('hsva(0,0%,100%,1)', createColorInstance)?.toHex8()).toBe(
+      '#ffffffff',
+    );
+    expect(parseCSSColorFormatString('hsva(0,0%,50%,0.502)', createColorInstance)?.toHex8()).toBe(
       '#80808080',
     );
-    expect(parseCSSColorFormatString('hsva(0,100%,100%,0.502)', createColor)?.toHex8()).toBe(
+    expect(
+      parseCSSColorFormatString('hsva(0,100%,100%,0.502)', createColorInstance)?.toHex8(),
+    ).toBe('#ff000080');
+    expect(
+      parseCSSColorFormatString('hsva(120,100%,100%,0.498)', createColorInstance)?.toHex8(),
+    ).toBe('#00ff007f');
+    expect(
+      parseCSSColorFormatString('hsva(240,100%,100%,0.251)', createColorInstance)?.toHex8(),
+    ).toBe('#0000ff40');
+    expect(
+      parseCSSColorFormatString('hsva(60,100%,100%,0.753)', createColorInstance)?.toHex8(),
+    ).toBe('#ffff00c0');
+    expect(
+      parseCSSColorFormatString('hsva(180,100%,100%,0.125)', createColorInstance)?.toHex8(),
+    ).toBe('#00ffff20');
+    expect(
+      parseCSSColorFormatString('hsva(300,100%,100%,0.6)', createColorInstance)?.toHex8(),
+    ).toBe('#ff00ff99');
+    expect(parseCSSColorFormatString('hsva(0,100%,100%,50%)', createColorInstance)?.toHex8()).toBe(
       '#ff000080',
     );
-    expect(parseCSSColorFormatString('hsva(120,100%,100%,0.498)', createColor)?.toHex8()).toBe(
-      '#00ff007f',
-    );
-    expect(parseCSSColorFormatString('hsva(240,100%,100%,0.251)', createColor)?.toHex8()).toBe(
-      '#0000ff40',
-    );
-    expect(parseCSSColorFormatString('hsva(60,100%,100%,0.753)', createColor)?.toHex8()).toBe(
-      '#ffff00c0',
-    );
-    expect(parseCSSColorFormatString('hsva(180,100%,100%,0.125)', createColor)?.toHex8()).toBe(
-      '#00ffff20',
-    );
-    expect(parseCSSColorFormatString('hsva(300,100%,100%,0.6)', createColor)?.toHex8()).toBe(
-      '#ff00ff99',
-    );
-    expect(parseCSSColorFormatString('hsva(0,100%,100%,50%)', createColor)?.toHex8()).toBe(
-      '#ff000080',
-    );
-    expect(parseCSSColorFormatString('hsva(120,100%,100%,25%)', createColor)?.toHex8()).toBe(
-      '#00ff0040',
-    );
-    expect(parseCSSColorFormatString('hsva(240,100%,100%,0%)', createColor)?.toHex8()).toBe(
+    expect(
+      parseCSSColorFormatString('hsva(120,100%,100%,25%)', createColorInstance)?.toHex8(),
+    ).toBe('#00ff0040');
+    expect(parseCSSColorFormatString('hsva(240,100%,100%,0%)', createColorInstance)?.toHex8()).toBe(
       '#0000ff00',
     );
   });
 
   it('parses HWB inputs', () => {
-    expect(parseCSSColorFormatString('hwb(0 0% 0%)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hwb(120 40% 20%)', createColor)?.toHex()).toBe('#66cc66');
-    expect(parseCSSColorFormatString('hwb(210 10% 30% / 0.25)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('hwb(0 0% 0%)', createColorInstance)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('hwb(120 40% 20%)', createColorInstance)?.toHex()).toBe(
+      '#66cc66',
+    );
+    expect(
+      parseCSSColorFormatString('hwb(210 10% 30% / 0.25)', createColorInstance)?.toHex8(),
+    ).toBe('#1a66b340');
+    expect(parseCSSColorFormatString('hwb(210 10% 30% 25%)', createColorInstance)?.toHex8()).toBe(
       '#1a66b340',
     );
-    expect(parseCSSColorFormatString('hwb(210 10% 30% 25%)', createColor)?.toHex8()).toBe(
-      '#1a66b340',
+    expect(parseCSSColorFormatString('hwb(480 0% 0%)', createColorInstance)?.toHex()).toBe(
+      '#00ff00',
     );
-    expect(parseCSSColorFormatString('hwb(480 0% 0%)', createColor)?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hwb(0.5turn 0% 0%)', createColor)?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hwb(3.141592653589793rad 0% 0%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('hwb(0.5turn 0% 0%)', createColorInstance)?.toHex()).toBe(
       '#00ffff',
     );
-    expect(parseCSSColorFormatString('hwb(200grad 0% 0%)', createColor)?.toHex()).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('hwb(3.141592653589793rad 0% 0%)', createColorInstance)?.toHex(),
+    ).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hwb(200grad 0% 0%)', createColorInstance)?.toHex()).toBe(
+      '#00ffff',
+    );
   });
 
   it('parses flexible HSL and HSV inputs', () => {
-    expect(parseCSSColorFormatString('hsl(180 100% 50%)', createColor)?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(180 100% 50% / 0.25)', createColor)?.toHex8()).toBe(
-      '#00ffff40',
+    expect(parseCSSColorFormatString('hsl(180 100% 50%)', createColorInstance)?.toHex()).toBe(
+      '#00ffff',
     );
-    expect(parseCSSColorFormatString('hsv(300 100% 100% / 0.5)', createColor)?.toHex8()).toBe(
-      '#ff00ff80',
-    );
+    expect(
+      parseCSSColorFormatString('hsl(180 100% 50% / 0.25)', createColorInstance)?.toHex8(),
+    ).toBe('#00ffff40');
+    expect(
+      parseCSSColorFormatString('hsv(300 100% 100% / 0.5)', createColorInstance)?.toHex8(),
+    ).toBe('#ff00ff80');
   });
 
   it('parses CMYK inputs', () => {
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 100%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 100%)', createColorInstance)?.toHex()).toBe(
       '#000000',
     );
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 0%)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 50%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 0%)', createColorInstance)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 50%)', createColorInstance)?.toHex()).toBe(
       '#808080',
     );
-    expect(parseCSSColorFormatString('cmyk(0%,100%,100%,0%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(0%,100%,100%,0%)', createColorInstance)?.toHex()).toBe(
       '#ff0000',
     );
-    expect(parseCSSColorFormatString('cmyk(100%, 0%, 100%, 0%)', createColor)?.toHex()).toBe(
-      '#00ff00',
-    );
-    expect(parseCSSColorFormatString('cmyk(100%, 100%, 0%, 0%)', createColor)?.toHex()).toBe(
-      '#0000ff',
-    );
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 100%, 0%)', createColor)?.toHex()).toBe(
+    expect(
+      parseCSSColorFormatString('cmyk(100%, 0%, 100%, 0%)', createColorInstance)?.toHex(),
+    ).toBe('#00ff00');
+    expect(
+      parseCSSColorFormatString('cmyk(100%, 100%, 0%, 0%)', createColorInstance)?.toHex(),
+    ).toBe('#0000ff');
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 100%, 0%)', createColorInstance)?.toHex()).toBe(
       '#ffff00',
     );
-    expect(parseCSSColorFormatString('cmyk(100%, 0%, 0%, 0%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(100%, 0%, 0%, 0%)', createColorInstance)?.toHex()).toBe(
       '#00ffff',
     );
-    expect(parseCSSColorFormatString('cmyk(0%, 100%, 0%, 0%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(0%, 100%, 0%, 0%)', createColorInstance)?.toHex()).toBe(
       '#ff00ff',
     );
   });
 
   it('parses LAB inputs', () => {
-    expect(parseCSSColorFormatString('lab(0% 0 0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('lab(100% 0.005 -0.01)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('lab(0% 0 0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('lab(100% 0.005 -0.01)', createColorInstance)?.toHex()).toBe(
       '#ffffff',
     );
-    expect(parseCSSColorFormatString('lab(53.585% 0.003 -0.006)', createColor)?.toHex()).toBe(
-      '#808080',
-    );
-    expect(parseCSSColorFormatString('lab(53.233% 80.109 67.22)', createColor)?.toHex()).toBe(
-      '#ff0000',
-    );
-    expect(parseCSSColorFormatString('lab(87.737% -86.185 83.181)', createColor)?.toHex()).toBe(
-      '#00ff00',
-    );
-    expect(parseCSSColorFormatString('lab(32.303% 79.197 -107.864)', createColor)?.toHex()).toBe(
-      '#0000ff',
-    );
-    expect(parseCSSColorFormatString('lab(97.138% -21.556 94.482)', createColor)?.toHex()).toBe(
-      '#ffff00',
-    );
-    expect(parseCSSColorFormatString('lab(91.117% -48.08 -14.138)', createColor)?.toHex()).toBe(
-      '#00ffff',
-    );
-    expect(parseCSSColorFormatString('lab(60.32% 98.254 -60.843)', createColor)?.toHex()).toBe(
-      '#ff00ff',
-    );
+    expect(
+      parseCSSColorFormatString('lab(53.585% 0.003 -0.006)', createColorInstance)?.toHex(),
+    ).toBe('#808080');
+    expect(
+      parseCSSColorFormatString('lab(53.233% 80.109 67.22)', createColorInstance)?.toHex(),
+    ).toBe('#ff0000');
+    expect(
+      parseCSSColorFormatString('lab(87.737% -86.185 83.181)', createColorInstance)?.toHex(),
+    ).toBe('#00ff00');
+    expect(
+      parseCSSColorFormatString('lab(32.303% 79.197 -107.864)', createColorInstance)?.toHex(),
+    ).toBe('#0000ff');
+    expect(
+      parseCSSColorFormatString('lab(97.138% -21.556 94.482)', createColorInstance)?.toHex(),
+    ).toBe('#ffff00');
+    expect(
+      parseCSSColorFormatString('lab(91.117% -48.08 -14.138)', createColorInstance)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('lab(60.32% 98.254 -60.843)', createColorInstance)?.toHex(),
+    ).toBe('#ff00ff');
   });
 
   it('parses LCH inputs', () => {
-    expect(parseCSSColorFormatString('lch(0% 0 0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('lch(100% 0.012 296.813)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('lch(0% 0 0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('lch(100% 0.012 296.813)', createColorInstance)?.toHex()).toBe(
       '#ffffff',
     );
-    expect(parseCSSColorFormatString('lch(53.585% 0.007 296.813)', createColor)?.toHex()).toBe(
-      '#808080',
-    );
-    expect(parseCSSColorFormatString('lch(53.233% 104.576 40)', createColor)?.toHex()).toBe(
+    expect(
+      parseCSSColorFormatString('lch(53.585% 0.007 296.813)', createColorInstance)?.toHex(),
+    ).toBe('#808080');
+    expect(parseCSSColorFormatString('lch(53.233% 104.576 40)', createColorInstance)?.toHex()).toBe(
       '#ff0000',
     );
-    expect(parseCSSColorFormatString('lch(87.737% 119.779 136.016)', createColor)?.toHex()).toBe(
-      '#00ff00',
-    );
-    expect(parseCSSColorFormatString('lch(32.303% 133.816 306.287)', createColor)?.toHex()).toBe(
-      '#0000ff',
-    );
-    expect(parseCSSColorFormatString('lch(97.138% 96.91 102.852)', createColor)?.toHex()).toBe(
-      '#ffff00',
-    );
-    expect(parseCSSColorFormatString('lch(91.117% 50.115 196.386)', createColor)?.toHex()).toBe(
-      '#00ffff',
-    );
-    expect(parseCSSColorFormatString('lch(60.32% 115.567 328.233)', createColor)?.toHex()).toBe(
-      '#ff00ff',
-    );
     expect(
-      parseCSSColorFormatString('lch(91.117% 50.115 0.5455166667turn)', createColor)?.toHex(),
+      parseCSSColorFormatString('lch(87.737% 119.779 136.016)', createColorInstance)?.toHex(),
+    ).toBe('#00ff00');
+    expect(
+      parseCSSColorFormatString('lch(32.303% 133.816 306.287)', createColorInstance)?.toHex(),
+    ).toBe('#0000ff');
+    expect(
+      parseCSSColorFormatString('lch(97.138% 96.91 102.852)', createColorInstance)?.toHex(),
+    ).toBe('#ffff00');
+    expect(
+      parseCSSColorFormatString('lch(91.117% 50.115 196.386)', createColorInstance)?.toHex(),
     ).toBe('#00ffff');
     expect(
-      parseCSSColorFormatString('lch(91.117% 50.115 3.427586338rad)', createColor)?.toHex(),
+      parseCSSColorFormatString('lch(60.32% 115.567 328.233)', createColorInstance)?.toHex(),
+    ).toBe('#ff00ff');
+    expect(
+      parseCSSColorFormatString(
+        'lch(91.117% 50.115 0.5455166667turn)',
+        createColorInstance,
+      )?.toHex(),
     ).toBe('#00ffff');
     expect(
-      parseCSSColorFormatString('lch(91.117% 50.115 218.2066667grad)', createColor)?.toHex(),
+      parseCSSColorFormatString('lch(91.117% 50.115 3.427586338rad)', createColorInstance)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString(
+        'lch(91.117% 50.115 218.2066667grad)',
+        createColorInstance,
+      )?.toHex(),
     ).toBe('#00ffff');
   });
 
   it('parses very small LAB/LCH percentage lightness like canonical LAB/LCH (not OKLAB/OKLCH)', () => {
-    const labHalfPercent = parseCSSColorFormatString('lab(0.5% 0 0)', createColor)?.toHex();
-    const labHalfUnit = parseCSSColorFormatString('lab(0.5 0 0)', createColor)?.toHex();
+    const labHalfPercent = parseCSSColorFormatString('lab(0.5% 0 0)', createColorInstance)?.toHex();
+    const labHalfUnit = parseCSSColorFormatString('lab(0.5 0 0)', createColorInstance)?.toHex();
     expect(labHalfPercent).toBe(labHalfUnit);
 
-    const lchHalfPercent = parseCSSColorFormatString('lch(0.5% 0 0)', createColor)?.toHex();
-    const lchHalfUnit = parseCSSColorFormatString('lch(0.5 0 0)', createColor)?.toHex();
+    const lchHalfPercent = parseCSSColorFormatString('lch(0.5% 0 0)', createColorInstance)?.toHex();
+    const lchHalfUnit = parseCSSColorFormatString('lch(0.5 0 0)', createColorInstance)?.toHex();
     expect(lchHalfPercent).toBe(lchHalfUnit);
 
     expect(labHalfPercent).not.toBe(
-      parseCSSColorFormatString('oklab(0.5 0 0)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklab(0.5 0 0)', createColorInstance)?.toHex(),
     );
     expect(lchHalfPercent).not.toBe(
-      parseCSSColorFormatString('oklch(0.5 0 0)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklch(0.5 0 0)', createColorInstance)?.toHex(),
     );
   });
 
   it('parses OKLCH inputs', () => {
-    expect(parseCSSColorFormatString('oklch(0 0 0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('oklch(1 0 89.876)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('oklch(0.599871 0 89.876)', createColor)?.toHex()).toBe(
-      '#808080',
-    );
-    expect(parseCSSColorFormatString('oklch(0.627955 0.257683 29.234)', createColor)?.toHex()).toBe(
-      '#ff0000',
-    );
-    expect(parseCSSColorFormatString('oklch(0.86644 0.294827 142.495)', createColor)?.toHex()).toBe(
-      '#00ff00',
+    expect(parseCSSColorFormatString('oklch(0 0 0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('oklch(1 0 89.876)', createColorInstance)?.toHex()).toBe(
+      '#ffffff',
     );
     expect(
-      parseCSSColorFormatString('oklch(0.452014 0.313214 264.052)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklch(0.599871 0 89.876)', createColorInstance)?.toHex(),
+    ).toBe('#808080');
+    expect(
+      parseCSSColorFormatString('oklch(0.627955 0.257683 29.234)', createColorInstance)?.toHex(),
+    ).toBe('#ff0000');
+    expect(
+      parseCSSColorFormatString('oklch(0.86644 0.294827 142.495)', createColorInstance)?.toHex(),
+    ).toBe('#00ff00');
+    expect(
+      parseCSSColorFormatString('oklch(0.452014 0.313214 264.052)', createColorInstance)?.toHex(),
     ).toBe('#0000ff');
     expect(
-      parseCSSColorFormatString('oklch(0.967983 0.211006 109.769)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklch(0.967983 0.211006 109.769)', createColorInstance)?.toHex(),
     ).toBe('#ffff00');
-    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 194.769)', createColor)?.toHex()).toBe(
-      '#00ffff',
-    );
     expect(
-      parseCSSColorFormatString('oklch(0.701674 0.322491 328.363)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklch(0.905399 0.15455 194.769)', createColorInstance)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('oklch(0.701674 0.322491 328.363)', createColorInstance)?.toHex(),
     ).toBe('#ff00ff');
     expect(
-      parseCSSColorFormatString('oklch(0.905399 0.15455 0.541025turn)', createColor)?.toHex(),
+      parseCSSColorFormatString(
+        'oklch(0.905399 0.15455 0.541025turn)',
+        createColorInstance,
+      )?.toHex(),
     ).toBe('#00ffff');
     expect(
-      parseCSSColorFormatString('oklch(0.905399 0.15455 3.399358831rad)', createColor)?.toHex(),
+      parseCSSColorFormatString(
+        'oklch(0.905399 0.15455 3.399358831rad)',
+        createColorInstance,
+      )?.toHex(),
     ).toBe('#00ffff');
     expect(
-      parseCSSColorFormatString('oklch(0.905399 0.15455 216.41grad)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklch(0.905399 0.15455 216.41grad)', createColorInstance)?.toHex(),
     ).toBe('#00ffff');
   });
 
   it('parses OKLAB inputs', () => {
-    expect(parseCSSColorFormatString('oklab(0 0 0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('oklab(1 0 0)', createColor)?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('oklab(0.599871 0 0)', createColor)?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('oklab(0 0 0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('oklab(1 0 0)', createColorInstance)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('oklab(0.599871 0 0)', createColorInstance)?.toHex()).toBe(
+      '#808080',
+    );
     expect(
-      parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846)', createColorInstance)?.toHex(),
     ).toBe('#ff0000');
     expect(
-      parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498)', createColor)?.toHex(),
+      parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498)', createColorInstance)?.toHex(),
     ).toBe('#00ff00');
     expect(
-      parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528)', createColor)?.toHex(),
+      parseCSSColorFormatString(
+        'oklab(0.452014 -0.032457 -0.311528)',
+        createColorInstance,
+      )?.toHex(),
     ).toBe('#0000ff');
   });
 
   it('parses OKLAB inputs with optional alpha', () => {
     expect(
-      parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846 / 0.5)', createColor)?.toHex8(),
+      parseCSSColorFormatString(
+        'oklab(0.627955 0.224863 0.125846 / 0.5)',
+        createColorInstance,
+      )?.toHex8(),
     ).toBe('#ff000080');
     expect(
-      parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498 / 25%)', createColor)?.toHex8(),
+      parseCSSColorFormatString(
+        'oklab(0.86644 -0.233888 0.179498 / 25%)',
+        createColorInstance,
+      )?.toHex8(),
     ).toBe('#00ff0040');
     expect(
-      parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528 0.75)', createColor)?.toHex8(),
+      parseCSSColorFormatString(
+        'oklab(0.452014 -0.032457 -0.311528 0.75)',
+        createColorInstance,
+      )?.toHex8(),
     ).toBe('#0000ffbf');
-    expect(parseCSSColorFormatString('oklab(0.599871 0 0 / 0%)', createColor)?.toHex8()).toBe(
-      '#80808000',
-    );
+    expect(
+      parseCSSColorFormatString('oklab(0.599871 0 0 / 0%)', createColorInstance)?.toHex8(),
+    ).toBe('#80808000');
   });
 
   it('parses additional forgiving input variations', () => {
-    expect(parseCSSColorFormatString('cmyk(0% 100% 100% 0%)', createColor)?.toHex()).toBe(
+    expect(parseCSSColorFormatString('cmyk(0% 100% 100% 0%)', createColorInstance)?.toHex()).toBe(
       '#ff0000',
     );
-    expect(parseCSSColorFormatString('lab(53.233%, 80.109, 67.22)', createColor)?.toHex()).toBe(
-      '#ff0000',
-    );
-    expect(parseCSSColorFormatString('lch(53.233%,104.576,40)', createColor)?.toHex()).toBe(
+    expect(
+      parseCSSColorFormatString('lab(53.233%, 80.109, 67.22)', createColorInstance)?.toHex(),
+    ).toBe('#ff0000');
+    expect(parseCSSColorFormatString('lch(53.233%,104.576,40)', createColorInstance)?.toHex()).toBe(
       '#ff0000',
     );
   });
 
   it('clamps out-of-range channel values for supported CSS formats', () => {
-    expect(parseCSSColorFormatString('rgb(300,0,0)', createColor)?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(-1,0,0)', createColor)?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgba(0,0,0,2)', createColor)?.toHex8()).toBe('#000000ff');
-    expect(parseCSSColorFormatString('rgba(0,0,0,-0.1)', createColor)?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('hsl(400,50%,50%)', createColor)?.toHex()).toBe('#bf9540');
-    expect(parseCSSColorFormatString('hsla(0,0%,0%,200%)', createColor)?.toHex8()).toBe(
+    expect(parseCSSColorFormatString('rgb(300,0,0)', createColorInstance)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('rgb(-1,0,0)', createColorInstance)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('rgba(0,0,0,2)', createColorInstance)?.toHex8()).toBe(
+      '#000000ff',
+    );
+    expect(parseCSSColorFormatString('rgba(0,0,0,-0.1)', createColorInstance)?.toHex8()).toBe(
+      '#00000000',
+    );
+    expect(parseCSSColorFormatString('hsl(400,50%,50%)', createColorInstance)?.toHex()).toBe(
+      '#bf9540',
+    );
+    expect(parseCSSColorFormatString('hsla(0,0%,0%,200%)', createColorInstance)?.toHex8()).toBe(
       '#000000ff',
     );
   });
 
   it('returns null on invalid inputs', () => {
-    expect(parseCSSColorFormatString('hsva(0,0%,0%)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('cmyk(0%,0%,0%)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('cmyk(0%,0%,0%,101%)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('lab(120% 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('lab(50% 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('lch(120% 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('lch(50% 30)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklab(1.1 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklab(-0.1 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklab(0.5 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklab(0.5 0 0 / foo)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklch(1.1 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('oklch(-0.1 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('hwb(0 0%)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('foo(1,2,3)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('color(foo 1 0 0)', createColor)).toBeNull();
-    expect(parseCSSColorFormatString('color(display-p3 1 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('hsva(0,0%,0%)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('cmyk(0%,0%,0%)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('cmyk(0%,0%,0%,101%)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('lab(120% 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('lab(50% 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('lch(120% 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('lch(50% 30)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(1.1 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(-0.1 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0 0 / foo)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklch(1.1 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('oklch(-0.1 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('hwb(0 0%)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('foo(1,2,3)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('color(foo 1 0 0)', createColorInstance)).toBeNull();
+    expect(parseCSSColorFormatString('color(display-p3 1 0)', createColorInstance)).toBeNull();
   });
 });

--- a/src/color/__test__/parse.test.ts
+++ b/src/color/__test__/parse.test.ts
@@ -1,65 +1,90 @@
+import { Color } from '../color';
 import { parseCSSColorFormatString } from '../parse';
+
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('parseCSSColorFormatString', () => {
   it('parses RGB inputs', () => {
-    expect(parseCSSColorFormatString('rgb(0, 0, 0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgb(255, 255, 255)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('rgb(128, 128, 128)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('rgb(255, 0, 0)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(0, 255, 0)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('rgb(0, 0, 255)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('rgb(255, 255, 0)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('rgb(0, 255, 255)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('rgb(255, 0, 255)')?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('rgb(0%, 0%, 0%)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgb(100%, 100%, 100%)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('rgb(50%, 50%, 50%)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('rgb(100%, 0%, 0%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(0%, 100%, 0%)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('rgb(0%, 0%, 100%)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('rgb(100%, 100%, 0%)')?.toHex()).toBe('#ffff00');
+    expect(parseCSSColorFormatString('rgb(0, 0, 0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('rgb(255, 255, 255)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('rgb(128, 128, 128)', createColor)?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('rgb(255, 0, 0)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('rgb(0, 255, 0)', createColor)?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('rgb(0, 0, 255)', createColor)?.toHex()).toBe('#0000ff');
+    expect(parseCSSColorFormatString('rgb(255, 255, 0)', createColor)?.toHex()).toBe('#ffff00');
+    expect(parseCSSColorFormatString('rgb(0, 255, 255)', createColor)?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('rgb(255, 0, 255)', createColor)?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('rgb(0%, 0%, 0%)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('rgb(100%, 100%, 100%)', createColor)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('rgb(50%, 50%, 50%)', createColor)?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('rgb(100%, 0%, 0%)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('rgb(0%, 100%, 0%)', createColor)?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('rgb(0%, 0%, 100%)', createColor)?.toHex()).toBe('#0000ff');
+    expect(parseCSSColorFormatString('rgb(100%, 100%, 0%)', createColor)?.toHex()).toBe('#ffff00');
   });
 
   it('parses RGBA inputs', () => {
-    expect(parseCSSColorFormatString('rgba(0, 0, 0, 0)')?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('rgba(255, 255, 255, 1)')?.toHex8()).toBe('#ffffffff');
-    expect(parseCSSColorFormatString('rgba(128, 128, 128, 0.502)')?.toHex8()).toBe('#80808080');
-    expect(parseCSSColorFormatString('rgba(255, 0, 0, 0.502)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('rgba(0, 255, 0, 0.498)')?.toHex8()).toBe('#00ff007f');
-    expect(parseCSSColorFormatString('rgba(0, 0, 255, 0.251)')?.toHex8()).toBe('#0000ff40');
-    expect(parseCSSColorFormatString('rgba(255, 255, 0, 0.753)')?.toHex8()).toBe('#ffff00c0');
-    expect(parseCSSColorFormatString('rgba(0, 255, 255, 0.125)')?.toHex8()).toBe('#00ffff20');
-    expect(parseCSSColorFormatString('rgba(255, 0, 255, 0.6)')?.toHex8()).toBe('#ff00ff99');
-    expect(parseCSSColorFormatString('RGBA(255,0,0,50%)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('rgba(0,255,0,25%)')?.toHex8()).toBe('#00ff0040');
-    expect(parseCSSColorFormatString('rgba(0,0,255,0%)')?.toHex8()).toBe('#0000ff00');
+    expect(parseCSSColorFormatString('rgba(0, 0, 0, 0)', createColor)?.toHex8()).toBe('#00000000');
+    expect(parseCSSColorFormatString('rgba(255, 255, 255, 1)', createColor)?.toHex8()).toBe(
+      '#ffffffff',
+    );
+    expect(parseCSSColorFormatString('rgba(128, 128, 128, 0.502)', createColor)?.toHex8()).toBe(
+      '#80808080',
+    );
+    expect(parseCSSColorFormatString('rgba(255, 0, 0, 0.502)', createColor)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('rgba(0, 255, 0, 0.498)', createColor)?.toHex8()).toBe(
+      '#00ff007f',
+    );
+    expect(parseCSSColorFormatString('rgba(0, 0, 255, 0.251)', createColor)?.toHex8()).toBe(
+      '#0000ff40',
+    );
+    expect(parseCSSColorFormatString('rgba(255, 255, 0, 0.753)', createColor)?.toHex8()).toBe(
+      '#ffff00c0',
+    );
+    expect(parseCSSColorFormatString('rgba(0, 255, 255, 0.125)', createColor)?.toHex8()).toBe(
+      '#00ffff20',
+    );
+    expect(parseCSSColorFormatString('rgba(255, 0, 255, 0.6)', createColor)?.toHex8()).toBe(
+      '#ff00ff99',
+    );
+    expect(parseCSSColorFormatString('RGBA(255,0,0,50%)', createColor)?.toHex8()).toBe('#ff000080');
+    expect(parseCSSColorFormatString('rgba(0,255,0,25%)', createColor)?.toHex8()).toBe('#00ff0040');
+    expect(parseCSSColorFormatString('rgba(0,0,255,0%)', createColor)?.toHex8()).toBe('#0000ff00');
   });
 
   it('parses flexible RGB-style inputs', () => {
-    expect(parseCSSColorFormatString('rgb(100 200 150)')?.toRGB()).toEqual({
+    expect(parseCSSColorFormatString('rgb(100 200 150)', createColor)?.toRGB()).toEqual({
       r: 100,
       g: 200,
       b: 150,
     });
-    expect(parseCSSColorFormatString('rgb(100,200 150)')?.toRGB()).toEqual({
+    expect(parseCSSColorFormatString('rgb(100,200 150)', createColor)?.toRGB()).toEqual({
       r: 100,
       g: 200,
       b: 150,
     });
-    expect(parseCSSColorFormatString('rgb(0 0 0.5)')?.toRGB()).toEqual({ r: 0, g: 0, b: 128 });
-    expect(parseCSSColorFormatString('rgb(10% 20% 30% / 50%)')?.toRGBA()).toEqual({
+    expect(parseCSSColorFormatString('rgb(0 0 0.5)', createColor)?.toRGB()).toEqual({
+      r: 0,
+      g: 0,
+      b: 128,
+    });
+    expect(parseCSSColorFormatString('rgb(10% 20% 30% / 50%)', createColor)?.toRGBA()).toEqual({
       r: 26,
       g: 51,
       b: 77,
       a: 0.5,
     });
-    expect(parseCSSColorFormatString('rgba(0.1 0.2 0.3 / 0.4)')?.toRGBA()).toEqual({
+    expect(parseCSSColorFormatString('rgba(0.1 0.2 0.3 / 0.4)', createColor)?.toRGBA()).toEqual({
       r: 26,
       g: 51,
       b: 77,
       a: 0.4,
     });
-    expect(parseCSSColorFormatString('rgba(5 10 15 / 25%)')?.toRGBA()).toEqual({
+    expect(parseCSSColorFormatString('rgba(5 10 15 / 25%)', createColor)?.toRGBA()).toEqual({
       r: 5,
       g: 10,
       b: 15,
@@ -68,232 +93,382 @@ describe('parseCSSColorFormatString', () => {
   });
 
   it('parses color() inputs', () => {
-    expect(parseCSSColorFormatString('color(srgb 1 0 0)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('color(srgb 100% 0% 0% / 25%)')?.toHex8()).toBe('#ff000040');
-    expect(parseCSSColorFormatString('color(srgb, 1, 1, 1, 50%)')?.toHex8()).toBe('#ffffff80');
-    expect(parseCSSColorFormatString('color(display-p3 0 100% 0 / 75%)')?.toHex8()).toBe(
-      '#00ff00bf',
+    expect(parseCSSColorFormatString('color(srgb 1 0 0)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('color(srgb 100% 0% 0% / 25%)', createColor)?.toHex8()).toBe(
+      '#ff000040',
     );
-    expect(parseCSSColorFormatString('color(display-p3, 50%, 20%, 10% / 0.5)')?.toHex8()).toBe(
-      '#8a2c0d80',
+    expect(parseCSSColorFormatString('color(srgb, 1, 1, 1, 50%)', createColor)?.toHex8()).toBe(
+      '#ffffff80',
     );
-    expect(parseCSSColorFormatString('color(rec2020 25% 50% 75%)')?.toHex()).toBe('#0090cc');
-    expect(parseCSSColorFormatString('color(rec2020 0 0.5 1 / 0.25)')?.toHex8()).toBe('#0092ff40');
-    expect(parseCSSColorFormatString('color(REC2020 0% 0% 0% / 100%)')?.toHex()).toBe('#000000');
+    expect(
+      parseCSSColorFormatString('color(display-p3 0 100% 0 / 75%)', createColor)?.toHex8(),
+    ).toBe('#00ff00bf');
+    expect(
+      parseCSSColorFormatString('color(display-p3, 50%, 20%, 10% / 0.5)', createColor)?.toHex8(),
+    ).toBe('#8a2c0d80');
+    expect(parseCSSColorFormatString('color(rec2020 25% 50% 75%)', createColor)?.toHex()).toBe(
+      '#0090cc',
+    );
+    expect(parseCSSColorFormatString('color(rec2020 0 0.5 1 / 0.25)', createColor)?.toHex8()).toBe(
+      '#0092ff40',
+    );
+    expect(parseCSSColorFormatString('color(REC2020 0% 0% 0% / 100%)', createColor)?.toHex()).toBe(
+      '#000000',
+    );
   });
 
   it('parses HSL inputs', () => {
-    expect(parseCSSColorFormatString('hsl(0, 0%, 0%)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('hsl(0, 0%, 100%)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('hsl(0, 0%, 50%)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('hsl(0, 100%, 50%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hsl(120, 100%, 50%)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hsl(240, 100%, 50%)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('hsl(60, 100%, 50%)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('hsl(180, 100%, 50%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(300, 100%, 50%)')?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('hsl(120deg, 100%, 25%)')?.toHex()).toBe('#008000');
-    expect(parseCSSColorFormatString('hsl(0.5turn 100% 50%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(3.141592653589793rad 100% 50%)')?.toHex()).toBe(
+    expect(parseCSSColorFormatString('hsl(0, 0%, 0%)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('hsl(0, 0%, 100%)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('hsl(0, 0%, 50%)', createColor)?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('hsl(0, 100%, 50%)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('hsl(120, 100%, 50%)', createColor)?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('hsl(240, 100%, 50%)', createColor)?.toHex()).toBe('#0000ff');
+    expect(parseCSSColorFormatString('hsl(60, 100%, 50%)', createColor)?.toHex()).toBe('#ffff00');
+    expect(parseCSSColorFormatString('hsl(180, 100%, 50%)', createColor)?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hsl(300, 100%, 50%)', createColor)?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('hsl(120deg, 100%, 25%)', createColor)?.toHex()).toBe(
+      '#008000',
+    );
+    expect(parseCSSColorFormatString('hsl(0.5turn 100% 50%)', createColor)?.toHex()).toBe(
       '#00ffff',
     );
-    expect(parseCSSColorFormatString('hsl(200grad 100% 50%)')?.toHex()).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('hsl(3.141592653589793rad 100% 50%)', createColor)?.toHex(),
+    ).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hsl(200grad 100% 50%)', createColor)?.toHex()).toBe(
+      '#00ffff',
+    );
   });
 
   it('parses HSLA inputs', () => {
-    expect(parseCSSColorFormatString('hsla(0, 0%, 0%, 0)')?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('hsla(0, 0%, 100%, 1)')?.toHex8()).toBe('#ffffffff');
-    expect(parseCSSColorFormatString('hsla(0, 0%, 50%, 0.502)')?.toHex8()).toBe('#80808080');
-    expect(parseCSSColorFormatString('hsla(0, 100%, 50%, 0.502)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('hsla(120, 100%, 50%, 0.498)')?.toHex8()).toBe('#00ff007f');
-    expect(parseCSSColorFormatString('hsla(240, 100%, 50%, 0.251)')?.toHex8()).toBe('#0000ff40');
-    expect(parseCSSColorFormatString('hsla(60, 100%, 50%, 0.753)')?.toHex8()).toBe('#ffff00c0');
-    expect(parseCSSColorFormatString('hsla(180, 100%, 50%, 0.125)')?.toHex8()).toBe('#00ffff20');
-    expect(parseCSSColorFormatString('hsla(300, 100%, 50%, 0.6)')?.toHex8()).toBe('#ff00ff99');
-    expect(parseCSSColorFormatString('hsla(0,100%,50%,50%)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('hsla(120,100%,50%,25%)')?.toHex8()).toBe('#00ff0040');
-    expect(parseCSSColorFormatString('hsla(240,100%,50%,0%)')?.toHex8()).toBe('#0000ff00');
+    expect(parseCSSColorFormatString('hsla(0, 0%, 0%, 0)', createColor)?.toHex8()).toBe(
+      '#00000000',
+    );
+    expect(parseCSSColorFormatString('hsla(0, 0%, 100%, 1)', createColor)?.toHex8()).toBe(
+      '#ffffffff',
+    );
+    expect(parseCSSColorFormatString('hsla(0, 0%, 50%, 0.502)', createColor)?.toHex8()).toBe(
+      '#80808080',
+    );
+    expect(parseCSSColorFormatString('hsla(0, 100%, 50%, 0.502)', createColor)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('hsla(120, 100%, 50%, 0.498)', createColor)?.toHex8()).toBe(
+      '#00ff007f',
+    );
+    expect(parseCSSColorFormatString('hsla(240, 100%, 50%, 0.251)', createColor)?.toHex8()).toBe(
+      '#0000ff40',
+    );
+    expect(parseCSSColorFormatString('hsla(60, 100%, 50%, 0.753)', createColor)?.toHex8()).toBe(
+      '#ffff00c0',
+    );
+    expect(parseCSSColorFormatString('hsla(180, 100%, 50%, 0.125)', createColor)?.toHex8()).toBe(
+      '#00ffff20',
+    );
+    expect(parseCSSColorFormatString('hsla(300, 100%, 50%, 0.6)', createColor)?.toHex8()).toBe(
+      '#ff00ff99',
+    );
+    expect(parseCSSColorFormatString('hsla(0,100%,50%,50%)', createColor)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('hsla(120,100%,50%,25%)', createColor)?.toHex8()).toBe(
+      '#00ff0040',
+    );
+    expect(parseCSSColorFormatString('hsla(240,100%,50%,0%)', createColor)?.toHex8()).toBe(
+      '#0000ff00',
+    );
   });
 
   it('parses HSV inputs', () => {
-    expect(parseCSSColorFormatString('hsv(0,0%,0%)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('hsv(0,0%,100%)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('hsv(0,0%,50%)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('hsv(0,100%,100%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hsv(120,100%,100%)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hsv(240,100%,100%)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('hsv(60,100%,100%)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('hsv(180,100%,100%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsv(300,100%,100%)')?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('hsv(0,0%,0%)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('hsv(0,0%,100%)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('hsv(0,0%,50%)', createColor)?.toHex()).toBe('#808080');
+    expect(parseCSSColorFormatString('hsv(0,100%,100%)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('hsv(120,100%,100%)', createColor)?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('hsv(240,100%,100%)', createColor)?.toHex()).toBe('#0000ff');
+    expect(parseCSSColorFormatString('hsv(60,100%,100%)', createColor)?.toHex()).toBe('#ffff00');
+    expect(parseCSSColorFormatString('hsv(180,100%,100%)', createColor)?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hsv(300,100%,100%)', createColor)?.toHex()).toBe('#ff00ff');
   });
 
   it('parses HSVA inputs', () => {
-    expect(parseCSSColorFormatString('hsva(0,0%,0%,0)')?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('hsva(0,0%,100%,1)')?.toHex8()).toBe('#ffffffff');
-    expect(parseCSSColorFormatString('hsva(0,0%,50%,0.502)')?.toHex8()).toBe('#80808080');
-    expect(parseCSSColorFormatString('hsva(0,100%,100%,0.502)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('hsva(120,100%,100%,0.498)')?.toHex8()).toBe('#00ff007f');
-    expect(parseCSSColorFormatString('hsva(240,100%,100%,0.251)')?.toHex8()).toBe('#0000ff40');
-    expect(parseCSSColorFormatString('hsva(60,100%,100%,0.753)')?.toHex8()).toBe('#ffff00c0');
-    expect(parseCSSColorFormatString('hsva(180,100%,100%,0.125)')?.toHex8()).toBe('#00ffff20');
-    expect(parseCSSColorFormatString('hsva(300,100%,100%,0.6)')?.toHex8()).toBe('#ff00ff99');
-    expect(parseCSSColorFormatString('hsva(0,100%,100%,50%)')?.toHex8()).toBe('#ff000080');
-    expect(parseCSSColorFormatString('hsva(120,100%,100%,25%)')?.toHex8()).toBe('#00ff0040');
-    expect(parseCSSColorFormatString('hsva(240,100%,100%,0%)')?.toHex8()).toBe('#0000ff00');
+    expect(parseCSSColorFormatString('hsva(0,0%,0%,0)', createColor)?.toHex8()).toBe('#00000000');
+    expect(parseCSSColorFormatString('hsva(0,0%,100%,1)', createColor)?.toHex8()).toBe('#ffffffff');
+    expect(parseCSSColorFormatString('hsva(0,0%,50%,0.502)', createColor)?.toHex8()).toBe(
+      '#80808080',
+    );
+    expect(parseCSSColorFormatString('hsva(0,100%,100%,0.502)', createColor)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('hsva(120,100%,100%,0.498)', createColor)?.toHex8()).toBe(
+      '#00ff007f',
+    );
+    expect(parseCSSColorFormatString('hsva(240,100%,100%,0.251)', createColor)?.toHex8()).toBe(
+      '#0000ff40',
+    );
+    expect(parseCSSColorFormatString('hsva(60,100%,100%,0.753)', createColor)?.toHex8()).toBe(
+      '#ffff00c0',
+    );
+    expect(parseCSSColorFormatString('hsva(180,100%,100%,0.125)', createColor)?.toHex8()).toBe(
+      '#00ffff20',
+    );
+    expect(parseCSSColorFormatString('hsva(300,100%,100%,0.6)', createColor)?.toHex8()).toBe(
+      '#ff00ff99',
+    );
+    expect(parseCSSColorFormatString('hsva(0,100%,100%,50%)', createColor)?.toHex8()).toBe(
+      '#ff000080',
+    );
+    expect(parseCSSColorFormatString('hsva(120,100%,100%,25%)', createColor)?.toHex8()).toBe(
+      '#00ff0040',
+    );
+    expect(parseCSSColorFormatString('hsva(240,100%,100%,0%)', createColor)?.toHex8()).toBe(
+      '#0000ff00',
+    );
   });
 
   it('parses HWB inputs', () => {
-    expect(parseCSSColorFormatString('hwb(0 0% 0%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('hwb(120 40% 20%)')?.toHex()).toBe('#66cc66');
-    expect(parseCSSColorFormatString('hwb(210 10% 30% / 0.25)')?.toHex8()).toBe('#1a66b340');
-    expect(parseCSSColorFormatString('hwb(210 10% 30% 25%)')?.toHex8()).toBe('#1a66b340');
-    expect(parseCSSColorFormatString('hwb(480 0% 0%)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('hwb(0.5turn 0% 0%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hwb(3.141592653589793rad 0% 0%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hwb(200grad 0% 0%)')?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hwb(0 0% 0%)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('hwb(120 40% 20%)', createColor)?.toHex()).toBe('#66cc66');
+    expect(parseCSSColorFormatString('hwb(210 10% 30% / 0.25)', createColor)?.toHex8()).toBe(
+      '#1a66b340',
+    );
+    expect(parseCSSColorFormatString('hwb(210 10% 30% 25%)', createColor)?.toHex8()).toBe(
+      '#1a66b340',
+    );
+    expect(parseCSSColorFormatString('hwb(480 0% 0%)', createColor)?.toHex()).toBe('#00ff00');
+    expect(parseCSSColorFormatString('hwb(0.5turn 0% 0%)', createColor)?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hwb(3.141592653589793rad 0% 0%)', createColor)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('hwb(200grad 0% 0%)', createColor)?.toHex()).toBe('#00ffff');
   });
 
   it('parses flexible HSL and HSV inputs', () => {
-    expect(parseCSSColorFormatString('hsl(180 100% 50%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('hsl(180 100% 50% / 0.25)')?.toHex8()).toBe('#00ffff40');
-    expect(parseCSSColorFormatString('hsv(300 100% 100% / 0.5)')?.toHex8()).toBe('#ff00ff80');
+    expect(parseCSSColorFormatString('hsl(180 100% 50%)', createColor)?.toHex()).toBe('#00ffff');
+    expect(parseCSSColorFormatString('hsl(180 100% 50% / 0.25)', createColor)?.toHex8()).toBe(
+      '#00ffff40',
+    );
+    expect(parseCSSColorFormatString('hsv(300 100% 100% / 0.5)', createColor)?.toHex8()).toBe(
+      '#ff00ff80',
+    );
   });
 
   it('parses CMYK inputs', () => {
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 100%)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 0%)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 50%)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('cmyk(0%,100%,100%,0%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('cmyk(100%, 0%, 100%, 0%)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('cmyk(100%, 100%, 0%, 0%)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('cmyk(0%, 0%, 100%, 0%)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('cmyk(100%, 0%, 0%, 0%)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('cmyk(0%, 100%, 0%, 0%)')?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 100%)', createColor)?.toHex()).toBe(
+      '#000000',
+    );
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 0%)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 0%, 50%)', createColor)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('cmyk(0%,100%,100%,0%)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('cmyk(100%, 0%, 100%, 0%)', createColor)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('cmyk(100%, 100%, 0%, 0%)', createColor)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('cmyk(0%, 0%, 100%, 0%)', createColor)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('cmyk(100%, 0%, 0%, 0%)', createColor)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('cmyk(0%, 100%, 0%, 0%)', createColor)?.toHex()).toBe(
+      '#ff00ff',
+    );
   });
 
   it('parses LAB inputs', () => {
-    expect(parseCSSColorFormatString('lab(0% 0 0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('lab(100% 0.005 -0.01)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('lab(53.585% 0.003 -0.006)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('lab(53.233% 80.109 67.22)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('lab(87.737% -86.185 83.181)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('lab(32.303% 79.197 -107.864)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('lab(97.138% -21.556 94.482)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('lab(91.117% -48.08 -14.138)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('lab(60.32% 98.254 -60.843)')?.toHex()).toBe('#ff00ff');
+    expect(parseCSSColorFormatString('lab(0% 0 0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('lab(100% 0.005 -0.01)', createColor)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('lab(53.585% 0.003 -0.006)', createColor)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('lab(53.233% 80.109 67.22)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('lab(87.737% -86.185 83.181)', createColor)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('lab(32.303% 79.197 -107.864)', createColor)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('lab(97.138% -21.556 94.482)', createColor)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('lab(91.117% -48.08 -14.138)', createColor)?.toHex()).toBe(
+      '#00ffff',
+    );
+    expect(parseCSSColorFormatString('lab(60.32% 98.254 -60.843)', createColor)?.toHex()).toBe(
+      '#ff00ff',
+    );
   });
 
   it('parses LCH inputs', () => {
-    expect(parseCSSColorFormatString('lch(0% 0 0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('lch(100% 0.012 296.813)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('lch(53.585% 0.007 296.813)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('lch(53.233% 104.576 40)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('lch(87.737% 119.779 136.016)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('lch(32.303% 133.816 306.287)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('lch(97.138% 96.91 102.852)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('lch(91.117% 50.115 196.386)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('lch(60.32% 115.567 328.233)')?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('lch(91.117% 50.115 0.5455166667turn)')?.toHex()).toBe(
+    expect(parseCSSColorFormatString('lch(0% 0 0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('lch(100% 0.012 296.813)', createColor)?.toHex()).toBe(
+      '#ffffff',
+    );
+    expect(parseCSSColorFormatString('lch(53.585% 0.007 296.813)', createColor)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('lch(53.233% 104.576 40)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('lch(87.737% 119.779 136.016)', createColor)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(parseCSSColorFormatString('lch(32.303% 133.816 306.287)', createColor)?.toHex()).toBe(
+      '#0000ff',
+    );
+    expect(parseCSSColorFormatString('lch(97.138% 96.91 102.852)', createColor)?.toHex()).toBe(
+      '#ffff00',
+    );
+    expect(parseCSSColorFormatString('lch(91.117% 50.115 196.386)', createColor)?.toHex()).toBe(
       '#00ffff',
     );
-    expect(parseCSSColorFormatString('lch(91.117% 50.115 3.427586338rad)')?.toHex()).toBe(
-      '#00ffff',
+    expect(parseCSSColorFormatString('lch(60.32% 115.567 328.233)', createColor)?.toHex()).toBe(
+      '#ff00ff',
     );
-    expect(parseCSSColorFormatString('lch(91.117% 50.115 218.2066667grad)')?.toHex()).toBe(
-      '#00ffff',
-    );
+    expect(
+      parseCSSColorFormatString('lch(91.117% 50.115 0.5455166667turn)', createColor)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('lch(91.117% 50.115 3.427586338rad)', createColor)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('lch(91.117% 50.115 218.2066667grad)', createColor)?.toHex(),
+    ).toBe('#00ffff');
   });
 
   it('parses very small LAB/LCH percentage lightness like canonical LAB/LCH (not OKLAB/OKLCH)', () => {
-    const labHalfPercent = parseCSSColorFormatString('lab(0.5% 0 0)')?.toHex();
-    const labHalfUnit = parseCSSColorFormatString('lab(0.5 0 0)')?.toHex();
+    const labHalfPercent = parseCSSColorFormatString('lab(0.5% 0 0)', createColor)?.toHex();
+    const labHalfUnit = parseCSSColorFormatString('lab(0.5 0 0)', createColor)?.toHex();
     expect(labHalfPercent).toBe(labHalfUnit);
 
-    const lchHalfPercent = parseCSSColorFormatString('lch(0.5% 0 0)')?.toHex();
-    const lchHalfUnit = parseCSSColorFormatString('lch(0.5 0 0)')?.toHex();
+    const lchHalfPercent = parseCSSColorFormatString('lch(0.5% 0 0)', createColor)?.toHex();
+    const lchHalfUnit = parseCSSColorFormatString('lch(0.5 0 0)', createColor)?.toHex();
     expect(lchHalfPercent).toBe(lchHalfUnit);
 
-    expect(labHalfPercent).not.toBe(parseCSSColorFormatString('oklab(0.5 0 0)')?.toHex());
-    expect(lchHalfPercent).not.toBe(parseCSSColorFormatString('oklch(0.5 0 0)')?.toHex());
+    expect(labHalfPercent).not.toBe(
+      parseCSSColorFormatString('oklab(0.5 0 0)', createColor)?.toHex(),
+    );
+    expect(lchHalfPercent).not.toBe(
+      parseCSSColorFormatString('oklch(0.5 0 0)', createColor)?.toHex(),
+    );
   });
 
   it('parses OKLCH inputs', () => {
-    expect(parseCSSColorFormatString('oklch(0 0 0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('oklch(1 0 89.876)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('oklch(0.599871 0 89.876)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('oklch(0.627955 0.257683 29.234)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('oklch(0.86644 0.294827 142.495)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('oklch(0.452014 0.313214 264.052)')?.toHex()).toBe('#0000ff');
-    expect(parseCSSColorFormatString('oklch(0.967983 0.211006 109.769)')?.toHex()).toBe('#ffff00');
-    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 194.769)')?.toHex()).toBe('#00ffff');
-    expect(parseCSSColorFormatString('oklch(0.701674 0.322491 328.363)')?.toHex()).toBe('#ff00ff');
-    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 0.541025turn)')?.toHex()).toBe(
+    expect(parseCSSColorFormatString('oklch(0 0 0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('oklch(1 0 89.876)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('oklch(0.599871 0 89.876)', createColor)?.toHex()).toBe(
+      '#808080',
+    );
+    expect(parseCSSColorFormatString('oklch(0.627955 0.257683 29.234)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('oklch(0.86644 0.294827 142.495)', createColor)?.toHex()).toBe(
+      '#00ff00',
+    );
+    expect(
+      parseCSSColorFormatString('oklch(0.452014 0.313214 264.052)', createColor)?.toHex(),
+    ).toBe('#0000ff');
+    expect(
+      parseCSSColorFormatString('oklch(0.967983 0.211006 109.769)', createColor)?.toHex(),
+    ).toBe('#ffff00');
+    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 194.769)', createColor)?.toHex()).toBe(
       '#00ffff',
     );
-    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 3.399358831rad)')?.toHex()).toBe(
-      '#00ffff',
-    );
-    expect(parseCSSColorFormatString('oklch(0.905399 0.15455 216.41grad)')?.toHex()).toBe(
-      '#00ffff',
-    );
+    expect(
+      parseCSSColorFormatString('oklch(0.701674 0.322491 328.363)', createColor)?.toHex(),
+    ).toBe('#ff00ff');
+    expect(
+      parseCSSColorFormatString('oklch(0.905399 0.15455 0.541025turn)', createColor)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('oklch(0.905399 0.15455 3.399358831rad)', createColor)?.toHex(),
+    ).toBe('#00ffff');
+    expect(
+      parseCSSColorFormatString('oklch(0.905399 0.15455 216.41grad)', createColor)?.toHex(),
+    ).toBe('#00ffff');
   });
 
   it('parses OKLAB inputs', () => {
-    expect(parseCSSColorFormatString('oklab(0 0 0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('oklab(1 0 0)')?.toHex()).toBe('#ffffff');
-    expect(parseCSSColorFormatString('oklab(0.599871 0 0)')?.toHex()).toBe('#808080');
-    expect(parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498)')?.toHex()).toBe('#00ff00');
-    expect(parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528)')?.toHex()).toBe(
-      '#0000ff',
-    );
+    expect(parseCSSColorFormatString('oklab(0 0 0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('oklab(1 0 0)', createColor)?.toHex()).toBe('#ffffff');
+    expect(parseCSSColorFormatString('oklab(0.599871 0 0)', createColor)?.toHex()).toBe('#808080');
+    expect(
+      parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846)', createColor)?.toHex(),
+    ).toBe('#ff0000');
+    expect(
+      parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498)', createColor)?.toHex(),
+    ).toBe('#00ff00');
+    expect(
+      parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528)', createColor)?.toHex(),
+    ).toBe('#0000ff');
   });
 
   it('parses OKLAB inputs with optional alpha', () => {
-    expect(parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846 / 0.5)')?.toHex8()).toBe(
-      '#ff000080',
+    expect(
+      parseCSSColorFormatString('oklab(0.627955 0.224863 0.125846 / 0.5)', createColor)?.toHex8(),
+    ).toBe('#ff000080');
+    expect(
+      parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498 / 25%)', createColor)?.toHex8(),
+    ).toBe('#00ff0040');
+    expect(
+      parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528 0.75)', createColor)?.toHex8(),
+    ).toBe('#0000ffbf');
+    expect(parseCSSColorFormatString('oklab(0.599871 0 0 / 0%)', createColor)?.toHex8()).toBe(
+      '#80808000',
     );
-    expect(parseCSSColorFormatString('oklab(0.86644 -0.233888 0.179498 / 25%)')?.toHex8()).toBe(
-      '#00ff0040',
-    );
-    expect(parseCSSColorFormatString('oklab(0.452014 -0.032457 -0.311528 0.75)')?.toHex8()).toBe(
-      '#0000ffbf',
-    );
-    expect(parseCSSColorFormatString('oklab(0.599871 0 0 / 0%)')?.toHex8()).toBe('#80808000');
   });
 
   it('parses additional forgiving input variations', () => {
-    expect(parseCSSColorFormatString('cmyk(0% 100% 100% 0%)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('lab(53.233%, 80.109, 67.22)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('lch(53.233%,104.576,40)')?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('cmyk(0% 100% 100% 0%)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('lab(53.233%, 80.109, 67.22)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
+    expect(parseCSSColorFormatString('lch(53.233%,104.576,40)', createColor)?.toHex()).toBe(
+      '#ff0000',
+    );
   });
 
   it('clamps out-of-range channel values for supported CSS formats', () => {
-    expect(parseCSSColorFormatString('rgb(300,0,0)')?.toHex()).toBe('#ff0000');
-    expect(parseCSSColorFormatString('rgb(-1,0,0)')?.toHex()).toBe('#000000');
-    expect(parseCSSColorFormatString('rgba(0,0,0,2)')?.toHex8()).toBe('#000000ff');
-    expect(parseCSSColorFormatString('rgba(0,0,0,-0.1)')?.toHex8()).toBe('#00000000');
-    expect(parseCSSColorFormatString('hsl(400,50%,50%)')?.toHex()).toBe('#bf9540');
-    expect(parseCSSColorFormatString('hsla(0,0%,0%,200%)')?.toHex8()).toBe('#000000ff');
+    expect(parseCSSColorFormatString('rgb(300,0,0)', createColor)?.toHex()).toBe('#ff0000');
+    expect(parseCSSColorFormatString('rgb(-1,0,0)', createColor)?.toHex()).toBe('#000000');
+    expect(parseCSSColorFormatString('rgba(0,0,0,2)', createColor)?.toHex8()).toBe('#000000ff');
+    expect(parseCSSColorFormatString('rgba(0,0,0,-0.1)', createColor)?.toHex8()).toBe('#00000000');
+    expect(parseCSSColorFormatString('hsl(400,50%,50%)', createColor)?.toHex()).toBe('#bf9540');
+    expect(parseCSSColorFormatString('hsla(0,0%,0%,200%)', createColor)?.toHex8()).toBe(
+      '#000000ff',
+    );
   });
 
   it('returns null on invalid inputs', () => {
-    expect(parseCSSColorFormatString('hsva(0,0%,0%)')).toBeNull();
-    expect(parseCSSColorFormatString('cmyk(0%,0%,0%)')).toBeNull();
-    expect(parseCSSColorFormatString('cmyk(0%,0%,0%,101%)')).toBeNull();
-    expect(parseCSSColorFormatString('lab(120% 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('lab(50% 0)')).toBeNull();
-    expect(parseCSSColorFormatString('lch(120% 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('lch(50% 30)')).toBeNull();
-    expect(parseCSSColorFormatString('oklab(1.1 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('oklab(-0.1 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('oklab(0.5 0)')).toBeNull();
-    expect(parseCSSColorFormatString('oklab(0.5 0 0 / foo)')).toBeNull();
-    expect(parseCSSColorFormatString('oklch(1.1 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('oklch(-0.1 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('hwb(0 0%)')).toBeNull();
-    expect(parseCSSColorFormatString('foo(1,2,3)')).toBeNull();
-    expect(parseCSSColorFormatString('color(foo 1 0 0)')).toBeNull();
-    expect(parseCSSColorFormatString('color(display-p3 1 0)')).toBeNull();
+    expect(parseCSSColorFormatString('hsva(0,0%,0%)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('cmyk(0%,0%,0%)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('cmyk(0%,0%,0%,101%)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('lab(120% 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('lab(50% 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('lch(120% 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('lch(50% 30)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(1.1 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(-0.1 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklab(0.5 0 0 / foo)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklch(1.1 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('oklch(-0.1 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('hwb(0 0%)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('foo(1,2,3)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('color(foo 1 0 0)', createColor)).toBeNull();
+    expect(parseCSSColorFormatString('color(display-p3 1 0)', createColor)).toBeNull();
   });
 });

--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -10,6 +10,8 @@ import {
 } from '../readability';
 import { getColorList } from '../utils';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('getWCAGContrastRatio', () => {
   it('red dark on #000000 alpha 1', () => {
     const fg = new Color('#990000');
@@ -2888,7 +2890,7 @@ describe('readability selection helpers', () => {
     const basicSwatch = new Color('#85ff97').getColorSwatch({ extended: false });
     const resultBasic = getMostReadableTextColorForBackground(
       background,
-      getColorList(basicSwatch),
+      getColorList(basicSwatch, createColor),
     );
     expect(resultBasic.equals(basicSwatch[900])).toBe(true);
 
@@ -2898,7 +2900,7 @@ describe('readability selection helpers', () => {
     });
     const resultExtended = getMostReadableTextColorForBackground(
       background,
-      getColorList(extendedSwatch),
+      getColorList(extendedSwatch, createColor),
     );
     expect(resultExtended.equals(extendedSwatch[950])).toBe(true);
   });
@@ -2916,7 +2918,7 @@ describe('readability selection helpers', () => {
     const textColor = new Color('#111827');
     const swatch = new Color('#fbbf24').getColorSwatch({ extended: true, centerOn500: true });
 
-    const result = getBestBackgroundColorForText(textColor, getColorList(swatch));
+    const result = getBestBackgroundColorForText(textColor, getColorList(swatch, createColor));
 
     expect(result.toHex()).toBe(swatch[50].toHex());
   });

--- a/src/color/__test__/readability.test.ts
+++ b/src/color/__test__/readability.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import {
   getAPCAReadabilityReport,
   getAPCAReadabilityScore,
@@ -9,8 +9,6 @@ import {
   isTextReadable,
 } from '../readability';
 import { getColorList } from '../utils';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('getWCAGContrastRatio', () => {
   it('red dark on #000000 alpha 1', () => {
@@ -2890,7 +2888,7 @@ describe('readability selection helpers', () => {
     const basicSwatch = new Color('#85ff97').getColorSwatch({ extended: false });
     const resultBasic = getMostReadableTextColorForBackground(
       background,
-      getColorList(basicSwatch, createColor),
+      getColorList(basicSwatch, createColorInstance),
     );
     expect(resultBasic.equals(basicSwatch[900])).toBe(true);
 
@@ -2900,7 +2898,7 @@ describe('readability selection helpers', () => {
     });
     const resultExtended = getMostReadableTextColorForBackground(
       background,
-      getColorList(extendedSwatch, createColor),
+      getColorList(extendedSwatch, createColorInstance),
     );
     expect(resultExtended.equals(extendedSwatch[950])).toBe(true);
   });
@@ -2918,7 +2916,10 @@ describe('readability selection helpers', () => {
     const textColor = new Color('#111827');
     const swatch = new Color('#fbbf24').getColorSwatch({ extended: true, centerOn500: true });
 
-    const result = getBestBackgroundColorForText(textColor, getColorList(swatch, createColor));
+    const result = getBestBackgroundColorForText(
+      textColor,
+      getColorList(swatch, createColorInstance),
+    );
 
     expect(result.toHex()).toBe(swatch[50].toHex());
   });

--- a/src/color/__test__/srgb.test.ts
+++ b/src/color/__test__/srgb.test.ts
@@ -1,0 +1,51 @@
+import { linearChannelToSrgb, srgbChannelToLinear } from '../srgb';
+
+describe('srgbChannelToLinear', () => {
+  it('converts canonical boundary values for SRGB and WCAG pivots', () => {
+    expect(srgbChannelToLinear(0, 'SRGB')).toBe(0);
+    expect(srgbChannelToLinear(255, 'SRGB')).toBe(1);
+    expect(srgbChannelToLinear(0, 'WCAG')).toBe(0);
+    expect(srgbChannelToLinear(255, 'WCAG')).toBe(1);
+
+    expect(srgbChannelToLinear(10.31475, 'SRGB')).toBeCloseTo(0.0031308, 6);
+    expect(srgbChannelToLinear(10.0164, 'WCAG')).toBeCloseTo(0.003041, 5);
+  });
+
+  it('clamps out-of-range channel values', () => {
+    expect(srgbChannelToLinear(-10, 'SRGB')).toBe(0);
+    expect(srgbChannelToLinear(300, 'SRGB')).toBe(1);
+  });
+});
+
+describe('linearChannelToSrgb', () => {
+  it('converts canonical boundary values for SRGB and WCAG pivots', () => {
+    expect(linearChannelToSrgb(0, 'SRGB')).toBe(0);
+    expect(linearChannelToSrgb(1, 'SRGB')).toBeCloseTo(255, 10);
+    expect(linearChannelToSrgb(0, 'WCAG')).toBe(0);
+    expect(linearChannelToSrgb(1, 'WCAG')).toBeCloseTo(255, 10);
+
+    expect(linearChannelToSrgb(0.0031308, 'SRGB')).toBeCloseTo(10.31475, 4);
+    expect(linearChannelToSrgb(0.003041, 'WCAG')).toBeCloseTo(10.02137, 5);
+  });
+
+  it('clamps out-of-range linear values', () => {
+    expect(linearChannelToSrgb(-1, 'WCAG')).toBe(0);
+    expect(linearChannelToSrgb(2, 'WCAG')).toBeCloseTo(255, 10);
+  });
+});
+
+describe('sRGB transfer round-trip behavior', () => {
+  it('round-trips representative values within floating-point tolerance', () => {
+    const channel0 = linearChannelToSrgb(srgbChannelToLinear(0, 'SRGB'), 'SRGB');
+    const channel1 = linearChannelToSrgb(srgbChannelToLinear(64, 'SRGB'), 'SRGB');
+    const channel2 = linearChannelToSrgb(srgbChannelToLinear(127.5, 'SRGB'), 'SRGB');
+    const channel3 = linearChannelToSrgb(srgbChannelToLinear(200, 'SRGB'), 'SRGB');
+    const channel4 = linearChannelToSrgb(srgbChannelToLinear(255, 'SRGB'), 'SRGB');
+
+    expect(channel0).toBeCloseTo(0, 10);
+    expect(channel1).toBeCloseTo(64, 10);
+    expect(channel2).toBeCloseTo(127.5, 10);
+    expect(channel3).toBeCloseTo(200, 10);
+    expect(channel4).toBeCloseTo(255, 10);
+  });
+});

--- a/src/color/__test__/swatch.test.ts
+++ b/src/color/__test__/swatch.test.ts
@@ -1,13 +1,11 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import { getColorSwatch } from '../swatch';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('getPaletteColorVariations', () => {
   describe('black', () => {
     it('returns grayscale steps', () => {
       const baseColor = new Color('#000000');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, {}, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#666666');
       expect(swatch[200].toHex()).toBe('#4d4d4d');
@@ -24,7 +22,7 @@ describe('getPaletteColorVariations', () => {
   describe('white', () => {
     it('returns darker grays for higher numbers', () => {
       const baseColor = new Color('#ffffff');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ffffff');
       expect(swatch[200].toHex()).toBe('#ffffff');
@@ -41,7 +39,7 @@ describe('getPaletteColorVariations', () => {
   describe('gray', () => {
     it('keeps shades neutral', () => {
       const baseColor = new Color('#808080');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#e6e6e6');
       expect(swatch[200].toHex()).toBe('#cccccc');
@@ -58,7 +56,7 @@ describe('getPaletteColorVariations', () => {
   describe('dark navy', () => {
     it('spans from vibrant blue to black', () => {
       const baseColor = new Color('#123456');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, {}, createColorInstance);
       expect(swatch.mainStop).toBe(700);
       expect(swatch[100].toHex()).toBe('#9dcdfd');
       expect(swatch[200].toHex()).toBe('#6fb3f8');
@@ -75,7 +73,7 @@ describe('getPaletteColorVariations', () => {
   describe('pastel blue', () => {
     it('lightens up to white and darkens gradually', () => {
       const baseColor = new Color('#abcdef');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(300);
       expect(swatch[100].toHex()).toBe('#ffffff');
       expect(swatch[200].toHex()).toBe('#d5e7f8');
@@ -92,7 +90,7 @@ describe('getPaletteColorVariations', () => {
   describe('red', () => {
     it('creates a classic red palette', () => {
       const baseColor = new Color('#ff0000');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, {}, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ffcccc');
       expect(swatch[200].toHex()).toBe('#ff9999');
@@ -109,7 +107,7 @@ describe('getPaletteColorVariations', () => {
   describe('green', () => {
     it('creates a classic green palette', () => {
       const baseColor = new Color('#00ff00');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ccffcc');
       expect(swatch[200].toHex()).toBe('#99ff99');
@@ -126,7 +124,7 @@ describe('getPaletteColorVariations', () => {
   describe('blue', () => {
     it('creates a classic blue palette', () => {
       const baseColor = new Color('#0000ff');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ccccff');
       expect(swatch[200].toHex()).toBe('#9999ff');
@@ -143,7 +141,7 @@ describe('getPaletteColorVariations', () => {
   describe('greyish teal', () => {
     it('retains its muted character', () => {
       const baseColor = new Color('#7f8c8d');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, undefined, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#e7f0f1');
       expect(swatch[200].toHex()).toBe('#c9dadc');
@@ -160,7 +158,7 @@ describe('getPaletteColorVariations', () => {
   describe('brand blue', () => {
     it('spans a useful design range', () => {
       const baseColor = new Color('#3498db');
-      const swatch = getColorSwatch(baseColor, createColor);
+      const swatch = getColorSwatch(baseColor, {}, createColorInstance);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#def1fd');
       expect(swatch[200].toHex()).toBe('#b0dbf8');
@@ -177,8 +175,8 @@ describe('getPaletteColorVariations', () => {
   describe('swatch metadata', () => {
     it('labels swatches by type', () => {
       const baseColor = new Color('#3498db');
-      const basicSwatch = getColorSwatch(baseColor, createColor);
-      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColor);
+      const basicSwatch = getColorSwatch(baseColor, undefined, createColorInstance);
+      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColorInstance);
 
       expect(basicSwatch.type).toBe('BASIC');
       expect(basicSwatch.mainStop).toBe(500);
@@ -190,7 +188,7 @@ describe('getPaletteColorVariations', () => {
   describe('centering options', () => {
     it('can force centering on 500 even for very dark colors', () => {
       const baseColor = new Color('#123456');
-      const swatch = getColorSwatch(baseColor, { centerOn500: true }, createColor);
+      const swatch = getColorSwatch(baseColor, { centerOn500: true }, createColorInstance);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#449af0');
@@ -208,7 +206,7 @@ describe('getPaletteColorVariations', () => {
   describe('extended swatches', () => {
     it('includes intermediate stops while preserving the base anchors', () => {
       const baseColor = new Color('#ff0000');
-      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColorInstance);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[50].toHex()).toBe('#ffe5e5');
@@ -234,7 +232,7 @@ describe('getPaletteColorVariations', () => {
 
     it('smoothly interpolates neutral colors', () => {
       const baseColor = new Color('#808080');
-      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColorInstance);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[50].toHex()).toBe('#f3f3f3');
@@ -260,8 +258,8 @@ describe('getPaletteColorVariations', () => {
 
     it('matches anchor shades between base and extended swatches', () => {
       const baseColor = new Color('#3498db');
-      const baseSwatch = getColorSwatch(baseColor, createColor);
-      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColor);
+      const baseSwatch = getColorSwatch(baseColor, {}, createColorInstance);
+      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColorInstance);
 
       expect(extendedSwatch.mainStop).toBe(baseSwatch.mainStop);
       expect(extendedSwatch[100].toHex()).toBe(baseSwatch[100].toHex());
@@ -279,7 +277,7 @@ describe('getPaletteColorVariations', () => {
   describe('alpha preservation', () => {
     it('keeps the base alpha for all generated stops', () => {
       const baseColor = new Color('rgba(52, 152, 219, 0.4)');
-      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColorInstance);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[300].toRGBA().a).toBeCloseTo(0.4, 5);

--- a/src/color/__test__/swatch.test.ts
+++ b/src/color/__test__/swatch.test.ts
@@ -1,11 +1,13 @@
 import { Color } from '../color';
 import { getColorSwatch } from '../swatch';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('getPaletteColorVariations', () => {
   describe('black', () => {
     it('returns grayscale steps', () => {
       const baseColor = new Color('#000000');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#666666');
       expect(swatch[200].toHex()).toBe('#4d4d4d');
@@ -22,7 +24,7 @@ describe('getPaletteColorVariations', () => {
   describe('white', () => {
     it('returns darker grays for higher numbers', () => {
       const baseColor = new Color('#ffffff');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ffffff');
       expect(swatch[200].toHex()).toBe('#ffffff');
@@ -39,7 +41,7 @@ describe('getPaletteColorVariations', () => {
   describe('gray', () => {
     it('keeps shades neutral', () => {
       const baseColor = new Color('#808080');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#e6e6e6');
       expect(swatch[200].toHex()).toBe('#cccccc');
@@ -56,7 +58,7 @@ describe('getPaletteColorVariations', () => {
   describe('dark navy', () => {
     it('spans from vibrant blue to black', () => {
       const baseColor = new Color('#123456');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(700);
       expect(swatch[100].toHex()).toBe('#9dcdfd');
       expect(swatch[200].toHex()).toBe('#6fb3f8');
@@ -73,7 +75,7 @@ describe('getPaletteColorVariations', () => {
   describe('pastel blue', () => {
     it('lightens up to white and darkens gradually', () => {
       const baseColor = new Color('#abcdef');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(300);
       expect(swatch[100].toHex()).toBe('#ffffff');
       expect(swatch[200].toHex()).toBe('#d5e7f8');
@@ -90,7 +92,7 @@ describe('getPaletteColorVariations', () => {
   describe('red', () => {
     it('creates a classic red palette', () => {
       const baseColor = new Color('#ff0000');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ffcccc');
       expect(swatch[200].toHex()).toBe('#ff9999');
@@ -107,7 +109,7 @@ describe('getPaletteColorVariations', () => {
   describe('green', () => {
     it('creates a classic green palette', () => {
       const baseColor = new Color('#00ff00');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ccffcc');
       expect(swatch[200].toHex()).toBe('#99ff99');
@@ -124,7 +126,7 @@ describe('getPaletteColorVariations', () => {
   describe('blue', () => {
     it('creates a classic blue palette', () => {
       const baseColor = new Color('#0000ff');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#ccccff');
       expect(swatch[200].toHex()).toBe('#9999ff');
@@ -141,7 +143,7 @@ describe('getPaletteColorVariations', () => {
   describe('greyish teal', () => {
     it('retains its muted character', () => {
       const baseColor = new Color('#7f8c8d');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#e7f0f1');
       expect(swatch[200].toHex()).toBe('#c9dadc');
@@ -158,7 +160,7 @@ describe('getPaletteColorVariations', () => {
   describe('brand blue', () => {
     it('spans a useful design range', () => {
       const baseColor = new Color('#3498db');
-      const swatch = getColorSwatch(baseColor);
+      const swatch = getColorSwatch(baseColor, createColor);
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#def1fd');
       expect(swatch[200].toHex()).toBe('#b0dbf8');
@@ -175,8 +177,8 @@ describe('getPaletteColorVariations', () => {
   describe('swatch metadata', () => {
     it('labels swatches by type', () => {
       const baseColor = new Color('#3498db');
-      const basicSwatch = getColorSwatch(baseColor);
-      const extendedSwatch = getColorSwatch(baseColor, { extended: true });
+      const basicSwatch = getColorSwatch(baseColor, createColor);
+      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColor);
 
       expect(basicSwatch.type).toBe('BASIC');
       expect(basicSwatch.mainStop).toBe(500);
@@ -188,7 +190,7 @@ describe('getPaletteColorVariations', () => {
   describe('centering options', () => {
     it('can force centering on 500 even for very dark colors', () => {
       const baseColor = new Color('#123456');
-      const swatch = getColorSwatch(baseColor, { centerOn500: true });
+      const swatch = getColorSwatch(baseColor, { centerOn500: true }, createColor);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[100].toHex()).toBe('#449af0');
@@ -206,7 +208,7 @@ describe('getPaletteColorVariations', () => {
   describe('extended swatches', () => {
     it('includes intermediate stops while preserving the base anchors', () => {
       const baseColor = new Color('#ff0000');
-      const swatch = getColorSwatch(baseColor, { extended: true });
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[50].toHex()).toBe('#ffe5e5');
@@ -232,7 +234,7 @@ describe('getPaletteColorVariations', () => {
 
     it('smoothly interpolates neutral colors', () => {
       const baseColor = new Color('#808080');
-      const swatch = getColorSwatch(baseColor, { extended: true });
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[50].toHex()).toBe('#f3f3f3');
@@ -258,8 +260,8 @@ describe('getPaletteColorVariations', () => {
 
     it('matches anchor shades between base and extended swatches', () => {
       const baseColor = new Color('#3498db');
-      const baseSwatch = getColorSwatch(baseColor);
-      const extendedSwatch = getColorSwatch(baseColor, { extended: true });
+      const baseSwatch = getColorSwatch(baseColor, createColor);
+      const extendedSwatch = getColorSwatch(baseColor, { extended: true }, createColor);
 
       expect(extendedSwatch.mainStop).toBe(baseSwatch.mainStop);
       expect(extendedSwatch[100].toHex()).toBe(baseSwatch[100].toHex());
@@ -277,7 +279,7 @@ describe('getPaletteColorVariations', () => {
   describe('alpha preservation', () => {
     it('keeps the base alpha for all generated stops', () => {
       const baseColor = new Color('rgba(52, 152, 219, 0.4)');
-      const swatch = getColorSwatch(baseColor, { extended: true });
+      const swatch = getColorSwatch(baseColor, { extended: true }, createColor);
 
       expect(swatch.mainStop).toBe(500);
       expect(swatch[300].toRGBA().a).toBeCloseTo(0.4, 5);

--- a/src/color/__test__/temperature.test.ts
+++ b/src/color/__test__/temperature.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import {
   getColorFromTemperature,
   getColorFromTemperatureLabel,
@@ -6,8 +6,6 @@ import {
   getColorTemperatureString,
   matchPartialColorTemperatureLabel,
 } from '../temperature';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('getColorTemperature', () => {
   it('estimates temperature for a near-incandescent warm color', () => {
@@ -145,140 +143,150 @@ describe('getColorTemperature', () => {
 
 describe('getColorTemperatureString', () => {
   it('includes label for colors near temperature reference colors', () => {
-    expect(getColorTemperatureString(new Color('#ffffff'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#ffffff'), {}, createColorInstance)).toBe(
       '6504 K (cloudy sky)',
     );
-    expect(getColorTemperatureString(new Color('#c0c0c0'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#c0c0c0'), {}, createColorInstance)).toBe(
       '6504 K (cloudy sky)',
     );
-    expect(getColorTemperatureString(new Color('#ff8400'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#ff8400'), {}, createColorInstance)).toBe(
       '1881 K (candlelight)',
     );
-    expect(getColorTemperatureString(new Color('#ffa757'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#ffa757'), {}, createColorInstance)).toBe(
       '2583 K (incandescent lamp)',
     );
-    expect(getColorTemperatureString(new Color('#ffbb81'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#ffbb81'), {}, createColorInstance)).toBe(
       '3198 K (halogen lamp)',
     );
-    expect(getColorTemperatureString(new Color('#ffd3af'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#ffd3af'), {}, createColorInstance)).toBe(
       '4142 K (fluorescent lamp)',
     );
-    expect(getColorTemperatureString(new Color('#fff6ed'), createColor)).toBe('5889 K (daylight)');
-    expect(getColorTemperatureString(new Color('#f3f2ff'), createColor)).toBe(
+    expect(getColorTemperatureString(new Color('#fff6ed'), {}, createColorInstance)).toBe(
+      '5889 K (daylight)',
+    );
+    expect(getColorTemperatureString(new Color('#f3f2ff'), {}, createColorInstance)).toBe(
       '7049 K (cloudy sky)',
     );
-    expect(getColorTemperatureString(new Color('#dde6ff'), createColor)).toBe('8309 K (shade)');
-    expect(getColorTemperatureString(new Color('#cadaff'), createColor)).toBe('10026 K (blue sky)');
+    expect(getColorTemperatureString(new Color('#dde6ff'), {}, createColorInstance)).toBe(
+      '8309 K (shade)',
+    );
+    expect(getColorTemperatureString(new Color('#cadaff'), {}, createColorInstance)).toBe(
+      '10026 K (blue sky)',
+    );
   });
 
   it('omits label for saturated or unrelated colors', () => {
-    expect(getColorTemperatureString(new Color('#ff0000'), createColor)).toBe('2655 K');
-    expect(getColorTemperatureString(new Color('#0000ff'), createColor)).toBe('1667 K');
-    expect(getColorTemperatureString(new Color('#00ff00'), createColor)).toBe('6069 K');
-    expect(getColorTemperatureString(new Color('#00ffff'), createColor)).toBe('12822 K');
-    expect(getColorTemperatureString(new Color('#ff00ff'), createColor)).toBe('3544 K');
-    expect(getColorTemperatureString(new Color('#ffff00'), createColor)).toBe('3909 K');
-    expect(getColorTemperatureString(new Color('#808080'), createColor)).toBe('6504 K');
-    expect(getColorTemperatureString(new Color('#404040'), createColor)).toBe('6504 K');
-    expect(getColorTemperatureString(new Color('#000000'), createColor)).toBe('0 K');
-    expect(getColorTemperatureString(new Color('#ff00bf'), createColor)).toBe('0 K');
-    expect(getColorTemperatureString(new Color('#00bfff'), createColor)).toBe('44005 K');
+    expect(getColorTemperatureString(new Color('#ff0000'), {}, createColorInstance)).toBe('2655 K');
+    expect(getColorTemperatureString(new Color('#0000ff'), {}, createColorInstance)).toBe('1667 K');
+    expect(getColorTemperatureString(new Color('#00ff00'), {}, createColorInstance)).toBe('6069 K');
+    expect(getColorTemperatureString(new Color('#00ffff'), {}, createColorInstance)).toBe(
+      '12822 K',
+    );
+    expect(getColorTemperatureString(new Color('#ff00ff'), {}, createColorInstance)).toBe('3544 K');
+    expect(getColorTemperatureString(new Color('#ffff00'), {}, createColorInstance)).toBe('3909 K');
+    expect(getColorTemperatureString(new Color('#808080'), {}, createColorInstance)).toBe('6504 K');
+    expect(getColorTemperatureString(new Color('#404040'), {}, createColorInstance)).toBe('6504 K');
+    expect(getColorTemperatureString(new Color('#000000'), {}, createColorInstance)).toBe('0 K');
+    expect(getColorTemperatureString(new Color('#ff00bf'), {}, createColorInstance)).toBe('0 K');
+    expect(getColorTemperatureString(new Color('#00bfff'), {}, createColorInstance)).toBe(
+      '44005 K',
+    );
   });
 
   it('formats numbers when requested', () => {
     expect(
       getColorTemperatureString(
-        getColorFromTemperatureLabel('Cloudy sky'),
+        getColorFromTemperatureLabel('Cloudy sky', createColorInstance),
         {
           formatNumber: true,
         },
-        createColor,
+        createColorInstance,
       ),
     ).toBe('7,049 K (cloudy sky)');
     expect(
-      getColorTemperatureString(new Color('#ff0000'), { formatNumber: true }, createColor),
+      getColorTemperatureString(new Color('#ff0000'), { formatNumber: true }, createColorInstance),
     ).toBe('2,655 K');
   });
 });
 
 describe('getColorFromTemperature', () => {
   it('returns the expected color for temperatures across all ranges', () => {
-    expect(getColorFromTemperature(1500, createColor).toHex()).toBe('#ff6c00');
-    expect(getColorFromTemperature(1999, createColor).toHex()).toBe('#ff890e');
-    expect(getColorFromTemperature(2000, createColor).toHex()).toBe('#ff890e');
-    expect(getColorFromTemperature(2500, createColor).toHex()).toBe('#ff9f46');
-    expect(getColorFromTemperature(3000, createColor).toHex()).toBe('#ffb16e');
-    expect(getColorFromTemperature(3500, createColor).toHex()).toBe('#ffc18d');
-    expect(getColorFromTemperature(4000, createColor).toHex()).toBe('#ffcea6');
-    expect(getColorFromTemperature(4500, createColor).toHex()).toBe('#ffdabb');
-    expect(getColorFromTemperature(5000, createColor).toHex()).toBe('#ffe4ce');
-    expect(getColorFromTemperature(6499, createColor).toHex()).toBe('#fffefa');
-    expect(getColorFromTemperature(6500, createColor).toHex()).toBe('#fffefa');
-    expect(getColorFromTemperature(7499, createColor).toHex()).toBe('#e6ebff');
-    expect(getColorFromTemperature(7500, createColor).toHex()).toBe('#e6ebff');
-    expect(getColorFromTemperature(8999, createColor).toHex()).toBe('#d2dfff');
-    expect(getColorFromTemperature(9000, createColor).toHex()).toBe('#d2dfff');
-    expect(getColorFromTemperature(20000, createColor).toHex()).toBe('#abc6ff');
+    expect(getColorFromTemperature(1500, createColorInstance).toHex()).toBe('#ff6c00');
+    expect(getColorFromTemperature(1999, createColorInstance).toHex()).toBe('#ff890e');
+    expect(getColorFromTemperature(2000, createColorInstance).toHex()).toBe('#ff890e');
+    expect(getColorFromTemperature(2500, createColorInstance).toHex()).toBe('#ff9f46');
+    expect(getColorFromTemperature(3000, createColorInstance).toHex()).toBe('#ffb16e');
+    expect(getColorFromTemperature(3500, createColorInstance).toHex()).toBe('#ffc18d');
+    expect(getColorFromTemperature(4000, createColorInstance).toHex()).toBe('#ffcea6');
+    expect(getColorFromTemperature(4500, createColorInstance).toHex()).toBe('#ffdabb');
+    expect(getColorFromTemperature(5000, createColorInstance).toHex()).toBe('#ffe4ce');
+    expect(getColorFromTemperature(6499, createColorInstance).toHex()).toBe('#fffefa');
+    expect(getColorFromTemperature(6500, createColorInstance).toHex()).toBe('#fffefa');
+    expect(getColorFromTemperature(7499, createColorInstance).toHex()).toBe('#e6ebff');
+    expect(getColorFromTemperature(7500, createColorInstance).toHex()).toBe('#e6ebff');
+    expect(getColorFromTemperature(8999, createColorInstance).toHex()).toBe('#d2dfff');
+    expect(getColorFromTemperature(9000, createColorInstance).toHex()).toBe('#d2dfff');
+    expect(getColorFromTemperature(20000, createColorInstance).toHex()).toBe('#abc6ff');
   });
 });
 
 describe('getColorFromTemperatureLabel', () => {
   it('returns the expected color for each label', () => {
-    let color = getColorFromTemperatureLabel('Candlelight', createColor);
+    let color = getColorFromTemperatureLabel('Candlelight', createColorInstance);
     expect(color.toHex()).toBe('#ff8400');
 
-    color = getColorFromTemperatureLabel('Incandescent lamp', createColor);
+    color = getColorFromTemperatureLabel('Incandescent lamp', createColorInstance);
     expect(color.toHex()).toBe('#ffa757');
 
-    color = getColorFromTemperatureLabel('Halogen lamp', createColor);
+    color = getColorFromTemperatureLabel('Halogen lamp', createColorInstance);
     expect(color.toHex()).toBe('#ffbb81');
 
-    color = getColorFromTemperatureLabel('Fluorescent lamp', createColor);
+    color = getColorFromTemperatureLabel('Fluorescent lamp', createColorInstance);
     expect(color.toHex()).toBe('#ffd3af');
 
-    color = getColorFromTemperatureLabel('Daylight', createColor);
+    color = getColorFromTemperatureLabel('Daylight', createColorInstance);
     expect(color.toHex()).toBe('#fff6ed');
 
-    color = getColorFromTemperatureLabel('Cloudy sky', createColor);
+    color = getColorFromTemperatureLabel('Cloudy sky', createColorInstance);
     expect(color.toHex()).toBe('#f3f2ff');
 
-    color = getColorFromTemperatureLabel('Shade', createColor);
+    color = getColorFromTemperatureLabel('Shade', createColorInstance);
     expect(color.toHex()).toBe('#dde6ff');
 
-    color = getColorFromTemperatureLabel('Blue sky', createColor);
+    color = getColorFromTemperatureLabel('Blue sky', createColorInstance);
     expect(color.toHex()).toBe('#cadaff');
   });
 
   it('round-trips through getColorTemperature', () => {
-    let color = getColorFromTemperatureLabel('Candlelight', createColor);
+    let color = getColorFromTemperatureLabel('Candlelight', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Candlelight');
 
-    color = getColorFromTemperatureLabel('Incandescent lamp', createColor);
+    color = getColorFromTemperatureLabel('Incandescent lamp', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Incandescent lamp');
 
-    color = getColorFromTemperatureLabel('Halogen lamp', createColor);
+    color = getColorFromTemperatureLabel('Halogen lamp', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Halogen lamp');
 
-    color = getColorFromTemperatureLabel('Fluorescent lamp', createColor);
+    color = getColorFromTemperatureLabel('Fluorescent lamp', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Fluorescent lamp');
 
-    color = getColorFromTemperatureLabel('Daylight', createColor);
+    color = getColorFromTemperatureLabel('Daylight', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Daylight');
 
-    color = getColorFromTemperatureLabel('Cloudy sky', createColor);
+    color = getColorFromTemperatureLabel('Cloudy sky', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Cloudy sky');
 
-    color = getColorFromTemperatureLabel('Shade', createColor);
+    color = getColorFromTemperatureLabel('Shade', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Shade');
 
-    color = getColorFromTemperatureLabel('Blue sky', createColor);
+    color = getColorFromTemperatureLabel('Blue sky', createColorInstance);
     expect(getColorTemperature(color).label).toBe('Blue sky');
   });
 
   it('accepts mixed case temperature label', () => {
-    const t1 = getColorFromTemperatureLabel('Cloudy sky', createColor);
-    const t2 = getColorFromTemperatureLabel('cloudy sky', createColor);
-    const t3 = getColorFromTemperatureLabel('CLOUDY SKY', createColor);
+    const t1 = getColorFromTemperatureLabel('Cloudy sky', createColorInstance);
+    const t2 = getColorFromTemperatureLabel('cloudy sky', createColorInstance);
+    const t3 = getColorFromTemperatureLabel('CLOUDY SKY', createColorInstance);
 
     expect(t1.toHex()).toBe(t2.toHex());
     expect(t1.toHex()).toBe(t3.toHex());

--- a/src/color/__test__/temperature.test.ts
+++ b/src/color/__test__/temperature.test.ts
@@ -7,6 +7,8 @@ import {
   matchPartialColorTemperatureLabel,
 } from '../temperature';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('getColorTemperature', () => {
   it('estimates temperature for a near-incandescent warm color', () => {
     // Approximation based on incandescent lamp values (~2700–3000 K)
@@ -143,120 +145,140 @@ describe('getColorTemperature', () => {
 
 describe('getColorTemperatureString', () => {
   it('includes label for colors near temperature reference colors', () => {
-    expect(getColorTemperatureString(new Color('#ffffff'))).toBe('6504 K (cloudy sky)');
-    expect(getColorTemperatureString(new Color('#c0c0c0'))).toBe('6504 K (cloudy sky)');
-    expect(getColorTemperatureString(new Color('#ff8400'))).toBe('1881 K (candlelight)');
-    expect(getColorTemperatureString(new Color('#ffa757'))).toBe('2583 K (incandescent lamp)');
-    expect(getColorTemperatureString(new Color('#ffbb81'))).toBe('3198 K (halogen lamp)');
-    expect(getColorTemperatureString(new Color('#ffd3af'))).toBe('4142 K (fluorescent lamp)');
-    expect(getColorTemperatureString(new Color('#fff6ed'))).toBe('5889 K (daylight)');
-    expect(getColorTemperatureString(new Color('#f3f2ff'))).toBe('7049 K (cloudy sky)');
-    expect(getColorTemperatureString(new Color('#dde6ff'))).toBe('8309 K (shade)');
-    expect(getColorTemperatureString(new Color('#cadaff'))).toBe('10026 K (blue sky)');
+    expect(getColorTemperatureString(new Color('#ffffff'), createColor)).toBe(
+      '6504 K (cloudy sky)',
+    );
+    expect(getColorTemperatureString(new Color('#c0c0c0'), createColor)).toBe(
+      '6504 K (cloudy sky)',
+    );
+    expect(getColorTemperatureString(new Color('#ff8400'), createColor)).toBe(
+      '1881 K (candlelight)',
+    );
+    expect(getColorTemperatureString(new Color('#ffa757'), createColor)).toBe(
+      '2583 K (incandescent lamp)',
+    );
+    expect(getColorTemperatureString(new Color('#ffbb81'), createColor)).toBe(
+      '3198 K (halogen lamp)',
+    );
+    expect(getColorTemperatureString(new Color('#ffd3af'), createColor)).toBe(
+      '4142 K (fluorescent lamp)',
+    );
+    expect(getColorTemperatureString(new Color('#fff6ed'), createColor)).toBe('5889 K (daylight)');
+    expect(getColorTemperatureString(new Color('#f3f2ff'), createColor)).toBe(
+      '7049 K (cloudy sky)',
+    );
+    expect(getColorTemperatureString(new Color('#dde6ff'), createColor)).toBe('8309 K (shade)');
+    expect(getColorTemperatureString(new Color('#cadaff'), createColor)).toBe('10026 K (blue sky)');
   });
 
   it('omits label for saturated or unrelated colors', () => {
-    expect(getColorTemperatureString(new Color('#ff0000'))).toBe('2655 K');
-    expect(getColorTemperatureString(new Color('#0000ff'))).toBe('1667 K');
-    expect(getColorTemperatureString(new Color('#00ff00'))).toBe('6069 K');
-    expect(getColorTemperatureString(new Color('#00ffff'))).toBe('12822 K');
-    expect(getColorTemperatureString(new Color('#ff00ff'))).toBe('3544 K');
-    expect(getColorTemperatureString(new Color('#ffff00'))).toBe('3909 K');
-    expect(getColorTemperatureString(new Color('#808080'))).toBe('6504 K');
-    expect(getColorTemperatureString(new Color('#404040'))).toBe('6504 K');
-    expect(getColorTemperatureString(new Color('#000000'))).toBe('0 K');
-    expect(getColorTemperatureString(new Color('#ff00bf'))).toBe('0 K');
-    expect(getColorTemperatureString(new Color('#00bfff'))).toBe('44005 K');
+    expect(getColorTemperatureString(new Color('#ff0000'), createColor)).toBe('2655 K');
+    expect(getColorTemperatureString(new Color('#0000ff'), createColor)).toBe('1667 K');
+    expect(getColorTemperatureString(new Color('#00ff00'), createColor)).toBe('6069 K');
+    expect(getColorTemperatureString(new Color('#00ffff'), createColor)).toBe('12822 K');
+    expect(getColorTemperatureString(new Color('#ff00ff'), createColor)).toBe('3544 K');
+    expect(getColorTemperatureString(new Color('#ffff00'), createColor)).toBe('3909 K');
+    expect(getColorTemperatureString(new Color('#808080'), createColor)).toBe('6504 K');
+    expect(getColorTemperatureString(new Color('#404040'), createColor)).toBe('6504 K');
+    expect(getColorTemperatureString(new Color('#000000'), createColor)).toBe('0 K');
+    expect(getColorTemperatureString(new Color('#ff00bf'), createColor)).toBe('0 K');
+    expect(getColorTemperatureString(new Color('#00bfff'), createColor)).toBe('44005 K');
   });
 
   it('formats numbers when requested', () => {
     expect(
-      getColorTemperatureString(getColorFromTemperatureLabel('Cloudy sky'), {
-        formatNumber: true,
-      }),
+      getColorTemperatureString(
+        getColorFromTemperatureLabel('Cloudy sky'),
+        {
+          formatNumber: true,
+        },
+        createColor,
+      ),
     ).toBe('7,049 K (cloudy sky)');
-    expect(getColorTemperatureString(new Color('#ff0000'), { formatNumber: true })).toBe('2,655 K');
+    expect(
+      getColorTemperatureString(new Color('#ff0000'), { formatNumber: true }, createColor),
+    ).toBe('2,655 K');
   });
 });
 
 describe('getColorFromTemperature', () => {
   it('returns the expected color for temperatures across all ranges', () => {
-    expect(getColorFromTemperature(1500).toHex()).toBe('#ff6c00');
-    expect(getColorFromTemperature(1999).toHex()).toBe('#ff890e');
-    expect(getColorFromTemperature(2000).toHex()).toBe('#ff890e');
-    expect(getColorFromTemperature(2500).toHex()).toBe('#ff9f46');
-    expect(getColorFromTemperature(3000).toHex()).toBe('#ffb16e');
-    expect(getColorFromTemperature(3500).toHex()).toBe('#ffc18d');
-    expect(getColorFromTemperature(4000).toHex()).toBe('#ffcea6');
-    expect(getColorFromTemperature(4500).toHex()).toBe('#ffdabb');
-    expect(getColorFromTemperature(5000).toHex()).toBe('#ffe4ce');
-    expect(getColorFromTemperature(6499).toHex()).toBe('#fffefa');
-    expect(getColorFromTemperature(6500).toHex()).toBe('#fffefa');
-    expect(getColorFromTemperature(7499).toHex()).toBe('#e6ebff');
-    expect(getColorFromTemperature(7500).toHex()).toBe('#e6ebff');
-    expect(getColorFromTemperature(8999).toHex()).toBe('#d2dfff');
-    expect(getColorFromTemperature(9000).toHex()).toBe('#d2dfff');
-    expect(getColorFromTemperature(20000).toHex()).toBe('#abc6ff');
+    expect(getColorFromTemperature(1500, createColor).toHex()).toBe('#ff6c00');
+    expect(getColorFromTemperature(1999, createColor).toHex()).toBe('#ff890e');
+    expect(getColorFromTemperature(2000, createColor).toHex()).toBe('#ff890e');
+    expect(getColorFromTemperature(2500, createColor).toHex()).toBe('#ff9f46');
+    expect(getColorFromTemperature(3000, createColor).toHex()).toBe('#ffb16e');
+    expect(getColorFromTemperature(3500, createColor).toHex()).toBe('#ffc18d');
+    expect(getColorFromTemperature(4000, createColor).toHex()).toBe('#ffcea6');
+    expect(getColorFromTemperature(4500, createColor).toHex()).toBe('#ffdabb');
+    expect(getColorFromTemperature(5000, createColor).toHex()).toBe('#ffe4ce');
+    expect(getColorFromTemperature(6499, createColor).toHex()).toBe('#fffefa');
+    expect(getColorFromTemperature(6500, createColor).toHex()).toBe('#fffefa');
+    expect(getColorFromTemperature(7499, createColor).toHex()).toBe('#e6ebff');
+    expect(getColorFromTemperature(7500, createColor).toHex()).toBe('#e6ebff');
+    expect(getColorFromTemperature(8999, createColor).toHex()).toBe('#d2dfff');
+    expect(getColorFromTemperature(9000, createColor).toHex()).toBe('#d2dfff');
+    expect(getColorFromTemperature(20000, createColor).toHex()).toBe('#abc6ff');
   });
 });
 
 describe('getColorFromTemperatureLabel', () => {
   it('returns the expected color for each label', () => {
-    let color = getColorFromTemperatureLabel('Candlelight');
+    let color = getColorFromTemperatureLabel('Candlelight', createColor);
     expect(color.toHex()).toBe('#ff8400');
 
-    color = getColorFromTemperatureLabel('Incandescent lamp');
+    color = getColorFromTemperatureLabel('Incandescent lamp', createColor);
     expect(color.toHex()).toBe('#ffa757');
 
-    color = getColorFromTemperatureLabel('Halogen lamp');
+    color = getColorFromTemperatureLabel('Halogen lamp', createColor);
     expect(color.toHex()).toBe('#ffbb81');
 
-    color = getColorFromTemperatureLabel('Fluorescent lamp');
+    color = getColorFromTemperatureLabel('Fluorescent lamp', createColor);
     expect(color.toHex()).toBe('#ffd3af');
 
-    color = getColorFromTemperatureLabel('Daylight');
+    color = getColorFromTemperatureLabel('Daylight', createColor);
     expect(color.toHex()).toBe('#fff6ed');
 
-    color = getColorFromTemperatureLabel('Cloudy sky');
+    color = getColorFromTemperatureLabel('Cloudy sky', createColor);
     expect(color.toHex()).toBe('#f3f2ff');
 
-    color = getColorFromTemperatureLabel('Shade');
+    color = getColorFromTemperatureLabel('Shade', createColor);
     expect(color.toHex()).toBe('#dde6ff');
 
-    color = getColorFromTemperatureLabel('Blue sky');
+    color = getColorFromTemperatureLabel('Blue sky', createColor);
     expect(color.toHex()).toBe('#cadaff');
   });
 
   it('round-trips through getColorTemperature', () => {
-    let color = getColorFromTemperatureLabel('Candlelight');
+    let color = getColorFromTemperatureLabel('Candlelight', createColor);
     expect(getColorTemperature(color).label).toBe('Candlelight');
 
-    color = getColorFromTemperatureLabel('Incandescent lamp');
+    color = getColorFromTemperatureLabel('Incandescent lamp', createColor);
     expect(getColorTemperature(color).label).toBe('Incandescent lamp');
 
-    color = getColorFromTemperatureLabel('Halogen lamp');
+    color = getColorFromTemperatureLabel('Halogen lamp', createColor);
     expect(getColorTemperature(color).label).toBe('Halogen lamp');
 
-    color = getColorFromTemperatureLabel('Fluorescent lamp');
+    color = getColorFromTemperatureLabel('Fluorescent lamp', createColor);
     expect(getColorTemperature(color).label).toBe('Fluorescent lamp');
 
-    color = getColorFromTemperatureLabel('Daylight');
+    color = getColorFromTemperatureLabel('Daylight', createColor);
     expect(getColorTemperature(color).label).toBe('Daylight');
 
-    color = getColorFromTemperatureLabel('Cloudy sky');
+    color = getColorFromTemperatureLabel('Cloudy sky', createColor);
     expect(getColorTemperature(color).label).toBe('Cloudy sky');
 
-    color = getColorFromTemperatureLabel('Shade');
+    color = getColorFromTemperatureLabel('Shade', createColor);
     expect(getColorTemperature(color).label).toBe('Shade');
 
-    color = getColorFromTemperatureLabel('Blue sky');
+    color = getColorFromTemperatureLabel('Blue sky', createColor);
     expect(getColorTemperature(color).label).toBe('Blue sky');
   });
 
   it('accepts mixed case temperature label', () => {
-    const t1 = getColorFromTemperatureLabel('Cloudy sky');
-    const t2 = getColorFromTemperatureLabel('cloudy sky');
-    const t3 = getColorFromTemperatureLabel('CLOUDY SKY');
+    const t1 = getColorFromTemperatureLabel('Cloudy sky', createColor);
+    const t2 = getColorFromTemperatureLabel('cloudy sky', createColor);
+    const t3 = getColorFromTemperatureLabel('CLOUDY SKY', createColor);
 
     expect(t1.toHex()).toBe(t2.toHex());
     expect(t1.toHex()).toBe(t3.toHex());

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -1,9 +1,7 @@
 import { resolveCaseInsensitiveOption } from '../../utils';
-import { Color } from '../color';
+import { Color, createColorInstance } from '../color';
 import { getColorFromTemperatureLabel } from '../temperature';
 import { areColorsEqual, getColorRGBAFromInput, isColorDark, isColorOffWhite } from '../utils';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('areColorsEqual', () => {
   it('identifies identical colors across formats', () => {
@@ -391,7 +389,7 @@ describe('isColorOffWhite', () => {
 
 describe('getColorRGBAFromInput', () => {
   it('parses hex strings with leading/trailing spaces', () => {
-    expect(getColorRGBAFromInput('  #ff0000  ', createColor)).toEqual({
+    expect(getColorRGBAFromInput('  #ff0000  ', createColorInstance)).toEqual({
       r: 255,
       g: 0,
       b: 0,
@@ -400,7 +398,7 @@ describe('getColorRGBAFromInput', () => {
   });
 
   it('parses CSS color strings with leading/trailing spaces', () => {
-    expect(getColorRGBAFromInput('  rgb(255, 0, 0)  ', createColor)).toEqual({
+    expect(getColorRGBAFromInput('  rgb(255, 0, 0)  ', createColorInstance)).toEqual({
       r: 255,
       g: 0,
       b: 0,
@@ -409,30 +407,34 @@ describe('getColorRGBAFromInput', () => {
   });
 
   it('parses named colors with or without spaces', () => {
-    expect(new Color(getColorRGBAFromInput('lightblue', createColor)).toHex()).toBe('#add8e6');
-    expect(new Color(getColorRGBAFromInput('light blue', createColor)).toHex()).toBe('#add8e6');
+    expect(new Color(getColorRGBAFromInput('lightblue', createColorInstance)).toHex()).toBe(
+      '#add8e6',
+    );
+    expect(new Color(getColorRGBAFromInput('light blue', createColorInstance)).toHex()).toBe(
+      '#add8e6',
+    );
   });
 
   it('parses full and partial color temperature strings', () => {
-    expect(new Color(getColorRGBAFromInput('candlelight', createColor)).toHex()).toBe(
-      getColorFromTemperatureLabel('Candlelight', createColor).toHex(),
+    expect(new Color(getColorRGBAFromInput('candlelight', createColorInstance)).toHex()).toBe(
+      getColorFromTemperatureLabel('Candlelight', createColorInstance).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('incandescent', createColor)).toHex()).toBe(
-      getColorFromTemperatureLabel('Incandescent lamp', createColor).toHex(),
+    expect(new Color(getColorRGBAFromInput('incandescent', createColorInstance)).toHex()).toBe(
+      getColorFromTemperatureLabel('Incandescent lamp', createColorInstance).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('  shade  ', createColor)).toHex()).toBe(
-      getColorFromTemperatureLabel('Shade', createColor).toHex(),
+    expect(new Color(getColorRGBAFromInput('  shade  ', createColorInstance)).toHex()).toBe(
+      getColorFromTemperatureLabel('Shade', createColorInstance).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('cloudy sky', createColor)).toHex()).toBe(
-      getColorFromTemperatureLabel('Cloudy sky', createColor).toHex(),
+    expect(new Color(getColorRGBAFromInput('cloudy sky', createColorInstance)).toHex()).toBe(
+      getColorFromTemperatureLabel('Cloudy sky', createColorInstance).toHex(),
     );
   });
 
   it('throws on unknown color names', () => {
-    expect(() => getColorRGBAFromInput('notacolor', createColor)).toThrow();
+    expect(() => getColorRGBAFromInput('notacolor', createColorInstance)).toThrow();
   });
 });
 

--- a/src/color/__test__/utils.test.ts
+++ b/src/color/__test__/utils.test.ts
@@ -3,6 +3,8 @@ import { Color } from '../color';
 import { getColorFromTemperatureLabel } from '../temperature';
 import { areColorsEqual, getColorRGBAFromInput, isColorDark, isColorOffWhite } from '../utils';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('areColorsEqual', () => {
   it('identifies identical colors across formats', () => {
     expect(areColorsEqual(new Color('#ff0000'), new Color('#ff0000'))).toBe(true);
@@ -389,7 +391,7 @@ describe('isColorOffWhite', () => {
 
 describe('getColorRGBAFromInput', () => {
   it('parses hex strings with leading/trailing spaces', () => {
-    expect(getColorRGBAFromInput('  #ff0000  ')).toEqual({
+    expect(getColorRGBAFromInput('  #ff0000  ', createColor)).toEqual({
       r: 255,
       g: 0,
       b: 0,
@@ -398,7 +400,7 @@ describe('getColorRGBAFromInput', () => {
   });
 
   it('parses CSS color strings with leading/trailing spaces', () => {
-    expect(getColorRGBAFromInput('  rgb(255, 0, 0)  ')).toEqual({
+    expect(getColorRGBAFromInput('  rgb(255, 0, 0)  ', createColor)).toEqual({
       r: 255,
       g: 0,
       b: 0,
@@ -407,30 +409,30 @@ describe('getColorRGBAFromInput', () => {
   });
 
   it('parses named colors with or without spaces', () => {
-    expect(new Color(getColorRGBAFromInput('lightblue')).toHex()).toBe('#add8e6');
-    expect(new Color(getColorRGBAFromInput('light blue')).toHex()).toBe('#add8e6');
+    expect(new Color(getColorRGBAFromInput('lightblue', createColor)).toHex()).toBe('#add8e6');
+    expect(new Color(getColorRGBAFromInput('light blue', createColor)).toHex()).toBe('#add8e6');
   });
 
   it('parses full and partial color temperature strings', () => {
-    expect(new Color(getColorRGBAFromInput('candlelight')).toHex()).toBe(
-      getColorFromTemperatureLabel('Candlelight').toHex(),
+    expect(new Color(getColorRGBAFromInput('candlelight', createColor)).toHex()).toBe(
+      getColorFromTemperatureLabel('Candlelight', createColor).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('incandescent')).toHex()).toBe(
-      getColorFromTemperatureLabel('Incandescent lamp').toHex(),
+    expect(new Color(getColorRGBAFromInput('incandescent', createColor)).toHex()).toBe(
+      getColorFromTemperatureLabel('Incandescent lamp', createColor).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('  shade  ')).toHex()).toBe(
-      getColorFromTemperatureLabel('Shade').toHex(),
+    expect(new Color(getColorRGBAFromInput('  shade  ', createColor)).toHex()).toBe(
+      getColorFromTemperatureLabel('Shade', createColor).toHex(),
     );
 
-    expect(new Color(getColorRGBAFromInput('cloudy sky')).toHex()).toBe(
-      getColorFromTemperatureLabel('Cloudy sky').toHex(),
+    expect(new Color(getColorRGBAFromInput('cloudy sky', createColor)).toHex()).toBe(
+      getColorFromTemperatureLabel('Cloudy sky', createColor).toHex(),
     );
   });
 
   it('throws on unknown color names', () => {
-    expect(() => getColorRGBAFromInput('notacolor')).toThrow();
+    expect(() => getColorRGBAFromInput('notacolor', createColor)).toThrow();
   });
 });
 

--- a/src/color/color.helpers.ts
+++ b/src/color/color.helpers.ts
@@ -1,6 +1,6 @@
 import type { Color } from './color';
 
-export const COLOR_BRAND: unique symbol = Symbol('omni-color.Color');
+export const COLOR_BRAND: unique symbol = Symbol.for('omni-color.Color');
 
 export interface ColorBrand {
   readonly [COLOR_BRAND]: true;

--- a/src/color/color.helpers.ts
+++ b/src/color/color.helpers.ts
@@ -1,0 +1,20 @@
+import type { Color, CreateColorInstance } from './color';
+
+export const COLOR_BRAND: unique symbol = Symbol.for('omni-color.Color');
+
+export function isColorInstance(value: unknown): value is Color {
+  return !!value && typeof value === 'object' && (value as Partial<Color>)[COLOR_BRAND] === true;
+}
+
+let colorInstanceFactory: CreateColorInstance | undefined;
+
+export function setColorInstanceFactory(createColor: CreateColorInstance): void {
+  colorInstanceFactory = createColor;
+}
+
+export function getColorInstanceFactory(): CreateColorInstance {
+  if (!colorInstanceFactory) {
+    throw new Error('Color instance factory has not been initialized');
+  }
+  return colorInstanceFactory;
+}

--- a/src/color/color.helpers.ts
+++ b/src/color/color.helpers.ts
@@ -1,20 +1,7 @@
-import type { Color, CreateColorInstance } from './color';
+import type { Color } from './color';
 
 export const COLOR_BRAND: unique symbol = Symbol.for('omni-color.Color');
 
 export function isColorInstance(value: unknown): value is Color {
   return !!value && typeof value === 'object' && (value as Partial<Color>)[COLOR_BRAND] === true;
-}
-
-let colorInstanceFactory: CreateColorInstance | undefined;
-
-export function setColorInstanceFactory(createColor: CreateColorInstance): void {
-  colorInstanceFactory = createColor;
-}
-
-export function getColorInstanceFactory(): CreateColorInstance {
-  if (!colorInstanceFactory) {
-    throw new Error('Color instance factory has not been initialized');
-  }
-  return colorInstanceFactory;
 }

--- a/src/color/color.helpers.ts
+++ b/src/color/color.helpers.ts
@@ -1,7 +1,13 @@
 import type { Color } from './color';
 
-export const COLOR_BRAND: unique symbol = Symbol.for('omni-color.Color');
+export const COLOR_BRAND: unique symbol = Symbol('omni-color.Color');
+
+export interface ColorBrand {
+  readonly [COLOR_BRAND]: true;
+}
 
 export function isColorInstance(value: unknown): value is Color {
-  return !!value && typeof value === 'object' && (value as Partial<Color>)[COLOR_BRAND] === true;
+  return (
+    !!value && typeof value === 'object' && (value as Partial<ColorBrand>)[COLOR_BRAND] === true
+  );
 }

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -5,6 +5,7 @@ import {
   isColorPaletteSuitable,
 } from '../palette/palette';
 import { type CaseInsensitive, clampValue } from '../utils';
+import { COLOR_BRAND, setColorInstanceFactory } from './color.helpers';
 import type { ColorStringOptions } from './colorSpaces';
 import {
   averageColors,
@@ -34,6 +35,7 @@ import { type DeltaEOptions, getDeltaE } from './deltaE';
 import {
   cmykToString,
   type ColorCMYK,
+  type ColorFormat,
   type ColorHex,
   type ColorHSL,
   type ColorHSLA,
@@ -122,8 +124,11 @@ import {
   isColorDark,
   type IsColorDarkOptions,
   isColorOffWhite,
-  type ValidColorInputFormat,
 } from './utils';
+
+export type ValidColorInputFormat = Color | ColorFormat | string;
+
+export type CreateColorInstance = (input: ValidColorInputFormat) => Color;
 
 /**
  * The base omni-color object.
@@ -144,6 +149,9 @@ import {
  */
 export class Color {
   readonly #color: Readonly<ColorRGBA>;
+
+  // Runtime brand used by `isColorInstance` without relying on `instanceof`.
+  readonly [COLOR_BRAND] = true;
 
   /**
    * Create a new {@link Color} instance.
@@ -169,7 +177,16 @@ export class Color {
    */
   constructor(color?: ValidColorInputFormat | null) {
     // getColorRGBAFromInput always returns a fresh object
-    this.#color = Object.freeze({ ...getColorRGBAFromInput(color) });
+    this.#color = Object.freeze({ ...getColorRGBAFromInput(color, Color.#createColor) });
+  }
+
+  // Helper for dependency injection into utility modules that create Color instances.
+  static #createColor(input: ValidColorInputFormat): Color {
+    return new Color(input);
+  }
+
+  static {
+    setColorInstanceFactory(Color.#createColor);
   }
 
   /**
@@ -184,7 +201,7 @@ export class Color {
    * ```
    */
   static random(options?: RandomColorOptions): Color {
-    return new Color(getRandomColorRGBA(options));
+    return Color.#createColor(getRandomColorRGBA(options));
   }
 
   /**
@@ -201,9 +218,9 @@ export class Color {
    */
   static fromTemperature(temperature: number | CaseInsensitive<ColorTemperatureLabel>): Color {
     if (typeof temperature === 'number') {
-      return getColorFromTemperature(temperature);
+      return getColorFromTemperature(temperature, Color.#createColor);
     }
-    return getColorFromTemperatureLabel(temperature);
+    return getColorFromTemperatureLabel(temperature, Color.#createColor);
   }
 
   /**
@@ -230,7 +247,11 @@ export class Color {
     colors: readonly ValidColorInputFormat[],
     options?: ColorGradientOptions,
   ): Color[] {
-    return createColorGradient(getColorList(colors), options);
+    return createColorGradient(
+      getColorList(colors, Color.#createColor),
+      options,
+      Color.#createColor,
+    );
   }
 
   /**
@@ -466,7 +487,7 @@ export class Color {
    * Values out of range will be clamped to the nearest valid value.
    */
   setAlpha(alpha: number): Color {
-    return new Color({
+    return Color.#createColor({
       ...this.#color,
       a: Number.isFinite(alpha) ? +clampValue(alpha, 0, 1).toFixed(3) : 1,
     });
@@ -487,7 +508,7 @@ export class Color {
    * ```
    */
   spin(degrees: number): Color {
-    return spinColorHue(this, degrees);
+    return spinColorHue(this, degrees, Color.#createColor);
   }
 
   /**
@@ -504,7 +525,7 @@ export class Color {
    * ```
    */
   brighten(options?: ColorBrightnessOptions): Color {
-    return brightenColor(this, options);
+    return brightenColor(this, options, Color.#createColor);
   }
 
   /**
@@ -521,7 +542,7 @@ export class Color {
    * ```
    */
   darken(options?: ColorBrightnessOptions): Color {
-    return darkenColor(this, options);
+    return darkenColor(this, options, Color.#createColor);
   }
 
   /**
@@ -539,7 +560,7 @@ export class Color {
    * ```
    */
   saturate(options?: ColorSaturationOptions): Color {
-    return saturateColor(this, options);
+    return saturateColor(this, options, Color.#createColor);
   }
 
   /**
@@ -557,7 +578,7 @@ export class Color {
    * ```
    */
   desaturate(options?: ColorSaturationOptions): Color {
-    return desaturateColor(this, options);
+    return desaturateColor(this, options, Color.#createColor);
   }
 
   /**
@@ -567,7 +588,7 @@ export class Color {
    * @returns A new {@link Color} with the modified saturation.
    */
   grayscale(): Color {
-    return colorToGrayscale(this);
+    return colorToGrayscale(this, Color.#createColor);
   }
 
   /**
@@ -581,7 +602,11 @@ export class Color {
     if (others.length === 0) {
       return this.clone();
     }
-    return mixColors([this, ...getColorList(others)], options);
+    return mixColors(
+      [this, ...getColorList(others, Color.#createColor)],
+      options,
+      Color.#createColor,
+    );
   }
 
   /**
@@ -592,7 +617,7 @@ export class Color {
    * @returns A new {@link Color} that is the result of the blending.
    */
   blend(other: ValidColorInputFormat, options?: BlendColorsOptions): Color {
-    return blendColors(this, new Color(other), options);
+    return blendColors(this, Color.#createColor(other), options, Color.#createColor);
   }
 
   /**
@@ -606,7 +631,11 @@ export class Color {
     if (others.length === 0) {
       return this.clone();
     }
-    return averageColors([this, ...getColorList(others)], options);
+    return averageColors(
+      [this, ...getColorList(others, Color.#createColor)],
+      options,
+      Color.#createColor,
+    );
   }
 
   /**
@@ -658,7 +687,7 @@ export class Color {
    * ```
    */
   getComplementaryColors(options?: ColorHarmonyOptions): [Color, Color] {
-    return getComplementaryColors(this, options);
+    return getComplementaryColors(this, options, Color.#createColor);
   }
 
   /**
@@ -679,7 +708,7 @@ export class Color {
    * ```
    */
   getSplitComplementaryColors(options?: ColorHarmonyOptions): [Color, Color, Color] {
-    return getSplitComplementaryColors(this, options);
+    return getSplitComplementaryColors(this, options, Color.#createColor);
   }
 
   /**
@@ -701,7 +730,7 @@ export class Color {
    * ```
    */
   getTriadicHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color] {
-    return getTriadicHarmonyColors(this, options);
+    return getTriadicHarmonyColors(this, options, Color.#createColor);
   }
 
   /**
@@ -723,7 +752,7 @@ export class Color {
    * ```
    */
   getSquareHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color] {
-    return getSquareHarmonyColors(this, options);
+    return getSquareHarmonyColors(this, options, Color.#createColor);
   }
 
   /**
@@ -745,7 +774,7 @@ export class Color {
    * ```
    */
   getTetradicHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color] {
-    return getTetradicHarmonyColors(this, options);
+    return getTetradicHarmonyColors(this, options, Color.#createColor);
   }
 
   /**
@@ -768,7 +797,7 @@ export class Color {
    * ```
    */
   getAnalogousHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color, Color] {
-    return getAnalogousHarmonyColors(this, options);
+    return getAnalogousHarmonyColors(this, options, Color.#createColor);
   }
 
   /**
@@ -788,7 +817,7 @@ export class Color {
    * ```
    */
   getMonochromaticHarmonyColors(): [Color, Color, Color, Color, Color] {
-    return getMonochromaticHarmonyColors(this);
+    return getMonochromaticHarmonyColors(this, Color.#createColor);
   }
 
   /**
@@ -801,7 +830,7 @@ export class Color {
    * @returns A list of new {@link Color}s representing the original color and its harmony colors for the specified `harmony` option.
    */
   getHarmonyColors(harmony: CaseInsensitive<ColorHarmony>, options?: ColorHarmonyOptions): Color[] {
-    return getHarmonyColors(this, harmony, options);
+    return getHarmonyColors(this, harmony, options, Color.#createColor);
   }
 
   /**
@@ -835,7 +864,7 @@ export class Color {
   getColorSwatch(options?: ColorSwatchOptions & { extended: true }): ExtendedColorSwatch;
   getColorSwatch(options?: ColorSwatchOptions): ColorSwatch;
   getColorSwatch(options?: ColorSwatchOptions): ColorSwatch {
-    return getColorSwatch(this, options);
+    return getColorSwatch(this, options, Color.#createColor);
   }
 
   /**
@@ -860,7 +889,7 @@ export class Color {
     harmony: CaseInsensitive<ColorHarmony> = 'COMPLEMENTARY',
     options?: GenerateColorPaletteOptions,
   ): ColorPalette {
-    return generateColorPaletteFromBaseColor(this, harmony, options);
+    return generateColorPaletteFromBaseColor(this, harmony, options, Color.#createColor);
   }
 
   /**
@@ -876,7 +905,7 @@ export class Color {
    * ```
    */
   equals(other: ValidColorInputFormat): boolean {
-    return areColorsEqual(this, new Color(other));
+    return areColorsEqual(this, Color.#createColor(other));
   }
 
   /**
@@ -904,7 +933,7 @@ export class Color {
    * ```
    */
   differenceFrom(other: ValidColorInputFormat, options?: DeltaEOptions): number {
-    return getDeltaE(this, new Color(other), options);
+    return getDeltaE(this, Color.#createColor(other), options);
   }
 
   /**
@@ -966,7 +995,7 @@ export class Color {
    * @returns The WCAG contrast ratio between the two colors.
    */
   getWCAGContrastRatio(other: ValidColorInputFormat): number {
-    return getWCAGContrastRatio(this, new Color(other));
+    return getWCAGContrastRatio(this, Color.#createColor(other));
   }
 
   /**
@@ -981,7 +1010,7 @@ export class Color {
    * @returns The APCA readability score as a number.
    */
   getAPCAReadabilityScore(backgroundColor: ValidColorInputFormat): number {
-    return getAPCAReadabilityScore(this, new Color(backgroundColor));
+    return getAPCAReadabilityScore(this, Color.#createColor(backgroundColor));
   }
 
   /**
@@ -1010,7 +1039,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options?: APCAReadabilityOptions,
   ): APCAReadabilityReport {
-    return getAPCAReadabilityReport(this, new Color(backgroundColor), options);
+    return getAPCAReadabilityReport(this, Color.#createColor(backgroundColor), options);
   }
 
   /**
@@ -1036,7 +1065,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options?: WCAGReadabilityOptions,
   ): WCAGReadabilityReport {
-    return getWCAGReadabilityReport(this, new Color(backgroundColor), options);
+    return getWCAGReadabilityReport(this, Color.#createColor(backgroundColor), options);
   }
 
   /**
@@ -1053,7 +1082,11 @@ export class Color {
     textColors: readonly ValidColorInputFormat[] | ColorSwatch,
     options?: ReadabilityOptions,
   ): Color {
-    return getMostReadableTextColorForBackground(this, getColorList(textColors), options).clone();
+    return getMostReadableTextColorForBackground(
+      this,
+      getColorList(textColors, Color.#createColor),
+      options,
+    ).clone();
   }
 
   /**
@@ -1077,7 +1110,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options: ReadabilityOptions = {},
   ): boolean {
-    return isTextReadable(this, new Color(backgroundColor), options);
+    return isTextReadable(this, Color.#createColor(backgroundColor), options);
   }
 
   /**
@@ -1094,7 +1127,11 @@ export class Color {
     backgroundColors: readonly ValidColorInputFormat[] | ColorSwatch,
     options?: ReadabilityOptions,
   ): Color {
-    return getBestBackgroundColorForText(this, getColorList(backgroundColors), options).clone();
+    return getBestBackgroundColorForText(
+      this,
+      getColorList(backgroundColors, Color.#createColor),
+      options,
+    ).clone();
   }
 
   /**
@@ -1110,7 +1147,7 @@ export class Color {
    * Get the color's temperature as a string in Kelvin, optionally including a label for off-white colors.
    */
   getTemperatureAsString(options?: ColorTemperatureStringFormatOptions): string {
-    return getColorTemperatureString(this, options);
+    return getColorTemperatureString(this, options, Color.#createColor);
   }
 
   /**
@@ -1152,6 +1189,6 @@ export class Color {
    * @returns A new {@link Color} instance with the same color value.
    */
   clone(): Color {
-    return new Color({ ...this.#color });
+    return Color.#createColor({ ...this.#color });
   }
 }

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -5,7 +5,7 @@ import {
   isColorPaletteSuitable,
 } from '../palette/palette';
 import { type CaseInsensitive, clampValue } from '../utils';
-import { COLOR_BRAND } from './color.helpers';
+import { COLOR_BRAND, type ColorBrand } from './color.helpers';
 import type { ColorStringOptions } from './colorSpaces';
 import {
   averageColors,
@@ -149,7 +149,7 @@ export const createColorInstance: CreateColorInstance = (input: ValidColorInputF
  * red.toHex(); // '#ff0000'
  * ```
  */
-export class Color {
+export class Color implements ColorBrand {
   readonly #color: Readonly<ColorRGBA>;
 
   // Runtime brand used by `isColorInstance` without relying on `instanceof`.

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -5,7 +5,7 @@ import {
   isColorPaletteSuitable,
 } from '../palette/palette';
 import { type CaseInsensitive, clampValue } from '../utils';
-import { COLOR_BRAND, setColorInstanceFactory } from './color.helpers';
+import { COLOR_BRAND } from './color.helpers';
 import type { ColorStringOptions } from './colorSpaces';
 import {
   averageColors,
@@ -129,6 +129,8 @@ import {
 export type ValidColorInputFormat = Color | ColorFormat | string;
 
 export type CreateColorInstance = (input: ValidColorInputFormat) => Color;
+export const createColorInstance: CreateColorInstance = (input: ValidColorInputFormat) =>
+  new Color(input);
 
 /**
  * The base omni-color object.
@@ -177,16 +179,7 @@ export class Color {
    */
   constructor(color?: ValidColorInputFormat | null) {
     // getColorRGBAFromInput always returns a fresh object
-    this.#color = Object.freeze({ ...getColorRGBAFromInput(color, Color.#createColor) });
-  }
-
-  // Helper for dependency injection into utility modules that create Color instances.
-  static #createColor(input: ValidColorInputFormat): Color {
-    return new Color(input);
-  }
-
-  static {
-    setColorInstanceFactory(Color.#createColor);
+    this.#color = Object.freeze({ ...getColorRGBAFromInput(color, createColorInstance) });
   }
 
   /**
@@ -201,7 +194,7 @@ export class Color {
    * ```
    */
   static random(options?: RandomColorOptions): Color {
-    return Color.#createColor(getRandomColorRGBA(options));
+    return createColorInstance(getRandomColorRGBA(options));
   }
 
   /**
@@ -218,9 +211,9 @@ export class Color {
    */
   static fromTemperature(temperature: number | CaseInsensitive<ColorTemperatureLabel>): Color {
     if (typeof temperature === 'number') {
-      return getColorFromTemperature(temperature, Color.#createColor);
+      return getColorFromTemperature(temperature, createColorInstance);
     }
-    return getColorFromTemperatureLabel(temperature, Color.#createColor);
+    return getColorFromTemperatureLabel(temperature, createColorInstance);
   }
 
   /**
@@ -248,9 +241,9 @@ export class Color {
     options?: ColorGradientOptions,
   ): Color[] {
     return createColorGradient(
-      getColorList(colors, Color.#createColor),
+      getColorList(colors, createColorInstance),
       options,
-      Color.#createColor,
+      createColorInstance,
     );
   }
 
@@ -487,7 +480,7 @@ export class Color {
    * Values out of range will be clamped to the nearest valid value.
    */
   setAlpha(alpha: number): Color {
-    return Color.#createColor({
+    return createColorInstance({
       ...this.#color,
       a: Number.isFinite(alpha) ? +clampValue(alpha, 0, 1).toFixed(3) : 1,
     });
@@ -508,7 +501,7 @@ export class Color {
    * ```
    */
   spin(degrees: number): Color {
-    return spinColorHue(this, degrees, Color.#createColor);
+    return spinColorHue(this, degrees, createColorInstance);
   }
 
   /**
@@ -525,7 +518,7 @@ export class Color {
    * ```
    */
   brighten(options?: ColorBrightnessOptions): Color {
-    return brightenColor(this, options, Color.#createColor);
+    return brightenColor(this, options, createColorInstance);
   }
 
   /**
@@ -542,7 +535,7 @@ export class Color {
    * ```
    */
   darken(options?: ColorBrightnessOptions): Color {
-    return darkenColor(this, options, Color.#createColor);
+    return darkenColor(this, options, createColorInstance);
   }
 
   /**
@@ -560,7 +553,7 @@ export class Color {
    * ```
    */
   saturate(options?: ColorSaturationOptions): Color {
-    return saturateColor(this, options, Color.#createColor);
+    return saturateColor(this, options, createColorInstance);
   }
 
   /**
@@ -578,7 +571,7 @@ export class Color {
    * ```
    */
   desaturate(options?: ColorSaturationOptions): Color {
-    return desaturateColor(this, options, Color.#createColor);
+    return desaturateColor(this, options, createColorInstance);
   }
 
   /**
@@ -588,7 +581,7 @@ export class Color {
    * @returns A new {@link Color} with the modified saturation.
    */
   grayscale(): Color {
-    return colorToGrayscale(this, Color.#createColor);
+    return colorToGrayscale(this, createColorInstance);
   }
 
   /**
@@ -603,9 +596,9 @@ export class Color {
       return this.clone();
     }
     return mixColors(
-      [this, ...getColorList(others, Color.#createColor)],
+      [this, ...getColorList(others, createColorInstance)],
       options,
-      Color.#createColor,
+      createColorInstance,
     );
   }
 
@@ -617,7 +610,7 @@ export class Color {
    * @returns A new {@link Color} that is the result of the blending.
    */
   blend(other: ValidColorInputFormat, options?: BlendColorsOptions): Color {
-    return blendColors(this, Color.#createColor(other), options, Color.#createColor);
+    return blendColors(this, createColorInstance(other), options, createColorInstance);
   }
 
   /**
@@ -632,9 +625,9 @@ export class Color {
       return this.clone();
     }
     return averageColors(
-      [this, ...getColorList(others, Color.#createColor)],
+      [this, ...getColorList(others, createColorInstance)],
       options,
-      Color.#createColor,
+      createColorInstance,
     );
   }
 
@@ -687,7 +680,7 @@ export class Color {
    * ```
    */
   getComplementaryColors(options?: ColorHarmonyOptions): [Color, Color] {
-    return getComplementaryColors(this, options, Color.#createColor);
+    return getComplementaryColors(this, options, createColorInstance);
   }
 
   /**
@@ -708,7 +701,7 @@ export class Color {
    * ```
    */
   getSplitComplementaryColors(options?: ColorHarmonyOptions): [Color, Color, Color] {
-    return getSplitComplementaryColors(this, options, Color.#createColor);
+    return getSplitComplementaryColors(this, options, createColorInstance);
   }
 
   /**
@@ -730,7 +723,7 @@ export class Color {
    * ```
    */
   getTriadicHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color] {
-    return getTriadicHarmonyColors(this, options, Color.#createColor);
+    return getTriadicHarmonyColors(this, options, createColorInstance);
   }
 
   /**
@@ -752,7 +745,7 @@ export class Color {
    * ```
    */
   getSquareHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color] {
-    return getSquareHarmonyColors(this, options, Color.#createColor);
+    return getSquareHarmonyColors(this, options, createColorInstance);
   }
 
   /**
@@ -774,7 +767,7 @@ export class Color {
    * ```
    */
   getTetradicHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color] {
-    return getTetradicHarmonyColors(this, options, Color.#createColor);
+    return getTetradicHarmonyColors(this, options, createColorInstance);
   }
 
   /**
@@ -797,7 +790,7 @@ export class Color {
    * ```
    */
   getAnalogousHarmonyColors(options?: ColorHarmonyOptions): [Color, Color, Color, Color, Color] {
-    return getAnalogousHarmonyColors(this, options, Color.#createColor);
+    return getAnalogousHarmonyColors(this, options, createColorInstance);
   }
 
   /**
@@ -817,7 +810,7 @@ export class Color {
    * ```
    */
   getMonochromaticHarmonyColors(): [Color, Color, Color, Color, Color] {
-    return getMonochromaticHarmonyColors(this, Color.#createColor);
+    return getMonochromaticHarmonyColors(this, createColorInstance);
   }
 
   /**
@@ -830,7 +823,7 @@ export class Color {
    * @returns A list of new {@link Color}s representing the original color and its harmony colors for the specified `harmony` option.
    */
   getHarmonyColors(harmony: CaseInsensitive<ColorHarmony>, options?: ColorHarmonyOptions): Color[] {
-    return getHarmonyColors(this, harmony, options, Color.#createColor);
+    return getHarmonyColors(this, harmony, options, createColorInstance);
   }
 
   /**
@@ -864,7 +857,7 @@ export class Color {
   getColorSwatch(options?: ColorSwatchOptions & { extended: true }): ExtendedColorSwatch;
   getColorSwatch(options?: ColorSwatchOptions): ColorSwatch;
   getColorSwatch(options?: ColorSwatchOptions): ColorSwatch {
-    return getColorSwatch(this, options, Color.#createColor);
+    return getColorSwatch(this, options, createColorInstance);
   }
 
   /**
@@ -889,7 +882,7 @@ export class Color {
     harmony: CaseInsensitive<ColorHarmony> = 'COMPLEMENTARY',
     options?: GenerateColorPaletteOptions,
   ): ColorPalette {
-    return generateColorPaletteFromBaseColor(this, harmony, options, Color.#createColor);
+    return generateColorPaletteFromBaseColor(this, harmony, options, createColorInstance);
   }
 
   /**
@@ -905,7 +898,7 @@ export class Color {
    * ```
    */
   equals(other: ValidColorInputFormat): boolean {
-    return areColorsEqual(this, Color.#createColor(other));
+    return areColorsEqual(this, createColorInstance(other));
   }
 
   /**
@@ -933,7 +926,7 @@ export class Color {
    * ```
    */
   differenceFrom(other: ValidColorInputFormat, options?: DeltaEOptions): number {
-    return getDeltaE(this, Color.#createColor(other), options);
+    return getDeltaE(this, createColorInstance(other), options);
   }
 
   /**
@@ -995,7 +988,7 @@ export class Color {
    * @returns The WCAG contrast ratio between the two colors.
    */
   getWCAGContrastRatio(other: ValidColorInputFormat): number {
-    return getWCAGContrastRatio(this, Color.#createColor(other));
+    return getWCAGContrastRatio(this, createColorInstance(other));
   }
 
   /**
@@ -1010,7 +1003,7 @@ export class Color {
    * @returns The APCA readability score as a number.
    */
   getAPCAReadabilityScore(backgroundColor: ValidColorInputFormat): number {
-    return getAPCAReadabilityScore(this, Color.#createColor(backgroundColor));
+    return getAPCAReadabilityScore(this, createColorInstance(backgroundColor));
   }
 
   /**
@@ -1039,7 +1032,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options?: APCAReadabilityOptions,
   ): APCAReadabilityReport {
-    return getAPCAReadabilityReport(this, Color.#createColor(backgroundColor), options);
+    return getAPCAReadabilityReport(this, createColorInstance(backgroundColor), options);
   }
 
   /**
@@ -1065,7 +1058,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options?: WCAGReadabilityOptions,
   ): WCAGReadabilityReport {
-    return getWCAGReadabilityReport(this, Color.#createColor(backgroundColor), options);
+    return getWCAGReadabilityReport(this, createColorInstance(backgroundColor), options);
   }
 
   /**
@@ -1084,7 +1077,7 @@ export class Color {
   ): Color {
     return getMostReadableTextColorForBackground(
       this,
-      getColorList(textColors, Color.#createColor),
+      getColorList(textColors, createColorInstance),
       options,
     ).clone();
   }
@@ -1110,7 +1103,7 @@ export class Color {
     backgroundColor: ValidColorInputFormat,
     options: ReadabilityOptions = {},
   ): boolean {
-    return isTextReadable(this, Color.#createColor(backgroundColor), options);
+    return isTextReadable(this, createColorInstance(backgroundColor), options);
   }
 
   /**
@@ -1129,7 +1122,7 @@ export class Color {
   ): Color {
     return getBestBackgroundColorForText(
       this,
-      getColorList(backgroundColors, Color.#createColor),
+      getColorList(backgroundColors, createColorInstance),
       options,
     ).clone();
   }
@@ -1147,7 +1140,7 @@ export class Color {
    * Get the color's temperature as a string in Kelvin, optionally including a label for off-white colors.
    */
   getTemperatureAsString(options?: ColorTemperatureStringFormatOptions): string {
-    return getColorTemperatureString(this, options, Color.#createColor);
+    return getColorTemperatureString(this, options, createColorInstance);
   }
 
   /**
@@ -1189,6 +1182,6 @@ export class Color {
    * @returns A new {@link Color} instance with the same color value.
    */
   clone(): Color {
-    return Color.#createColor({ ...this.#color });
+    return createColorInstance({ ...this.#color });
   }
 }

--- a/src/color/colorSpaces.ts
+++ b/src/color/colorSpaces.ts
@@ -1,6 +1,6 @@
 import { type CaseInsensitive, clampValue } from '../utils';
 import type { ColorRGB } from './formats';
-import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
+import { linearChannelToSrgb, srgbChannelToLinear } from './srgb';
 
 export type ColorSpace = 'SRGB' | 'DISPLAY-P3' | 'REC2020';
 

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -479,24 +479,11 @@ function mixColorsAdditive({
   }
 }
 
-export function mixColors(colors: readonly Color[], createColor: CreateColorInstance): Color;
 export function mixColors(
   colors: readonly Color[],
-  options: MixColorsOptions | undefined,
+  options: MixColorsOptions = {},
   createColor: CreateColorInstance,
-): Color;
-export function mixColors(
-  colors: readonly Color[],
-  optionsOrCreateColor: MixColorsOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
-
   if (colors.length < 2) {
     throw new Error('at least two colors are required for mixing');
   }
@@ -680,26 +667,12 @@ function blendColorsInHSLSpace({
   });
 }
 
-export function blendColors(base: Color, blend: Color, createColor: CreateColorInstance): Color;
 export function blendColors(
   base: Color,
   blend: Color,
-  options: BlendColorsOptions | undefined,
+  options: BlendColorsOptions = {},
   createColor: CreateColorInstance,
-): Color;
-export function blendColors(
-  base: Color,
-  blend: Color,
-  optionsOrCreateColor: BlendColorsOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
-
   const mode = resolveCaseInsensitiveOption({
     allowedValues: BLEND_MODES,
     defaultValue: 'NORMAL',
@@ -878,24 +851,11 @@ function averageColorsInRgb(
   });
 }
 
-export function averageColors(colors: readonly Color[], createColor: CreateColorInstance): Color;
 export function averageColors(
   colors: readonly Color[],
-  options: AverageColorsOptions | undefined,
+  options: AverageColorsOptions = {},
   createColor: CreateColorInstance,
-): Color;
-export function averageColors(
-  colors: readonly Color[],
-  optionsOrCreateColor: AverageColorsOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
-
   if (colors.length < 2) {
     throw new Error('at least two colors are required for averaging');
   }

--- a/src/color/combinations.ts
+++ b/src/color/combinations.ts
@@ -1,7 +1,7 @@
 import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
-import { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
 import type { ColorHSL, ColorHSLA, ColorLCH, ColorOKLCH, ColorRGBA } from './formats';
-import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
+import { linearChannelToSrgb, srgbChannelToLinear } from './srgb';
 
 const MIX_TYPES = ['ADDITIVE', 'SUBTRACTIVE'] as const;
 export type MixType = (typeof MIX_TYPES)[number];
@@ -94,6 +94,7 @@ function mixSubtractiveHue(
 function mixColorsSubtractiveInRgb(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   const rgbValues = colors.map((color) => color.toRGBA());
   const r = mixNormalizedChannel(
@@ -114,12 +115,13 @@ function mixColorsSubtractiveInRgb(
 
   const a = mixAlphaChannel(colors, normalizedWeights);
 
-  return new Color({ r, g, b, a });
+  return createColor({ r, g, b, a });
 }
 
 function mixColorsSubtractiveInLinearRgb(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   const linearValues = colors
     .map((color) => color.toRGBA())
@@ -147,12 +149,13 @@ function mixColorsSubtractiveInLinearRgb(
   const b = Math.round(clampValue(linearChannelToSrgb(bLinear, 'SRGB'), 0, 255));
   const a = mixAlphaChannel(colors, normalizedWeights);
 
-  return new Color({ r, g, b, a });
+  return createColor({ r, g, b, a });
 }
 
 function mixColorsSubtractiveInHsl(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   const hslValues = colors.map((color) => color.toHSL());
   const saturation = mixNormalizedChannel(
@@ -176,12 +179,13 @@ function mixColorsSubtractiveInHsl(
 
   const a = mixAlphaChannel(colors, normalizedWeights);
 
-  return new Color({ h: hue, s: saturation, l: lightness, a });
+  return createColor({ h: hue, s: saturation, l: lightness, a });
 }
 
 function mixColorsSubtractiveInLch(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   const lchValues = colors.map((color) => color.toLCH());
   const lightnessValues = lchValues.map((value) => value.l);
@@ -210,14 +214,15 @@ function mixColorsSubtractiveInLch(
     c: chroma,
     h: hue,
   };
-  const rgba = new Color(lchResult).toRGBA();
+  const rgba = createColor(lchResult).toRGBA();
 
-  return new Color({ ...rgba, a });
+  return createColor({ ...rgba, a });
 }
 
 function mixColorsSubtractiveInOklch(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   const oklchValues = colors.map((color) => color.toOKLCH());
   const lightnessValues = oklchValues.map((value) => value.l);
@@ -245,28 +250,29 @@ function mixColorsSubtractiveInOklch(
     c: chroma,
     h: hue,
   };
-  const rgba = new Color(oklchResult).toRGBA();
+  const rgba = createColor(oklchResult).toRGBA();
 
-  return new Color({ ...rgba, a });
+  return createColor({ ...rgba, a });
 }
 
 function mixColorsSubtractive(
   colors: readonly Color[],
   space: MixSpace,
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   switch (space) {
     case 'RGB':
-      return mixColorsSubtractiveInRgb(colors, normalizedWeights);
+      return mixColorsSubtractiveInRgb(colors, normalizedWeights, createColor);
     case 'HSL':
-      return mixColorsSubtractiveInHsl(colors, normalizedWeights);
+      return mixColorsSubtractiveInHsl(colors, normalizedWeights, createColor);
     case 'LCH':
-      return mixColorsSubtractiveInLch(colors, normalizedWeights);
+      return mixColorsSubtractiveInLch(colors, normalizedWeights, createColor);
     case 'OKLCH':
-      return mixColorsSubtractiveInOklch(colors, normalizedWeights);
+      return mixColorsSubtractiveInOklch(colors, normalizedWeights, createColor);
     case 'LINEAR_RGB':
     default:
-      return mixColorsSubtractiveInLinearRgb(colors, normalizedWeights);
+      return mixColorsSubtractiveInLinearRgb(colors, normalizedWeights, createColor);
   }
 }
 
@@ -279,6 +285,7 @@ function mixColorsAdditiveInLinearRgb(
   colors: readonly Color[],
   weights: readonly number[],
   sumOfWeights: number,
+  createColor: CreateColorInstance,
 ): Color {
   const normalizationFactor = sumOfWeights || 1;
   let rLinear = 0;
@@ -303,13 +310,14 @@ function mixColorsAdditiveInLinearRgb(
     a: +clampValue(alpha / normalizationFactor, 0, 1).toFixed(3),
   };
 
-  return new Color(result);
+  return createColor(result);
 }
 
 function mixColorsAdditiveInHsl(
   colors: readonly Color[],
   weights: readonly number[],
   sumOfWeights: number,
+  createColor: CreateColorInstance,
 ): Color {
   const normalizationFactor = sumOfWeights || 1;
   let x = 0;
@@ -337,13 +345,14 @@ function mixColorsAdditiveInHsl(
     l: +clampValue(lightness, 0, 100).toFixed(3),
     a: +clampValue(alpha, 0, 1).toFixed(3),
   };
-  return new Color(result);
+  return createColor(result);
 }
 
 function mixColorsAdditiveInLch(
   colors: readonly Color[],
   weights: readonly number[],
   sumOfWeights: number,
+  createColor: CreateColorInstance,
 ): Color {
   const normalizationFactor = sumOfWeights || 1;
   let lightness = 0;
@@ -370,8 +379,8 @@ function mixColorsAdditiveInLch(
     c: +Math.max(0, chroma).toFixed(3),
     h: Number.isNaN(hue) ? 0 : hue,
   };
-  const rgba = new Color(lchResult).toRGBA();
-  return new Color({
+  const rgba = createColor(lchResult).toRGBA();
+  return createColor({
     ...rgba,
     a: +clampValue(alpha, 0, 1).toFixed(3),
   });
@@ -381,6 +390,7 @@ function mixColorsAdditiveInOklch(
   colors: readonly Color[],
   weights: readonly number[],
   sumOfWeights: number,
+  createColor: CreateColorInstance,
 ): Color {
   const normalizationFactor = sumOfWeights || 1;
   let lightness = 0;
@@ -407,8 +417,8 @@ function mixColorsAdditiveInOklch(
     c: +Math.max(0, chroma).toFixed(6),
     h: Number.isNaN(hue) ? 0 : hue,
   };
-  const rgba = new Color(oklchResult).toRGBA();
-  return new Color({
+  const rgba = createColor(oklchResult).toRGBA();
+  return createColor({
     ...rgba,
     a: +clampValue(alpha, 0, 1).toFixed(3),
   });
@@ -418,6 +428,7 @@ function mixColorsAdditiveInRgb(
   colors: readonly Color[],
   weights: readonly number[],
   sumOfWeights: number,
+  createColor: CreateColorInstance,
 ): Color {
   let r = 0;
   let g = 0;
@@ -437,31 +448,55 @@ function mixColorsAdditiveInRgb(
     b: Math.round(clampValue(b, 0, 255)),
     a: +clampValue(a / sumOfWeights, 0, 1).toFixed(3),
   };
-  return new Color(result);
+  return createColor(result);
 }
 
-function mixColorsAdditive(
-  colors: readonly Color[],
-  space: MixSpace,
-  weights: readonly number[],
-  sumOfWeights: number,
-) {
+function mixColorsAdditive({
+  colors,
+  space,
+  weights,
+  sumOfWeights,
+  createColor,
+}: {
+  colors: readonly Color[];
+  space: MixSpace;
+  weights: readonly number[];
+  sumOfWeights: number;
+  createColor: CreateColorInstance;
+}) {
   switch (space) {
     case 'LINEAR_RGB':
-      return mixColorsAdditiveInLinearRgb(colors, weights, sumOfWeights);
+      return mixColorsAdditiveInLinearRgb(colors, weights, sumOfWeights, createColor);
     case 'HSL':
-      return mixColorsAdditiveInHsl(colors, weights, sumOfWeights);
+      return mixColorsAdditiveInHsl(colors, weights, sumOfWeights, createColor);
     case 'LCH':
-      return mixColorsAdditiveInLch(colors, weights, sumOfWeights);
+      return mixColorsAdditiveInLch(colors, weights, sumOfWeights, createColor);
     case 'OKLCH':
-      return mixColorsAdditiveInOklch(colors, weights, sumOfWeights);
+      return mixColorsAdditiveInOklch(colors, weights, sumOfWeights, createColor);
     case 'RGB':
     default:
-      return mixColorsAdditiveInRgb(colors, weights, sumOfWeights);
+      return mixColorsAdditiveInRgb(colors, weights, sumOfWeights, createColor);
   }
 }
 
-export function mixColors(colors: readonly Color[], options: MixColorsOptions = {}): Color {
+export function mixColors(colors: readonly Color[], createColor: CreateColorInstance): Color;
+export function mixColors(
+  colors: readonly Color[],
+  options: MixColorsOptions | undefined,
+  createColor: CreateColorInstance,
+): Color;
+export function mixColors(
+  colors: readonly Color[],
+  optionsOrCreateColor: MixColorsOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
+
   if (colors.length < 2) {
     throw new Error('at least two colors are required for mixing');
   }
@@ -481,10 +516,16 @@ export function mixColors(colors: readonly Color[], options: MixColorsOptions = 
   const { weights, sumOfWeights, normalizedWeights } = getWeights(colors.length, options.weights);
 
   if (type === 'SUBTRACTIVE') {
-    return mixColorsSubtractive(colors, space, normalizedWeights);
+    return mixColorsSubtractive(colors, space, normalizedWeights, createColor);
   }
 
-  return mixColorsAdditive(colors, space, weights, sumOfWeights);
+  return mixColorsAdditive({
+    colors,
+    space,
+    weights,
+    sumOfWeights,
+    createColor,
+  });
 }
 
 const BLEND_MODES = ['NORMAL', 'MULTIPLY', 'SCREEN', 'OVERLAY'] as const;
@@ -566,7 +607,19 @@ function blendAlphaChannel(baseAlpha: number, blendAlpha: number, ratio: number)
   return +clampValue(mixedAlpha, 0, 1).toFixed(3);
 }
 
-function blendColorsInRGBSpace(base: Color, blend: Color, mode: BlendMode, ratio: number): Color {
+function blendColorsInRGBSpace({
+  base,
+  blend,
+  mode,
+  ratio,
+  createColor,
+}: {
+  base: Color;
+  blend: Color;
+  mode: BlendMode;
+  ratio: number;
+  createColor: CreateColorInstance;
+}): Color {
   const baseRGBA = base.toRGBA();
   const blendRGBA = blend.toRGBA();
   const r = (1 - ratio) * baseRGBA.r + ratio * blendChannel(mode, baseRGBA.r, blendRGBA.r);
@@ -579,10 +632,22 @@ function blendColorsInRGBSpace(base: Color, blend: Color, mode: BlendMode, ratio
     b: Math.round(clampValue(b, 0, 255)),
     a: +clampValue(a, 0, 1).toFixed(3),
   };
-  return new Color(resultRGBA);
+  return createColor(resultRGBA);
 }
 
-function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio: number): Color {
+function blendColorsInHSLSpace({
+  base,
+  blend,
+  mode,
+  ratio,
+  createColor,
+}: {
+  base: Color;
+  blend: Color;
+  mode: BlendMode;
+  ratio: number;
+  createColor: CreateColorInstance;
+}): Color {
   const baseHSL = base.toHSL();
   const blendHSL = blend.toHSL();
   const baseAlpha = base.toRGBA().a ?? 1;
@@ -594,7 +659,7 @@ function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio
     const s = (1 - ratio) * baseHSL.s + ratio * blendHSL.s;
     const l = (1 - ratio) * baseHSL.l + ratio * blendHSL.l;
 
-    return new Color({
+    return createColor({
       h,
       s,
       l,
@@ -607,7 +672,7 @@ function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio
   const l = blendValueChannel({ mode, base: baseHSL.l, blend: blendHSL.l, ratio, maxValue: 100 });
   const a = blendAlphaChannel(baseAlpha, blendAlpha, ratio);
 
-  return new Color({
+  return createColor({
     h,
     s,
     l,
@@ -615,7 +680,26 @@ function blendColorsInHSLSpace(base: Color, blend: Color, mode: BlendMode, ratio
   });
 }
 
-export function blendColors(base: Color, blend: Color, options: BlendColorsOptions = {}): Color {
+export function blendColors(base: Color, blend: Color, createColor: CreateColorInstance): Color;
+export function blendColors(
+  base: Color,
+  blend: Color,
+  options: BlendColorsOptions | undefined,
+  createColor: CreateColorInstance,
+): Color;
+export function blendColors(
+  base: Color,
+  blend: Color,
+  optionsOrCreateColor: BlendColorsOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
+
   const mode = resolveCaseInsensitiveOption({
     allowedValues: BLEND_MODES,
     defaultValue: 'NORMAL',
@@ -631,10 +715,10 @@ export function blendColors(base: Color, blend: Color, options: BlendColorsOptio
   const ratio = clampValue(options.ratio ?? 0.5, 0, 1);
 
   if (space === 'RGB') {
-    return blendColorsInRGBSpace(base, blend, mode, ratio);
+    return blendColorsInRGBSpace({ base, blend, mode, ratio, createColor });
   }
 
-  return blendColorsInHSLSpace(base, blend, mode, ratio);
+  return blendColorsInHSLSpace({ base, blend, mode, ratio, createColor });
 }
 
 export interface AverageColorsOptions {
@@ -663,7 +747,11 @@ function resolveAveragedHue(x: number, y: number, fallbackHue = 0): number {
   return Number.isNaN(normalizedHue) ? fallbackHue : normalizedHue;
 }
 
-function averageColorsInHsl(colors: readonly Color[], normalizedWeights: readonly number[]): Color {
+function averageColorsInHsl(
+  colors: readonly Color[],
+  normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
+): Color {
   let x = 0;
   let y = 0;
   let lightness = 0;
@@ -679,14 +767,18 @@ function averageColorsInHsl(colors: readonly Color[], normalizedWeights: readonl
   const hue = resolveAveragedHue(x, y);
   const saturation = clampValue(Math.hypot(x, y), 0, 100);
   const alpha = mixAlphaChannel(colors, normalizedWeights);
-  return new Color({
+  return createColor({
     h: Math.round(hue),
     s: Math.round(saturation),
     l: Math.round(lightness),
   }).setAlpha(alpha);
 }
 
-function averageColorsInLch(colors: readonly Color[], normalizedWeights: readonly number[]): Color {
+function averageColorsInLch(
+  colors: readonly Color[],
+  normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
+): Color {
   let lightness = 0;
   let chromaX = 0;
   let chromaY = 0;
@@ -702,7 +794,7 @@ function averageColorsInLch(colors: readonly Color[], normalizedWeights: readonl
   const chroma = Math.hypot(chromaX, chromaY);
   const hue = resolveAveragedHue(chromaX, chromaY);
   const alpha = mixAlphaChannel(colors, normalizedWeights);
-  return new Color({
+  return createColor({
     l: lightness,
     c: chroma,
     h: hue,
@@ -712,6 +804,7 @@ function averageColorsInLch(colors: readonly Color[], normalizedWeights: readonl
 function averageColorsInOklch(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   let lightness = 0;
   let chromaX = 0;
@@ -728,7 +821,7 @@ function averageColorsInOklch(
   const chroma = Math.hypot(chromaX, chromaY);
   const hue = resolveAveragedHue(chromaX, chromaY);
   const alpha = mixAlphaChannel(colors, normalizedWeights);
-  return new Color({
+  return createColor({
     l: lightness,
     c: chroma,
     h: hue,
@@ -738,6 +831,7 @@ function averageColorsInOklch(
 function averageColorsInLinearRgb(
   colors: readonly Color[],
   normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
 ): Color {
   let r = 0;
   let g = 0;
@@ -751,7 +845,7 @@ function averageColorsInLinearRgb(
     b += srgbChannelToLinear(val.b, 'SRGB') * weight;
     a += (val.a ?? 1) * weight;
   });
-  return new Color({
+  return createColor({
     r: Math.round(linearChannelToSrgb(r, 'SRGB')),
     g: Math.round(linearChannelToSrgb(g, 'SRGB')),
     b: Math.round(linearChannelToSrgb(b, 'SRGB')),
@@ -759,7 +853,11 @@ function averageColorsInLinearRgb(
   });
 }
 
-function averageColorsInRgb(colors: readonly Color[], normalizedWeights: readonly number[]): Color {
+function averageColorsInRgb(
+  colors: readonly Color[],
+  normalizedWeights: readonly number[],
+  createColor: CreateColorInstance,
+): Color {
   let r = 0;
   let g = 0;
   let b = 0;
@@ -772,7 +870,7 @@ function averageColorsInRgb(colors: readonly Color[], normalizedWeights: readonl
     b += val.b * weight;
     a += (val.a ?? 1) * weight;
   });
-  return new Color({
+  return createColor({
     r: Math.round(r),
     g: Math.round(g),
     b: Math.round(b),
@@ -780,7 +878,24 @@ function averageColorsInRgb(colors: readonly Color[], normalizedWeights: readonl
   });
 }
 
-export function averageColors(colors: readonly Color[], options: AverageColorsOptions = {}): Color {
+export function averageColors(colors: readonly Color[], createColor: CreateColorInstance): Color;
+export function averageColors(
+  colors: readonly Color[],
+  options: AverageColorsOptions | undefined,
+  createColor: CreateColorInstance,
+): Color;
+export function averageColors(
+  colors: readonly Color[],
+  optionsOrCreateColor: AverageColorsOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
+
   if (colors.length < 2) {
     throw new Error('at least two colors are required for averaging');
   }
@@ -794,15 +909,15 @@ export function averageColors(colors: readonly Color[], options: AverageColorsOp
 
   switch (space) {
     case 'HSL':
-      return averageColorsInHsl(colors, normalizedWeights);
+      return averageColorsInHsl(colors, normalizedWeights, createColor);
     case 'LCH':
-      return averageColorsInLch(colors, normalizedWeights);
+      return averageColorsInLch(colors, normalizedWeights, createColor);
     case 'OKLCH':
-      return averageColorsInOklch(colors, normalizedWeights);
+      return averageColorsInOklch(colors, normalizedWeights, createColor);
     case 'LINEAR_RGB':
-      return averageColorsInLinearRgb(colors, normalizedWeights);
+      return averageColorsInLinearRgb(colors, normalizedWeights, createColor);
     case 'RGB':
     default:
-      return averageColorsInRgb(colors, normalizedWeights);
+      return averageColorsInRgb(colors, normalizedWeights, createColor);
   }
 }

--- a/src/color/conversions.ts
+++ b/src/color/conversions.ts
@@ -17,7 +17,7 @@ import type {
   ColorRGBA,
 } from './formats';
 import { getColorFormatType } from './formats';
-import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
+import { linearChannelToSrgb, srgbChannelToLinear } from './srgb';
 import { validateColorOrThrow } from './validations';
 
 const LAB_DELTA = 6 / 29; // = 0.20689655

--- a/src/color/gradients.ts
+++ b/src/color/gradients.ts
@@ -1,5 +1,5 @@
 import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
-import type { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
 import type {
   ColorHSL,
   ColorHSV,
@@ -9,7 +9,7 @@ import type {
   ColorRGB,
   ColorRGBA,
 } from './formats';
-import { linearChannelToSrgb, srgbChannelToLinear } from './utils';
+import { linearChannelToSrgb, srgbChannelToLinear } from './srgb';
 
 const GRADIENT_SPACES = ['RGB', 'HSL', 'HSV', 'LCH', 'OKLAB', 'OKLCH'] as const;
 export type ColorGradientSpace = (typeof GRADIENT_SPACES)[number];
@@ -785,13 +785,29 @@ function adjustHueStops(
  */
 export function createColorGradient(
   colors: readonly Color[],
-  options: ColorGradientOptions = {},
+  createColor: CreateColorInstance,
+): Color[];
+export function createColorGradient(
+  colors: readonly Color[],
+  options: ColorGradientOptions | undefined,
+  createColor: CreateColorInstance,
+): Color[];
+export function createColorGradient(
+  colors: readonly Color[],
+  optionsOrCreateColor: ColorGradientOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): Color[] {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
+
   if (colors.length < MIN_SCALE_STOPS) {
     throw new Error('at least two colors are required to build a gradient');
   }
 
-  const ColorConstructor = colors[0].constructor as typeof Color;
   const stopCount = getStopCount(options.stops);
   const space = resolveCaseInsensitiveOption({
     allowedValues: GRADIENT_SPACES,
@@ -840,7 +856,7 @@ export function createColorGradient(
       space,
       stopCount,
       stops: vectors,
-    }).map((stop) => new ColorConstructor(stop));
+    }).map((stop) => createColor(stop));
   }
 
   return interpolateLinearStops({
@@ -850,5 +866,5 @@ export function createColorGradient(
     space,
     stopCount,
     stops: vectors,
-  }).map((stop) => new ColorConstructor(stop));
+  }).map((stop) => createColor(stop));
 }

--- a/src/color/gradients.ts
+++ b/src/color/gradients.ts
@@ -785,25 +785,9 @@ function adjustHueStops(
  */
 export function createColorGradient(
   colors: readonly Color[],
+  options: ColorGradientOptions = {},
   createColor: CreateColorInstance,
-): Color[];
-export function createColorGradient(
-  colors: readonly Color[],
-  options: ColorGradientOptions | undefined,
-  createColor: CreateColorInstance,
-): Color[];
-export function createColorGradient(
-  colors: readonly Color[],
-  optionsOrCreateColor: ColorGradientOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): Color[] {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
-
   if (colors.length < MIN_SCALE_STOPS) {
     throw new Error('at least two colors are required to build a gradient');
   }

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -61,56 +61,20 @@ function resolveGrayscaleHandlingMode(options: ColorHarmonyOptions): GrayscaleHa
   });
 }
 
-function resolveHarmonyArgs(
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined,
-  maybeCreateColor?: CreateColorInstance,
-): { createColor: CreateColorInstance; options: ColorHarmonyOptions } {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-
-  return {
-    createColor,
-    options: typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {}),
-  };
-}
-
 export function getComplementaryColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color];
-export function getComplementaryColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color];
-export function getComplementaryColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [color.clone(), spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode, createColor)];
 }
 
 export function getSplitComplementaryColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color, Color];
-export function getSplitComplementaryColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color, Color];
-export function getSplitComplementaryColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
@@ -121,19 +85,9 @@ export function getSplitComplementaryColors(
 
 export function getTriadicHarmonyColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color, Color];
-export function getTriadicHarmonyColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color, Color];
-export function getTriadicHarmonyColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
@@ -144,19 +98,9 @@ export function getTriadicHarmonyColors(
 
 export function getSquareHarmonyColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color, Color, Color];
-export function getSquareHarmonyColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color, Color, Color];
-export function getSquareHarmonyColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
@@ -168,19 +112,9 @@ export function getSquareHarmonyColors(
 
 export function getTetradicHarmonyColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color, Color, Color];
-export function getTetradicHarmonyColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color, Color, Color];
-export function getTetradicHarmonyColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: tetradic harmonies can also be "wide" (120, 180, 300) or go in the other direction, or potentially any rectangle
   // e.g. #0000ff => #0000ff, #ff00ff, #ffff00, #00ff00
@@ -195,19 +129,9 @@ export function getTetradicHarmonyColors(
 
 export function getAnalogousHarmonyColors(
   color: Color,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): [Color, Color, Color, Color, Color];
-export function getAnalogousHarmonyColors(
-  color: Color,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): [Color, Color, Color, Color, Color];
-export function getAnalogousHarmonyColors(
-  color: Color,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color, Color] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: verify, because other libraries seem to have a slightly narrower angle
   return [
@@ -234,21 +158,9 @@ export function getMonochromaticHarmonyColors(
 export function getHarmonyColors(
   color: Color,
   harmony: CaseInsensitive<ColorHarmony>,
+  options: ColorHarmonyOptions = {},
   createColor: CreateColorInstance,
-): Color[];
-export function getHarmonyColors(
-  color: Color,
-  harmony: CaseInsensitive<ColorHarmony>,
-  options: ColorHarmonyOptions | undefined,
-  createColor: CreateColorInstance,
-): Color[];
-export function getHarmonyColors(
-  color: Color,
-  harmony: CaseInsensitive<ColorHarmony>,
-  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): Color[] {
-  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const resolvedHarmony = resolveRequiredCaseInsensitiveOption({
     allowedValues: COLOR_HARMONIES,
     key: 'harmony',

--- a/src/color/harmonies.ts
+++ b/src/color/harmonies.ts
@@ -1,6 +1,6 @@
 import { type CaseInsensitive, clampValue } from '../utils';
 import { resolveCaseInsensitiveOption, resolveRequiredCaseInsensitiveOption } from '../utils';
-import { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
 import type { ColorHSLA } from './formats';
 
 // TODO: consider using LCH or OKLCH space mode for more human perceptual accuracy
@@ -26,25 +26,26 @@ export interface ColorHarmonyOptions {
 // "spins" lightness around grayscale degrees, where 0 is black and 180 is white, and
 // everything in between is grayish. 180-360 loop back in the opposite direction.
 // This is meant to handle grayscale colors with 0 saturation where spinning on hue does nothing.
-function spinLightness(hsla: ColorHSLA, degrees: number): Color {
+function spinLightness(hsla: ColorHSLA, degrees: number, createColor: CreateColorInstance): Color {
   const normalized = ((degrees % 360) + 360) % 360;
   const distance = normalized > 180 ? 360 - normalized : normalized;
   const ratio = distance / 180;
   const complementL = 100 - hsla.l;
   const newL = clampValue(Math.round(hsla.l + (complementL - hsla.l) * ratio), 0, 100);
-  return new Color({ ...hsla, l: newL });
+  return createColor({ ...hsla, l: newL });
 }
 
 function spinColorOnHueOrLightness(
   color: Color,
   degrees: number,
   grayscaleHandlingMode: GrayscaleHandlingMode,
+  createColor: CreateColorInstance,
 ): Color {
   const hsla = color.toHSLA();
   if (hsla.s === 0) {
     // If the color is grayscale (saturation 0), handle it based on the mode
     if (grayscaleHandlingMode === 'SPIN_LIGHTNESS') {
-      return spinLightness(hsla, degrees);
+      return spinLightness(hsla, degrees, createColor);
     }
     return color.clone(); // No change for grayscale in IGNORE mode (treating the operation as undefined)
   }
@@ -60,96 +61,194 @@ function resolveGrayscaleHandlingMode(options: ColorHarmonyOptions): GrayscaleHa
   });
 }
 
+function resolveHarmonyArgs(
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined,
+  maybeCreateColor?: CreateColorInstance,
+): { createColor: CreateColorInstance; options: ColorHarmonyOptions } {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+
+  return {
+    createColor,
+    options: typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {}),
+  };
+}
+
 export function getComplementaryColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color];
+export function getComplementaryColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color];
+export function getComplementaryColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
-  return [color.clone(), spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode)];
+  return [color.clone(), spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode, createColor)];
 }
 
 export function getSplitComplementaryColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color, Color];
+export function getSplitComplementaryColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color, Color];
+export function getSplitComplementaryColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
-    spinColorOnHueOrLightness(color, -150, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 150, grayscaleHandlingMode),
+    spinColorOnHueOrLightness(color, -150, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 150, grayscaleHandlingMode, createColor),
   ];
 }
 
 export function getTriadicHarmonyColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color, Color];
+export function getTriadicHarmonyColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color, Color];
+export function getTriadicHarmonyColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
-    spinColorOnHueOrLightness(color, -120, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 120, grayscaleHandlingMode),
+    spinColorOnHueOrLightness(color, -120, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 120, grayscaleHandlingMode, createColor),
   ];
 }
 
 export function getSquareHarmonyColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color];
+export function getSquareHarmonyColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color];
+export function getSquareHarmonyColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   return [
     color.clone(),
-    spinColorOnHueOrLightness(color, 90, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 270, grayscaleHandlingMode),
+    spinColorOnHueOrLightness(color, 90, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 270, grayscaleHandlingMode, createColor),
   ];
 }
 
 export function getTetradicHarmonyColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color];
+export function getTetradicHarmonyColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color];
+export function getTetradicHarmonyColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: tetradic harmonies can also be "wide" (120, 180, 300) or go in the other direction, or potentially any rectangle
   // e.g. #0000ff => #0000ff, #ff00ff, #ffff00, #00ff00
   // vs.  #0000ff => #0000ff, #00ffff, #ffff00, #ff0000
   return [
     color.clone(),
-    spinColorOnHueOrLightness(color, 60, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 240, grayscaleHandlingMode),
+    spinColorOnHueOrLightness(color, 60, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 180, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 240, grayscaleHandlingMode, createColor),
   ];
 }
 
 export function getAnalogousHarmonyColors(
   color: Color,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color, Color];
+export function getAnalogousHarmonyColors(
+  color: Color,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color, Color];
+export function getAnalogousHarmonyColors(
+  color: Color,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): [Color, Color, Color, Color, Color] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const grayscaleHandlingMode = resolveGrayscaleHandlingMode(options);
   // TODO: verify, because other libraries seem to have a slightly narrower angle
   return [
     color.clone(),
-    spinColorOnHueOrLightness(color, -30, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 30, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, -60, grayscaleHandlingMode),
-    spinColorOnHueOrLightness(color, 60, grayscaleHandlingMode),
+    spinColorOnHueOrLightness(color, -30, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 30, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, -60, grayscaleHandlingMode, createColor),
+    spinColorOnHueOrLightness(color, 60, grayscaleHandlingMode, createColor),
   ];
 }
 
-export function getMonochromaticHarmonyColors(color: Color): [Color, Color, Color, Color, Color] {
+export function getMonochromaticHarmonyColors(
+  color: Color,
+  createColor: CreateColorInstance,
+): [Color, Color, Color, Color, Color] {
   const hsla = color.toHSLA();
-  const lighter = new Color({ ...hsla, l: clampValue(hsla.l + 20, 0, 100) });
-  const darker = new Color({ ...hsla, l: clampValue(hsla.l - 20, 0, 100) });
-  const saturated = new Color({ ...hsla, s: clampValue(hsla.s + 20, 0, 100) });
-  const desaturated = new Color({ ...hsla, s: clampValue(hsla.s - 20, 0, 100) });
+  const lighter = createColor({ ...hsla, l: clampValue(hsla.l + 20, 0, 100) });
+  const darker = createColor({ ...hsla, l: clampValue(hsla.l - 20, 0, 100) });
+  const saturated = createColor({ ...hsla, s: clampValue(hsla.s + 20, 0, 100) });
+  const desaturated = createColor({ ...hsla, s: clampValue(hsla.s - 20, 0, 100) });
   return [color.clone(), lighter, darker, saturated, desaturated];
 }
 
 export function getHarmonyColors(
   color: Color,
   harmony: CaseInsensitive<ColorHarmony>,
-  options: ColorHarmonyOptions = {},
+  createColor: CreateColorInstance,
+): Color[];
+export function getHarmonyColors(
+  color: Color,
+  harmony: CaseInsensitive<ColorHarmony>,
+  options: ColorHarmonyOptions | undefined,
+  createColor: CreateColorInstance,
+): Color[];
+export function getHarmonyColors(
+  color: Color,
+  harmony: CaseInsensitive<ColorHarmony>,
+  optionsOrCreateColor: ColorHarmonyOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): Color[] {
+  const { options, createColor } = resolveHarmonyArgs(optionsOrCreateColor, maybeCreateColor);
   const resolvedHarmony = resolveRequiredCaseInsensitiveOption({
     allowedValues: COLOR_HARMONIES,
     key: 'harmony',
@@ -158,19 +257,19 @@ export function getHarmonyColors(
 
   switch (resolvedHarmony) {
     case 'COMPLEMENTARY':
-      return getComplementaryColors(color, options);
+      return getComplementaryColors(color, options, createColor);
     case 'SPLIT_COMPLEMENTARY':
-      return getSplitComplementaryColors(color, options);
+      return getSplitComplementaryColors(color, options, createColor);
     case 'TRIADIC':
-      return getTriadicHarmonyColors(color, options);
+      return getTriadicHarmonyColors(color, options, createColor);
     case 'SQUARE':
-      return getSquareHarmonyColors(color, options);
+      return getSquareHarmonyColors(color, options, createColor);
     case 'TETRADIC':
-      return getTetradicHarmonyColors(color, options);
+      return getTetradicHarmonyColors(color, options, createColor);
     case 'ANALOGOUS':
-      return getAnalogousHarmonyColors(color, options);
+      return getAnalogousHarmonyColors(color, options, createColor);
     case 'MONOCHROMATIC':
-      return getMonochromaticHarmonyColors(color);
+      return getMonochromaticHarmonyColors(color, createColor);
     default:
       throw new Error(`unknown color harmony: ${harmony}`);
   }

--- a/src/color/manipulations.ts
+++ b/src/color/manipulations.ts
@@ -1,5 +1,6 @@
 import { clampValue } from '../utils';
-import { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
+import { getColorInstanceFactory } from './color.helpers';
 import type { ColorLCH } from './formats';
 
 export type ColorBrightnessSpace = 'HSL' | 'LAB' | 'LCH';
@@ -31,6 +32,7 @@ export interface ColorSaturationOptions {
 const DEFAULT_MANIPULATION_AMOUNT = 10;
 // Default LAB/LCH lightness or chroma delta applied per 10% step when using LAB-backed spaces.
 const DEFAULT_LAB_LIGHTNESS_DELTA_PER_STEP = 18;
+const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 function getColorBrightnessOptions(
   options?: ColorBrightnessOptions,
@@ -69,89 +71,132 @@ function normalizeLCH(lch: ColorLCH): ColorLCH {
   };
 }
 
-export function spinColorHue(color: Color, degrees: number): Color {
+export function spinColorHue(
+  color: Color,
+  degrees: number,
+  createColor: CreateColorInstance = defaultCreateColor(),
+): Color {
   const hsla = color.toHSLA();
   const rotatedHue = (((hsla.h + degrees) % 360) + 360) % 360;
   hsla.h = rotatedHue;
-  return new Color(hsla);
+  return createColor(hsla);
 }
 
-export function brightenColor(color: Color, options?: ColorBrightnessOptions): Color {
+export function brightenColor(
+  color: Color,
+  optionsOrCreateColor: ColorBrightnessOptions | CreateColorInstance | undefined = undefined,
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function'
+      ? optionsOrCreateColor
+      : (maybeCreateColor ?? defaultCreateColor());
+  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorBrightnessOptions(options);
   switch (space) {
     case 'LAB': {
       const lab = color.toLAB();
       const updatedL = clampValue(lab.l + getLABLikeDelta(amount, labScale), 0, 100);
-      return new Color({ ...lab, l: updatedL }).setAlpha(color.getAlpha());
+      return createColor({ ...lab, l: updatedL }).setAlpha(color.getAlpha());
     }
     case 'LCH': {
       const lch = normalizeLCH(color.toLCH());
       const updatedL = clampValue(lch.l + getLABLikeDelta(amount, labScale), 0, 100);
-      return new Color({ ...lch, l: updatedL, format: 'LCH' }).setAlpha(color.getAlpha());
+      return createColor({ ...lch, l: updatedL, format: 'LCH' }).setAlpha(color.getAlpha());
     }
     case 'HSL':
     default: {
       const hsla = color.toHSLA();
       hsla.l = clampValue(hsla.l + amount, 0, 100);
-      return new Color(hsla);
+      return createColor(hsla);
     }
   }
 }
 
-export function darkenColor(color: Color, options?: ColorBrightnessOptions): Color {
+export function darkenColor(
+  color: Color,
+  optionsOrCreateColor: ColorBrightnessOptions | CreateColorInstance | undefined = undefined,
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function'
+      ? optionsOrCreateColor
+      : (maybeCreateColor ?? defaultCreateColor());
+  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorBrightnessOptions(options);
   switch (space) {
     case 'LAB': {
       const lab = color.toLAB();
       const updatedL = clampValue(lab.l - getLABLikeDelta(amount, labScale), 0, 100);
-      return new Color({ ...lab, l: updatedL }).setAlpha(color.getAlpha());
+      return createColor({ ...lab, l: updatedL }).setAlpha(color.getAlpha());
     }
     case 'LCH': {
       const lch = normalizeLCH(color.toLCH());
       const updatedL = clampValue(lch.l - getLABLikeDelta(amount, labScale), 0, 100);
-      return new Color({ ...lch, l: updatedL, format: 'LCH' }).setAlpha(color.getAlpha());
+      return createColor({ ...lch, l: updatedL, format: 'LCH' }).setAlpha(color.getAlpha());
     }
     case 'HSL':
     default: {
-      return brightenColor(color, { amount: -amount, space: 'HSL' });
+      return brightenColor(color, { amount: -amount, space: 'HSL' }, createColor);
     }
   }
 }
 
-export function saturateColor(color: Color, options?: ColorSaturationOptions): Color {
+export function saturateColor(
+  color: Color,
+  optionsOrCreateColor: ColorSaturationOptions | CreateColorInstance | undefined = undefined,
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function'
+      ? optionsOrCreateColor
+      : (maybeCreateColor ?? defaultCreateColor());
+  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorSaturationOptions(options);
   switch (space) {
     case 'LCH': {
       const lch = normalizeLCH(color.toLCH());
       const updatedC = Math.max(0, lch.c + getLABLikeDelta(amount, labScale));
-      return new Color({ ...lch, c: updatedC, format: 'LCH' }).setAlpha(color.getAlpha());
+      return createColor({ ...lch, c: updatedC, format: 'LCH' }).setAlpha(color.getAlpha());
     }
     case 'HSL':
     default: {
       const hsla = color.toHSLA();
       hsla.s = clampValue(hsla.s + amount, 0, 100);
-      return new Color(hsla);
+      return createColor(hsla);
     }
   }
 }
 
-export function desaturateColor(color: Color, options?: ColorSaturationOptions): Color {
+export function desaturateColor(
+  color: Color,
+  optionsOrCreateColor: ColorSaturationOptions | CreateColorInstance | undefined = undefined,
+  maybeCreateColor?: CreateColorInstance,
+): Color {
+  const createColor =
+    typeof optionsOrCreateColor === 'function'
+      ? optionsOrCreateColor
+      : (maybeCreateColor ?? defaultCreateColor());
+  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorSaturationOptions(options);
   switch (space) {
     case 'LCH': {
       const lch = normalizeLCH(color.toLCH());
       const updatedC = Math.max(0, lch.c - getLABLikeDelta(amount, labScale));
-      return new Color({ ...lch, c: updatedC, format: 'LCH' }).setAlpha(color.getAlpha());
+      return createColor({ ...lch, c: updatedC, format: 'LCH' }).setAlpha(color.getAlpha());
     }
     case 'HSL':
     default: {
-      return saturateColor(color, { amount: -amount, space: 'HSL' });
+      return saturateColor(color, { amount: -amount, space: 'HSL' }, createColor);
     }
   }
 }
 
-export function colorToGrayscale(color: Color): Color {
+export function colorToGrayscale(
+  color: Color,
+  createColor: CreateColorInstance = defaultCreateColor(),
+): Color {
   const hsla = color.toHSLA();
   hsla.s = 0;
-  return new Color(hsla);
+  return createColor(hsla);
 }

--- a/src/color/manipulations.ts
+++ b/src/color/manipulations.ts
@@ -1,6 +1,5 @@
 import { clampValue } from '../utils';
 import type { Color, CreateColorInstance } from './color';
-import { getColorInstanceFactory } from './color.helpers';
 import type { ColorLCH } from './formats';
 
 export type ColorBrightnessSpace = 'HSL' | 'LAB' | 'LCH';
@@ -32,7 +31,6 @@ export interface ColorSaturationOptions {
 const DEFAULT_MANIPULATION_AMOUNT = 10;
 // Default LAB/LCH lightness or chroma delta applied per 10% step when using LAB-backed spaces.
 const DEFAULT_LAB_LIGHTNESS_DELTA_PER_STEP = 18;
-const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 function getColorBrightnessOptions(
   options?: ColorBrightnessOptions,
@@ -74,7 +72,7 @@ function normalizeLCH(lch: ColorLCH): ColorLCH {
 export function spinColorHue(
   color: Color,
   degrees: number,
-  createColor: CreateColorInstance = defaultCreateColor(),
+  createColor: CreateColorInstance,
 ): Color {
   const hsla = color.toHSLA();
   const rotatedHue = (((hsla.h + degrees) % 360) + 360) % 360;
@@ -84,14 +82,9 @@ export function spinColorHue(
 
 export function brightenColor(
   color: Color,
-  optionsOrCreateColor: ColorBrightnessOptions | CreateColorInstance | undefined = undefined,
-  maybeCreateColor?: CreateColorInstance,
+  options: ColorBrightnessOptions = {},
+  createColor: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function'
-      ? optionsOrCreateColor
-      : (maybeCreateColor ?? defaultCreateColor());
-  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorBrightnessOptions(options);
   switch (space) {
     case 'LAB': {
@@ -115,14 +108,9 @@ export function brightenColor(
 
 export function darkenColor(
   color: Color,
-  optionsOrCreateColor: ColorBrightnessOptions | CreateColorInstance | undefined = undefined,
-  maybeCreateColor?: CreateColorInstance,
+  options: ColorBrightnessOptions = {},
+  createColor: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function'
-      ? optionsOrCreateColor
-      : (maybeCreateColor ?? defaultCreateColor());
-  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorBrightnessOptions(options);
   switch (space) {
     case 'LAB': {
@@ -144,14 +132,9 @@ export function darkenColor(
 
 export function saturateColor(
   color: Color,
-  optionsOrCreateColor: ColorSaturationOptions | CreateColorInstance | undefined = undefined,
-  maybeCreateColor?: CreateColorInstance,
+  options: ColorSaturationOptions = {},
+  createColor: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function'
-      ? optionsOrCreateColor
-      : (maybeCreateColor ?? defaultCreateColor());
-  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorSaturationOptions(options);
   switch (space) {
     case 'LCH': {
@@ -170,14 +153,9 @@ export function saturateColor(
 
 export function desaturateColor(
   color: Color,
-  optionsOrCreateColor: ColorSaturationOptions | CreateColorInstance | undefined = undefined,
-  maybeCreateColor?: CreateColorInstance,
+  options: ColorSaturationOptions = {},
+  createColor: CreateColorInstance,
 ): Color {
-  const createColor =
-    typeof optionsOrCreateColor === 'function'
-      ? optionsOrCreateColor
-      : (maybeCreateColor ?? defaultCreateColor());
-  const options = typeof optionsOrCreateColor === 'function' ? undefined : optionsOrCreateColor;
   const { amount, space, labScale } = getColorSaturationOptions(options);
   switch (space) {
     case 'LCH': {
@@ -192,10 +170,7 @@ export function desaturateColor(
   }
 }
 
-export function colorToGrayscale(
-  color: Color,
-  createColor: CreateColorInstance = defaultCreateColor(),
-): Color {
+export function colorToGrayscale(color: Color, createColor: CreateColorInstance): Color {
   const hsla = color.toHSLA();
   hsla.s = 0;
   return createColor(hsla);

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -1,5 +1,5 @@
 import { clampValue } from '../utils';
-import { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
 import {
   type ColorSpaceValues,
   convertColorSpaceValuesToRGB,
@@ -122,9 +122,9 @@ function parseHueAngle(value: string): number {
   return normalizeHue(numericValue);
 }
 
-function createColorOrNull(format: ColorFormat): Color | null {
+function createColorOrNull(format: ColorFormat, createColor: CreateColorInstance): Color | null {
   try {
-    return new Color(format);
+    return createColor(format);
   } catch {
     return null;
   }
@@ -176,7 +176,7 @@ function parseHueAndTwoPercentChannels(channels: string[]): ParsedHueAndPercentC
   return { hue, firstPercentChannel, secondPercentChannel };
 }
 
-function parseColor(params: string): Color | null {
+function parseColor(params: string, createColor: CreateColorInstance): Color | null {
   const separatorIndex = params.search(/[\s,]/);
   if (separatorIndex === -1) {
     return null;
@@ -212,7 +212,7 @@ function parseColor(params: string): Color | null {
   const colorSpaceValues: ColorSpaceValues = { r, g, b };
   const rgb = convertColorSpaceValuesToRGB(colorSpaceValues, colorSpaceName);
   if (colorParams.alpha === undefined) {
-    return createColorOrNull(rgb);
+    return createColorOrNull(rgb, createColor);
   }
 
   const alpha = parseAlpha(colorParams.alpha);
@@ -220,10 +220,10 @@ function parseColor(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ ...rgb, a: alpha });
+  return createColorOrNull({ ...rgb, a: alpha }, createColor);
 }
 
-function parseRGB(params: string): Color | null {
+function parseRGB(params: string, createColor: CreateColorInstance): Color | null {
   const rgbParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -239,7 +239,7 @@ function parseRGB(params: string): Color | null {
   }
 
   if (rgbParams.alpha === undefined) {
-    return createColorOrNull(rgbChannels);
+    return createColorOrNull(rgbChannels, createColor);
   }
 
   const alpha = parseAlpha(rgbParams.alpha);
@@ -247,10 +247,10 @@ function parseRGB(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ ...rgbChannels, a: alpha });
+  return createColorOrNull({ ...rgbChannels, a: alpha }, createColor);
 }
 
-function parseRGBA(params: string): Color | null {
+function parseRGBA(params: string, createColor: CreateColorInstance): Color | null {
   const rgbaParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -274,10 +274,10 @@ function parseRGBA(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ ...rgbChannels, a: alpha });
+  return createColorOrNull({ ...rgbChannels, a: alpha }, createColor);
 }
 
-function parseHSL(params: string): Color | null {
+function parseHSL(params: string, createColor: CreateColorInstance): Color | null {
   const hslParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -294,7 +294,7 @@ function parseHSL(params: string): Color | null {
 
   const { hue: h, firstPercentChannel: s, secondPercentChannel: l } = parsedChannels;
   if (hslParams.alpha === undefined) {
-    return createColorOrNull({ h, s, l });
+    return createColorOrNull({ h, s, l }, createColor);
   }
 
   const alpha = parseAlpha(hslParams.alpha);
@@ -302,10 +302,10 @@ function parseHSL(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ h, s, l, a: alpha });
+  return createColorOrNull({ h, s, l, a: alpha }, createColor);
 }
 
-function parseHSLA(params: string): Color | null {
+function parseHSLA(params: string, createColor: CreateColorInstance): Color | null {
   const hslaParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -330,10 +330,10 @@ function parseHSLA(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ h, s, l, a: alpha });
+  return createColorOrNull({ h, s, l, a: alpha }, createColor);
 }
 
-function parseHSV(params: string): Color | null {
+function parseHSV(params: string, createColor: CreateColorInstance): Color | null {
   const hsvParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -350,7 +350,7 @@ function parseHSV(params: string): Color | null {
 
   const { hue: h, firstPercentChannel: s, secondPercentChannel: v } = parsedChannels;
   if (hsvParams.alpha === undefined) {
-    return createColorOrNull({ h, s, v });
+    return createColorOrNull({ h, s, v }, createColor);
   }
 
   const alpha = parseAlpha(hsvParams.alpha);
@@ -358,10 +358,10 @@ function parseHSV(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ h, s, v, a: alpha });
+  return createColorOrNull({ h, s, v, a: alpha }, createColor);
 }
 
-function parseHSVA(params: string): Color | null {
+function parseHSVA(params: string, createColor: CreateColorInstance): Color | null {
   const hsvaParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -386,10 +386,10 @@ function parseHSVA(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ h, s, v, a: alpha });
+  return createColorOrNull({ h, s, v, a: alpha }, createColor);
 }
 
-function parseHWB(params: string): Color | null {
+function parseHWB(params: string, createColor: CreateColorInstance): Color | null {
   const hwbParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -406,7 +406,7 @@ function parseHWB(params: string): Color | null {
 
   const { hue: h, firstPercentChannel: w, secondPercentChannel: b } = parsedChannels;
   if (hwbParams.alpha === undefined) {
-    return createColorOrNull({ h, w, b });
+    return createColorOrNull({ h, w, b }, createColor);
   }
 
   const alpha = parseAlpha(hwbParams.alpha);
@@ -414,10 +414,10 @@ function parseHWB(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ h, w, b, a: alpha });
+  return createColorOrNull({ h, w, b, a: alpha }, createColor);
 }
 
-function parseCMYK(params: string): Color | null {
+function parseCMYK(params: string, createColor: CreateColorInstance): Color | null {
   const cmykParams = splitColorFunctionParams(params, { expectedChannels: 4 });
   if (!cmykParams) {
     return null;
@@ -428,10 +428,10 @@ function parseCMYK(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ c, m, y, k });
+  return createColorOrNull({ c, m, y, k }, createColor);
 }
 
-function parseLAB(params: string): Color | null {
+function parseLAB(params: string, createColor: CreateColorInstance): Color | null {
   const labParams = splitColorFunctionParams(params, { expectedChannels: 3 });
   if (!labParams) {
     return null;
@@ -446,10 +446,10 @@ function parseLAB(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ l, a, b, format: 'LAB' });
+  return createColorOrNull({ l, a, b, format: 'LAB' }, createColor);
 }
 
-function parseLCH(params: string): Color | null {
+function parseLCH(params: string, createColor: CreateColorInstance): Color | null {
   const lchParams = splitColorFunctionParams(params, { expectedChannels: 3 });
   if (!lchParams) {
     return null;
@@ -464,10 +464,10 @@ function parseLCH(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ l, c, h, format: 'LCH' });
+  return createColorOrNull({ l, c, h, format: 'LCH' }, createColor);
 }
 
-function parseOKLAB(params: string): Color | null {
+function parseOKLAB(params: string, createColor: CreateColorInstance): Color | null {
   const oklabParams = splitColorFunctionParams(params, {
     expectedChannels: 3,
     allowAlpha: true,
@@ -489,7 +489,7 @@ function parseOKLAB(params: string): Color | null {
     return null;
   }
 
-  const parsedColor = createColorOrNull({ l, a, b, format: 'OKLAB' });
+  const parsedColor = createColorOrNull({ l, a, b, format: 'OKLAB' }, createColor);
   if (!parsedColor) {
     return null;
   }
@@ -506,7 +506,7 @@ function parseOKLAB(params: string): Color | null {
   return parsedColor.setAlpha(alpha);
 }
 
-function parseOKLCH(params: string): Color | null {
+function parseOKLCH(params: string, createColor: CreateColorInstance): Color | null {
   const oklchParams = splitColorFunctionParams(params, { expectedChannels: 3 });
   if (!oklchParams) {
     return null;
@@ -524,12 +524,12 @@ function parseOKLCH(params: string): Color | null {
     return null;
   }
 
-  return createColorOrNull({ l, c, h });
+  return createColorOrNull({ l, c, h }, createColor);
 }
 
 const CSS_COLOR_PARSERS: {
   match: RegExp;
-  parse: (params: string) => Color | null;
+  parse: (params: string, createColor: CreateColorInstance) => Color | null;
 }[] = [
   { match: MATCH_COLOR_FUNCTION_REGEX, parse: parseColor },
   { match: MATCH_RGB_STRING_REGEX, parse: parseRGB },
@@ -546,13 +546,16 @@ const CSS_COLOR_PARSERS: {
   { match: MATCH_OKLCH_STRING_REGEX, parse: parseOKLCH },
 ] as const;
 
-export function parseCSSColorFormatString(colorFormatString: string): Color | null {
+export function parseCSSColorFormatString(
+  colorFormatString: string,
+  createColor: CreateColorInstance,
+): Color | null {
   const normalizedColorFormatString = colorFormatString.trim().toLowerCase();
 
   for (const parserDefinition of CSS_COLOR_PARSERS) {
     const match = normalizedColorFormatString.match(parserDefinition.match);
     if (match) {
-      return parserDefinition.parse(match[1].trim());
+      return parserDefinition.parse(match[1].trim(), createColor);
     }
   }
 

--- a/src/color/srgb.ts
+++ b/src/color/srgb.ts
@@ -1,0 +1,37 @@
+import { clampValue } from '../utils';
+
+const RGB_CHANNEL_MAX_VALUE = 255; // 8‑bit channel ceiling
+const SRGB_LINEAR_SEGMENT_DIVISOR = 12.92; // slope for low‑intensity segment
+const SRGB_GAMMA_OFFSET = 0.055; // additive term in sRGB gamma curve
+const SRGB_GAMMA_SCALE = 1.055; // multiplicative term in sRGB gamma curve
+const SRGB_GAMMA_EXPONENT = 2.4; // exponent in sRGB transfer function
+
+const SRGB_GAMMA_PIVOT_OPTIONS = {
+  SRGB: 0.04045,
+  WCAG: 0.03928,
+} as const;
+
+type SrgbGammaPivot = keyof typeof SRGB_GAMMA_PIVOT_OPTIONS;
+
+export function srgbChannelToLinear(srgbChannelVal: number, pivot: SrgbGammaPivot): number {
+  const c = clampValue(srgbChannelVal, 0, RGB_CHANNEL_MAX_VALUE) / RGB_CHANNEL_MAX_VALUE; // normalize
+  let result: number;
+  if (c <= SRGB_GAMMA_PIVOT_OPTIONS[pivot]) {
+    result = c / SRGB_LINEAR_SEGMENT_DIVISOR; // linear portion for dark colors
+  } else {
+    result = Math.pow((c + SRGB_GAMMA_OFFSET) / SRGB_GAMMA_SCALE, SRGB_GAMMA_EXPONENT); // gamma correction for brighter colors
+  }
+  return clampValue(result, 0, 1);
+}
+
+export function linearChannelToSrgb(linearChannelVal: number, pivot: SrgbGammaPivot): number {
+  const c = clampValue(linearChannelVal, 0, 1);
+  const threshold = SRGB_GAMMA_PIVOT_OPTIONS[pivot] / SRGB_LINEAR_SEGMENT_DIVISOR;
+  let result: number;
+  if (c > threshold) {
+    result = SRGB_GAMMA_SCALE * Math.pow(c, 1 / SRGB_GAMMA_EXPONENT) - SRGB_GAMMA_OFFSET;
+  } else {
+    result = c * SRGB_LINEAR_SEGMENT_DIVISOR;
+  }
+  return clampValue(result * RGB_CHANNEL_MAX_VALUE, 0, RGB_CHANNEL_MAX_VALUE);
+}

--- a/src/color/swatch.ts
+++ b/src/color/swatch.ts
@@ -222,10 +222,9 @@ function getExtendedColorSwatch(
   }) as ExtendedColorSwatch;
 }
 
-export function getColorSwatch(baseColor: Color, createColor: CreateColorInstance): ColorSwatch;
 export function getColorSwatch(
   baseColor: Color,
-  options: (ColorSwatchOptions & { extended: true }) | undefined,
+  options: ColorSwatchOptions & { extended: true },
   createColor: CreateColorInstance,
 ): ExtendedColorSwatch;
 export function getColorSwatch(
@@ -235,16 +234,9 @@ export function getColorSwatch(
 ): ColorSwatch;
 export function getColorSwatch(
   baseColor: Color,
-  optionsOrCreateColor: ColorSwatchOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
+  options: ColorSwatchOptions = {},
+  createColor: CreateColorInstance,
 ): ColorSwatch {
-  const createColor =
-    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
-  if (!createColor) {
-    throw new Error('createColor function is required');
-  }
-  const options =
-    typeof optionsOrCreateColor === 'function' ? ({} as ColorSwatchOptions) : optionsOrCreateColor;
   const mainStop = getMainStop(baseColor, options.centerOn500 ?? false);
 
   if (options.extended) {

--- a/src/color/swatch.ts
+++ b/src/color/swatch.ts
@@ -1,5 +1,5 @@
 import { clampValue } from '../utils';
-import { Color } from './color';
+import type { Color, CreateColorInstance } from './color';
 
 type BasicColorSwatchStop = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 type ExtendedColorSwatchStop =
@@ -158,12 +158,14 @@ function createSwatch<Stop extends number>({
   mainStop,
   stops,
   type,
+  createColor,
 }: {
   baseColor: Color;
   deltas: ColorSwatchStopDeltas<Stop>;
   mainStop: BasicColorSwatchStop;
   stops: readonly Stop[];
   type: ColorSwatch['type'];
+  createColor: CreateColorInstance;
 }): ColorSwatch {
   const { h: baseH, s: baseS, l: baseL, a: baseA } = baseColor.toHSLA();
 
@@ -173,7 +175,7 @@ function createSwatch<Stop extends number>({
     acc[stop] =
       stop === mainStop
         ? baseColor.clone()
-        : new Color({
+        : createColor({
             h: baseH,
             s: getAdjustedSaturation(baseS, delta.saturationDelta),
             l: clampValue(baseL + delta.lightnessDelta, 0, 100),
@@ -190,19 +192,25 @@ function createSwatch<Stop extends number>({
   } as ColorSwatch;
 }
 
-function getBaseColorSwatch(baseColor: Color, mainStop: BasicColorSwatchStop): BaseColorSwatch {
+function getBaseColorSwatch(
+  baseColor: Color,
+  mainStop: BasicColorSwatchStop,
+  createColor: CreateColorInstance,
+): BaseColorSwatch {
   return createSwatch({
     baseColor,
     deltas: BASIC_SWATCH_DELTAS,
     mainStop,
     stops: BASE_COLOR_SWATCH_STOPS,
     type: 'BASIC',
+    createColor,
   }) as BaseColorSwatch;
 }
 
 function getExtendedColorSwatch(
   baseColor: Color,
   mainStop: BasicColorSwatchStop,
+  createColor: CreateColorInstance,
 ): ExtendedColorSwatch {
   return createSwatch({
     baseColor,
@@ -210,20 +218,38 @@ function getExtendedColorSwatch(
     mainStop,
     stops: EXTENDED_COLOR_SWATCH_STOPS,
     type: 'EXTENDED',
+    createColor,
   }) as ExtendedColorSwatch;
 }
 
+export function getColorSwatch(baseColor: Color, createColor: CreateColorInstance): ColorSwatch;
 export function getColorSwatch(
   baseColor: Color,
-  options?: ColorSwatchOptions & { extended: true },
+  options: (ColorSwatchOptions & { extended: true }) | undefined,
+  createColor: CreateColorInstance,
 ): ExtendedColorSwatch;
-export function getColorSwatch(baseColor: Color, options?: ColorSwatchOptions): ColorSwatch;
-export function getColorSwatch(baseColor: Color, options: ColorSwatchOptions = {}): ColorSwatch {
+export function getColorSwatch(
+  baseColor: Color,
+  options: ColorSwatchOptions | undefined,
+  createColor: CreateColorInstance,
+): ColorSwatch;
+export function getColorSwatch(
+  baseColor: Color,
+  optionsOrCreateColor: ColorSwatchOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
+): ColorSwatch {
+  const createColor =
+    typeof optionsOrCreateColor === 'function' ? optionsOrCreateColor : maybeCreateColor;
+  if (!createColor) {
+    throw new Error('createColor function is required');
+  }
+  const options =
+    typeof optionsOrCreateColor === 'function' ? ({} as ColorSwatchOptions) : optionsOrCreateColor;
   const mainStop = getMainStop(baseColor, options.centerOn500 ?? false);
 
   if (options.extended) {
-    return getExtendedColorSwatch(baseColor, mainStop);
+    return getExtendedColorSwatch(baseColor, mainStop, createColor);
   }
 
-  return getBaseColorSwatch(baseColor, mainStop);
+  return getBaseColorSwatch(baseColor, mainStop, createColor);
 }

--- a/src/color/temperature.ts
+++ b/src/color/temperature.ts
@@ -1,6 +1,5 @@
 import { type CaseInsensitive, clampValue } from '../utils';
 import type { Color, CreateColorInstance } from './color';
-import { getColorInstanceFactory } from './color.helpers';
 import { srgbChannelToLinear } from './srgb';
 
 const COLOR_TEMPERATURE_LABELS = {
@@ -56,7 +55,6 @@ const LABEL_TO_TEMPERATURE_MAP: { [key in ColorTemperatureLabel]: number } = {
 // threshold of ~120 units (roughly half of the 0-255 channel range) was chosen
 // based on manual testing of canonical temperature colors and nearby hues.
 const MAX_COLOR_DISTANCE_FOR_LABEL = 120 * 120;
-const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 function getLabelForTemperature(temperature: number): ColorTemperatureLabel {
   const found = SORTED_TEMPERATURE_LABELS.find((t) => temperature < t.temperatureLimit);
@@ -94,22 +92,11 @@ export function getColorTemperature(color: Color): ColorTemperatureAndLabel {
   return { temperature, label: getLabelForTemperature(temperature) };
 }
 
-export function getColorTemperatureString(color: Color, createColor: CreateColorInstance): string;
 export function getColorTemperatureString(
   color: Color,
-  options: ColorTemperatureStringFormatOptions | undefined,
+  options: ColorTemperatureStringFormatOptions = {},
   createColor: CreateColorInstance,
-): string;
-export function getColorTemperatureString(
-  color: Color,
-  optionsOrCreateColor: ColorTemperatureStringFormatOptions | CreateColorInstance | undefined = {},
-  maybeCreateColor?: CreateColorInstance,
 ): string {
-  const createColor =
-    typeof optionsOrCreateColor === 'function'
-      ? optionsOrCreateColor
-      : (maybeCreateColor ?? defaultCreateColor());
-  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
   const { temperature, label } = getColorTemperature(color);
   const formattedTemperature = options.formatNumber ? temperature.toLocaleString() : temperature;
 
@@ -130,7 +117,7 @@ export function getColorTemperatureString(
 
 export function getColorFromTemperature(
   temperature: number,
-  createColor: CreateColorInstance = defaultCreateColor(),
+  createColor: CreateColorInstance,
 ): Color {
   // Clamp to the range supported by the conversion algorithm.
   const temp = clampValue(temperature, 1000, 40000) / 100;
@@ -184,7 +171,7 @@ export function matchPartialColorTemperatureLabel(
 
 export function getColorFromTemperatureLabel(
   label: CaseInsensitive<ColorTemperatureLabel>,
-  createColor: CreateColorInstance = defaultCreateColor(),
+  createColor: CreateColorInstance,
 ): Color {
   const matchedLabel = matchPartialColorTemperatureLabel(label);
   if (!matchedLabel) {

--- a/src/color/temperature.ts
+++ b/src/color/temperature.ts
@@ -1,6 +1,7 @@
 import { type CaseInsensitive, clampValue } from '../utils';
-import { Color } from './color';
-import { srgbChannelToLinear } from './utils';
+import type { Color, CreateColorInstance } from './color';
+import { getColorInstanceFactory } from './color.helpers';
+import { srgbChannelToLinear } from './srgb';
 
 const COLOR_TEMPERATURE_LABELS = {
   // Warm:
@@ -55,6 +56,7 @@ const LABEL_TO_TEMPERATURE_MAP: { [key in ColorTemperatureLabel]: number } = {
 // threshold of ~120 units (roughly half of the 0-255 channel range) was chosen
 // based on manual testing of canonical temperature colors and nearby hues.
 const MAX_COLOR_DISTANCE_FOR_LABEL = 120 * 120;
+const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 function getLabelForTemperature(temperature: number): ColorTemperatureLabel {
   const found = SORTED_TEMPERATURE_LABELS.find((t) => temperature < t.temperatureLimit);
@@ -92,17 +94,29 @@ export function getColorTemperature(color: Color): ColorTemperatureAndLabel {
   return { temperature, label: getLabelForTemperature(temperature) };
 }
 
+export function getColorTemperatureString(color: Color, createColor: CreateColorInstance): string;
 export function getColorTemperatureString(
   color: Color,
-  options: ColorTemperatureStringFormatOptions = {},
+  options: ColorTemperatureStringFormatOptions | undefined,
+  createColor: CreateColorInstance,
+): string;
+export function getColorTemperatureString(
+  color: Color,
+  optionsOrCreateColor: ColorTemperatureStringFormatOptions | CreateColorInstance | undefined = {},
+  maybeCreateColor?: CreateColorInstance,
 ): string {
+  const createColor =
+    typeof optionsOrCreateColor === 'function'
+      ? optionsOrCreateColor
+      : (maybeCreateColor ?? defaultCreateColor());
+  const options = typeof optionsOrCreateColor === 'function' ? {} : (optionsOrCreateColor ?? {});
   const { temperature, label } = getColorTemperature(color);
   const formattedTemperature = options.formatNumber ? temperature.toLocaleString() : temperature;
 
   // Compare the given color to the reference color generated for the estimated
   // temperature. If the color is close to the Planckian locus, attach the label
   // to the formatted temperature string.
-  const reference = getColorFromTemperature(temperature).toRGB();
+  const reference = getColorFromTemperature(temperature, createColor).toRGB();
   const { r, g, b } = color.toRGB();
   const dr = r - reference.r;
   const dg = g - reference.g;
@@ -114,7 +128,10 @@ export function getColorTemperatureString(
   return `${formattedTemperature} K`;
 }
 
-export function getColorFromTemperature(temperature: number): Color {
+export function getColorFromTemperature(
+  temperature: number,
+  createColor: CreateColorInstance = defaultCreateColor(),
+): Color {
   // Clamp to the range supported by the conversion algorithm.
   const temp = clampValue(temperature, 1000, 40000) / 100;
 
@@ -147,7 +164,7 @@ export function getColorFromTemperature(temperature: number): Color {
   }
   b = clampValue(b, 0, 255);
 
-  return new Color({ r: Math.round(r), g: Math.round(g), b: Math.round(b) });
+  return createColor({ r: Math.round(r), g: Math.round(g), b: Math.round(b) });
 }
 
 export function matchPartialColorTemperatureLabel(
@@ -165,10 +182,13 @@ export function matchPartialColorTemperatureLabel(
   return matchedLabel ?? null;
 }
 
-export function getColorFromTemperatureLabel(label: CaseInsensitive<ColorTemperatureLabel>): Color {
+export function getColorFromTemperatureLabel(
+  label: CaseInsensitive<ColorTemperatureLabel>,
+  createColor: CreateColorInstance = defaultCreateColor(),
+): Color {
   const matchedLabel = matchPartialColorTemperatureLabel(label);
   if (!matchedLabel) {
     throw new Error(`Unknown color temperature label: ${label}`);
   }
-  return getColorFromTemperature(LABEL_TO_TEMPERATURE_MAP[matchedLabel]);
+  return getColorFromTemperature(LABEL_TO_TEMPERATURE_MAP[matchedLabel], createColor);
 }

--- a/src/color/utils.ts
+++ b/src/color/utils.ts
@@ -1,17 +1,20 @@
-import { type CaseInsensitive, clampValue, resolveCaseInsensitiveOption } from '../utils';
-import { Color } from './color';
+import { type CaseInsensitive, resolveCaseInsensitiveOption } from '../utils';
+import type { Color, CreateColorInstance, ValidColorInputFormat } from './color';
 import { CSS_COLOR_NAME_TO_HEX_MAP } from './color.consts';
+import { isColorInstance } from './color.helpers';
 import { toRGBA } from './conversions';
-import type { ColorFormat, ColorHex, ColorRGBA } from './formats';
-import type { ColorSwatch } from './swatch';
-
-export type ValidColorInputFormat = Color | ColorFormat | string;
+import type { ColorHex, ColorRGBA } from './formats';
 import { parseCSSColorFormatString } from './parse';
 import { getRandomColorRGBA } from './random';
+import { srgbChannelToLinear } from './srgb';
+import type { ColorSwatch } from './swatch';
 import { getColorFromTemperatureLabel, matchPartialColorTemperatureLabel } from './temperature';
 
-export function getColorRGBAFromInput(color?: ColorFormat | Color | string | null): ColorRGBA {
-  if (color instanceof Color) {
+export function getColorRGBAFromInput(
+  color: ValidColorInputFormat | null | undefined,
+  createColor: CreateColorInstance,
+): ColorRGBA {
+  if (isColorInstance(color)) {
     return color.toRGBA();
   }
 
@@ -31,11 +34,11 @@ export function getColorRGBAFromInput(color?: ColorFormat | Color | string | nul
 
     const matchedColorTemperatureLabel = matchPartialColorTemperatureLabel(colorString);
     if (matchedColorTemperatureLabel) {
-      return getColorFromTemperatureLabel(matchedColorTemperatureLabel).toRGBA();
+      return getColorFromTemperatureLabel(matchedColorTemperatureLabel, createColor).toRGBA();
     }
 
     // Other CSS color format string (e.g. "rgb(255, 0, 0)"):
-    const parsedColor = parseCSSColorFormatString(colorString);
+    const parsedColor = parseCSSColorFormatString(colorString, createColor);
     if (parsedColor) {
       return parsedColor.toRGBA();
     }
@@ -44,46 +47,6 @@ export function getColorRGBAFromInput(color?: ColorFormat | Color | string | nul
   }
 
   return color ? toRGBA(color) : getRandomColorRGBA();
-}
-
-const RGB_CHANNEL_MAX_VALUE = 255; // 8‑bit channel ceiling
-const SRGB_LINEAR_SEGMENT_DIVISOR = 12.92; // slope for low‑intensity segment
-const SRGB_GAMMA_OFFSET = 0.055; // additive term in sRGB gamma curve
-const SRGB_GAMMA_SCALE = 1.055; // multiplicative term in sRGB gamma curve
-const SRGB_GAMMA_EXPONENT = 2.4; // exponent in sRGB transfer function
-
-const SRGB_GAMMA_PIVOT_OPTIONS = {
-  SRGB: 0.04045,
-  WCAG: 0.03928,
-} as const;
-
-type SrgbGammaPivot = keyof typeof SRGB_GAMMA_PIVOT_OPTIONS;
-
-// Does a gamma correction by converting the given sRGB channel value (0 to 255)
-// to a linear RGB channel value (0 to 1).
-export function srgbChannelToLinear(srgbChannelVal: number, pivot: SrgbGammaPivot): number {
-  const c = clampValue(srgbChannelVal, 0, RGB_CHANNEL_MAX_VALUE) / RGB_CHANNEL_MAX_VALUE; // normalize
-  let result: number;
-  if (c <= SRGB_GAMMA_PIVOT_OPTIONS[pivot]) {
-    result = c / SRGB_LINEAR_SEGMENT_DIVISOR; // linear portion for dark colors
-  } else {
-    result = Math.pow((c + SRGB_GAMMA_OFFSET) / SRGB_GAMMA_SCALE, SRGB_GAMMA_EXPONENT); // gamma correction for brighter colors
-  }
-  return clampValue(result, 0, 1);
-}
-
-// Inverts `srgbChannelToLinear()`. Takes a linearized channel value (0 to 1) and returns
-// the original sRGB channel value (0 to 255).
-export function linearChannelToSrgb(linearChannelVal: number, pivot: SrgbGammaPivot): number {
-  const c = clampValue(linearChannelVal, 0, 1);
-  const threshold = SRGB_GAMMA_PIVOT_OPTIONS[pivot] / SRGB_LINEAR_SEGMENT_DIVISOR;
-  let result: number;
-  if (c > threshold) {
-    result = SRGB_GAMMA_SCALE * Math.pow(c, 1 / SRGB_GAMMA_EXPONENT) - SRGB_GAMMA_OFFSET;
-  } else {
-    result = c * SRGB_LINEAR_SEGMENT_DIVISOR;
-  }
-  return clampValue(result * RGB_CHANNEL_MAX_VALUE, 0, RGB_CHANNEL_MAX_VALUE);
 }
 
 export function getRelativeLuminance(rgb: ColorRGBA): number {
@@ -200,14 +163,15 @@ export function areColorsEqual(color1: Color, color2: Color): boolean {
   return r1 === r2 && g1 === g2 && b1 === b2 && Math.abs(a1 - a2) <= ALPHA_EPSILON;
 }
 
-function isColor(value: unknown): value is Color {
-  return value instanceof Color;
-}
-
-export function getColorList(candidates: readonly ValidColorInputFormat[] | ColorSwatch): Color[] {
+export function getColorList(
+  candidates: readonly ValidColorInputFormat[] | ColorSwatch,
+  createColor: CreateColorInstance,
+): Color[] {
   if (Array.isArray(candidates)) {
-    return candidates.map((candidate) => (isColor(candidate) ? candidate : new Color(candidate)));
+    return candidates.map((candidate) =>
+      isColorInstance(candidate) ? candidate : createColor(candidate),
+    );
   }
 
-  return Object.values(candidates).filter(isColor);
+  return Object.values(candidates).filter(isColorInstance);
 }

--- a/src/palette/__test__/palette.test.ts
+++ b/src/palette/__test__/palette.test.ts
@@ -1,4 +1,4 @@
-import { Color } from '../../color/color';
+import { Color, createColorInstance } from '../../color/color';
 import {
   generateColorPaletteFromBaseColor,
   isColorPaletteSuitable,
@@ -6,8 +6,6 @@ import {
   SUITABLE_PALETTE_MIN_LIGHTNESS,
   SUITABLE_PALETTE_MIN_SATURATION,
 } from '../palette';
-
-const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
 
 describe('isColorPaletteSuitable()', () => {
   it('returns true when saturation and lightness are within palette-suitable ranges', () => {
@@ -56,7 +54,12 @@ describe('isColorPaletteSuitable()', () => {
 describe('generateColorPaletteFromBaseColor()', () => {
   it('harmonizes neutrals with the base color', () => {
     const baseColor = new Color('#ff0000');
-    const palette = generateColorPaletteFromBaseColor(baseColor, createColor);
+    const palette = generateColorPaletteFromBaseColor(
+      baseColor,
+      undefined,
+      {},
+      createColorInstance,
+    );
 
     expect(palette.neutrals[100].toHex()).toBe('#eeeeee');
     expect(palette.neutrals[500].toHex()).toBe('#888888');
@@ -70,77 +73,147 @@ describe('generateColorPaletteFromBaseColor()', () => {
   describe('neutral harmonization across many base colors', () => {
     it('creates neutrals and tinted neutrals for a broad spectrum', () => {
       const red = new Color('#ff0000');
-      const redPalette = generateColorPaletteFromBaseColor(red, createColor);
+      const redPalette = generateColorPaletteFromBaseColor(red, undefined, {}, createColorInstance);
       expect(redPalette.neutrals[500].toHex()).toBe('#888888');
       expect(redPalette.tintedNeutrals[500].toHex()).toBe('#988380');
 
       const orange = new Color('#ffa500');
-      const orangePalette = generateColorPaletteFromBaseColor(orange, createColor);
+      const orangePalette = generateColorPaletteFromBaseColor(
+        orange,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(orangePalette.neutrals[500].toHex()).toBe('#bbbbbb');
       expect(orangePalette.tintedNeutrals[500].toHex()).toBe('#c3bab0');
 
       const yellow = new Color('#ffff00');
-      const yellowPalette = generateColorPaletteFromBaseColor(yellow, createColor);
+      const yellowPalette = generateColorPaletteFromBaseColor(
+        yellow,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(yellowPalette.neutrals[500].toHex()).toBe('#f4f4f4');
       expect(yellowPalette.tintedNeutrals[500].toHex()).toBe('#f5f6e6');
 
       const green = new Color('#00ff00');
-      const greenPalette = generateColorPaletteFromBaseColor(green, createColor);
+      const greenPalette = generateColorPaletteFromBaseColor(
+        green,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(greenPalette.neutrals[500].toHex()).toBe('#d3d3d3');
       expect(greenPalette.tintedNeutrals[500].toHex()).toBe('#c8d8c7');
 
       const cyan = new Color('#00ffff');
-      const cyanPalette = generateColorPaletteFromBaseColor(cyan, createColor);
+      const cyanPalette = generateColorPaletteFromBaseColor(
+        cyan,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(cyanPalette.neutrals[500].toHex()).toBe('#e0e0e0');
       expect(cyanPalette.tintedNeutrals[500].toHex()).toBe('#d5e3e3');
 
       const blue = new Color('#0000ff');
-      const bluePalette = generateColorPaletteFromBaseColor(blue, createColor);
+      const bluePalette = generateColorPaletteFromBaseColor(
+        blue,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(bluePalette.neutrals[500].toHex()).toBe('#565656');
       expect(bluePalette.tintedNeutrals[500].toHex()).toBe('#4d5668');
 
       const magenta = new Color('#ff00ff');
-      const magentaPalette = generateColorPaletteFromBaseColor(magenta, createColor);
+      const magentaPalette = generateColorPaletteFromBaseColor(
+        magenta,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(magentaPalette.neutrals[500].toHex()).toBe('#9f9f9f');
       expect(magentaPalette.tintedNeutrals[500].toHex()).toBe('#ab98a9');
 
       const purple = new Color('#800080');
-      const purplePalette = generateColorPaletteFromBaseColor(purple, createColor);
+      const purplePalette = generateColorPaletteFromBaseColor(
+        purple,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(purplePalette.neutrals[500].toHex()).toBe('#4d4d4d');
       expect(purplePalette.tintedNeutrals[500].toHex()).toBe('#534a53');
 
       const teal = new Color('#008080');
-      const tealPalette = generateColorPaletteFromBaseColor(teal, createColor);
+      const tealPalette = generateColorPaletteFromBaseColor(
+        teal,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(tealPalette.neutrals[500].toHex()).toBe('#6f6f6f');
       expect(tealPalette.tintedNeutrals[500].toHex()).toBe('#6a7171');
 
       const olive = new Color('#808000');
-      const olivePalette = generateColorPaletteFromBaseColor(olive, createColor);
+      const olivePalette = generateColorPaletteFromBaseColor(
+        olive,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(olivePalette.neutrals[500].toHex()).toBe('#7a7a7a');
       expect(olivePalette.tintedNeutrals[500].toHex()).toBe('#7b7b73');
 
       const hotpink = new Color('#ff69b4');
-      const hotpinkPalette = generateColorPaletteFromBaseColor(hotpink, createColor);
+      const hotpinkPalette = generateColorPaletteFromBaseColor(
+        hotpink,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(hotpinkPalette.neutrals[500].toHex()).toBe('#a7a7a7');
       expect(hotpinkPalette.tintedNeutrals[500].toHex()).toBe('#b2a2a8');
 
       const maroon = new Color('#800000');
-      const maroonPalette = generateColorPaletteFromBaseColor(maroon, createColor);
+      const maroonPalette = generateColorPaletteFromBaseColor(
+        maroon,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(maroonPalette.neutrals[500].toHex()).toBe('#414141');
       expect(maroonPalette.tintedNeutrals[500].toHex()).toBe('#493f3d');
 
       const gray = new Color('#808080');
-      const grayPalette = generateColorPaletteFromBaseColor(gray, createColor);
+      const grayPalette = generateColorPaletteFromBaseColor(
+        gray,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(grayPalette.neutrals[500].toHex()).toBe('#808080');
       expect(grayPalette.tintedNeutrals[500].toHex()).toBe('#808080');
 
       const black = new Color('#000000');
-      const blackPalette = generateColorPaletteFromBaseColor(black, createColor);
+      const blackPalette = generateColorPaletteFromBaseColor(
+        black,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(blackPalette.neutrals[500].toHex()).toBe('#000000');
       expect(blackPalette.tintedNeutrals[500].toHex()).toBe('#000000');
 
       const white = new Color('#ffffff');
-      const whitePalette = generateColorPaletteFromBaseColor(white, createColor);
+      const whitePalette = generateColorPaletteFromBaseColor(
+        white,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(whitePalette.neutrals[500].toHex()).toBe('#ffffff');
       expect(whitePalette.tintedNeutrals[500].toHex()).toBe('#ffffff');
     });
@@ -158,7 +231,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             maxTintChroma: -0.5,
           },
         },
-        createColor,
+        createColorInstance,
       );
       expect(palette.tintedNeutrals[500].toHex()).toBe('#d3d3d3');
     });
@@ -174,7 +247,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             maxTintChroma: 0.02,
           },
         },
-        createColor,
+        createColorInstance,
       );
       expect(palette.tintedNeutrals[500].toHex()).toBe('#d1e4e4');
     });
@@ -189,7 +262,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
         {
           swatchOptions: { extended: true, centerOn500: false },
         },
-        createColor,
+        createColorInstance,
       );
 
       const expected = baseColor.getColorSwatch({ extended: true, centerOn500: false });
@@ -204,7 +277,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('centers palette swatches on 500 by default', () => {
       const baseColor = new Color('#222222');
-      const palette = generateColorPaletteFromBaseColor(baseColor, createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        baseColor,
+        undefined,
+        {},
+        createColorInstance,
+      );
 
       expect(palette.primary.mainStop).toBe(500);
     });
@@ -212,7 +290,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
   describe('neutral harmonization across the full swatch', () => {
     it('produces a complete range for red', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(palette.neutrals[100].toHex()).toBe('#eeeeee');
       expect(palette.neutrals[300].toHex()).toBe('#bbbbbb');
       expect(palette.neutrals[700].toHex()).toBe('#555555');
@@ -224,7 +307,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('produces a complete range for blue', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#0000ff'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#0000ff'),
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(palette.neutrals[100].toHex()).toBe('#bcbcbc');
       expect(palette.neutrals[300].toHex()).toBe('#898989');
       expect(palette.neutrals[700].toHex()).toBe('#232323');
@@ -236,7 +324,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('produces a complete range for green', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#00ff00'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#00ff00'),
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(palette.neutrals[100].toHex()).toBe('#ffffff');
       expect(palette.neutrals[300].toHex()).toBe('#ffffff');
       expect(palette.neutrals[700].toHex()).toBe('#a0a0a0');
@@ -248,13 +341,23 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('keeps tinted neutrals identical for achromatic bases', () => {
-      const white = generateColorPaletteFromBaseColor(new Color('#ffffff'), createColor);
+      const white = generateColorPaletteFromBaseColor(
+        new Color('#ffffff'),
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(white.neutrals[100].toHex()).toBe('#ffffff');
       expect(white.tintedNeutrals[100].toHex()).toBe('#ffffff');
       expect(white.neutrals[900].toHex()).toBe('#999999');
       expect(white.tintedNeutrals[900].toHex()).toBe('#999999');
 
-      const black = generateColorPaletteFromBaseColor(new Color('#000000'), createColor);
+      const black = generateColorPaletteFromBaseColor(
+        new Color('#000000'),
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(black.neutrals[100].toHex()).toBe('#666666');
       expect(black.tintedNeutrals[100].toHex()).toBe('#666666');
       expect(black.neutrals[900].toHex()).toBe('#000000');
@@ -273,7 +376,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             maxTintChroma: 0.5,
           },
         },
-        createColor,
+        createColorInstance,
       );
       expect(palette.tintedNeutrals[100].toHex()).toBe('#ffccff');
       expect(palette.tintedNeutrals[500].toHex()).toBe('#ff00ff');
@@ -290,7 +393,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             maxTintChroma: 0,
           },
         },
-        createColor,
+        createColorInstance,
       );
       expect(palette.neutrals[100].toHex()).toBe('#999999');
       expect(palette.tintedNeutrals[100].toHex()).toBe('#999999');
@@ -312,7 +415,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
               maxTintChroma: NaN,
             },
           },
-          createColor,
+          createColorInstance,
         ),
       ).toThrow();
     });
@@ -320,7 +423,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
   describe('semantic harmonization options', () => {
     it('produces semantic swatches with stable hex values for a red base', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(palette.info[300].toHex()).toBe('#d3d3ff');
       expect(palette.positive[700].toHex()).toBe('#073e03');
       expect(palette.negative[500].toHex()).toBe('#fc0940');
@@ -339,7 +447,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.02, 0.25],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const fullPull = generateColorPaletteFromBaseColor(
         base,
@@ -350,7 +458,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.02, 0.25],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const noPullHue = noPull.info[500].toOKLCH().h;
       expect(noPullHue).toBeGreaterThan(263);
@@ -371,7 +479,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.02, 0.25],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const over = generateColorPaletteFromBaseColor(
         base,
@@ -382,7 +490,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.02, 0.25],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const underHue = under.info[500].toOKLCH().h;
       expect(underHue).toBeGreaterThan(263);
@@ -394,7 +502,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('uses default hues for low chroma base colors', () => {
       const gray = new Color('#808080');
-      const palette = generateColorPaletteFromBaseColor(gray, createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        gray,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       const infoHue = palette.info[500].toOKLCH().h;
       const positiveHue = palette.positive[500].toOKLCH().h;
       expect(infoHue).toBeGreaterThan(263);
@@ -416,7 +529,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.1, 0.12],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeGreaterThanOrEqual(0.1);
@@ -435,7 +548,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [-1, 0],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeCloseTo(0.04, 3);
@@ -444,10 +557,20 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('generates semantic colors for white and black bases', () => {
       const white = new Color('#ffffff');
-      const whitePalette = generateColorPaletteFromBaseColor(white, createColor);
+      const whitePalette = generateColorPaletteFromBaseColor(
+        white,
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(whitePalette.info[500].toHex()).not.toBe('#ffffff');
       const black = new Color('#000000');
-      const blackPalette = generateColorPaletteFromBaseColor(black, createColor);
+      const blackPalette = generateColorPaletteFromBaseColor(
+        black,
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(blackPalette.info[500].toHex()).not.toBe('#000000');
     });
 
@@ -461,7 +584,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [0.3, 0.1],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeGreaterThan(0.29);
@@ -478,7 +601,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
             chromaRange: [-0.5, -0.1],
           },
         },
-        createColor,
+        createColorInstance,
       );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeCloseTo(0.0395, 3);
@@ -494,13 +617,18 @@ describe('generateColorPaletteFromBaseColor()', () => {
           {
             semanticHarmonization: { huePull: NaN, chromaRange: [NaN, NaN] },
           },
-          createColor,
+          createColorInstance,
         ),
       ).toThrow();
     });
 
     it('creates positive and negative swatches across the spectrum', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        undefined,
+        undefined,
+        createColorInstance,
+      );
       expect(palette.positive[100].toHex()).toBe('#7dff74');
       expect(palette.positive[500].toHex()).toBe('#0ba700');
       expect(palette.positive[700].toHex()).toBe('#073e03');
@@ -510,7 +638,12 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('provides full semantic colors for grayscale bases', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#808080'), createColor);
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#808080'),
+        undefined,
+        {},
+        createColorInstance,
+      );
       expect(palette.info[500].toHex()).toBe('#758099');
       expect(palette.positive[500].toHex()).toBe('#6b8971');
       expect(palette.negative[500].toHex()).toBe('#a17271');
@@ -524,7 +657,8 @@ describe('generateColorPaletteFromBaseColor()', () => {
       const palette = generateColorPaletteFromBaseColor(
         new Color('#ff0000'),
         'COMPLEMENTARY',
-        createColor,
+        undefined,
+        createColorInstance,
       );
       expect(palette.secondaryColors.length).toBe(1);
       expect(palette.primary[100].toHex()).toBe('#ffcccc');
@@ -538,7 +672,8 @@ describe('generateColorPaletteFromBaseColor()', () => {
       const palette = generateColorPaletteFromBaseColor(
         new Color('#ff0000'),
         'TRIADIC',
-        createColor,
+        {},
+        createColorInstance,
       );
       expect(palette.secondaryColors.length).toBe(2);
       expect(palette.primary[500].toHex()).toBe('#ff0000');
@@ -552,7 +687,8 @@ describe('generateColorPaletteFromBaseColor()', () => {
       const analogous = generateColorPaletteFromBaseColor(
         new Color('#336699'),
         'ANALOGOUS',
-        createColor,
+        undefined,
+        createColorInstance,
       );
       expect(analogous.secondaryColors.length).toBe(4);
       expect(analogous.secondaryColors[0][500].toHex()).toBe('#339999');
@@ -561,7 +697,8 @@ describe('generateColorPaletteFromBaseColor()', () => {
       const monochromatic = generateColorPaletteFromBaseColor(
         new Color('#336699'),
         'MONOCHROMATIC',
-        createColor,
+        {},
+        createColorInstance,
       );
       expect(monochromatic.secondaryColors.length).toBe(4);
       expect(monochromatic.secondaryColors[0][500].toHex()).toBe('#6699cc');

--- a/src/palette/__test__/palette.test.ts
+++ b/src/palette/__test__/palette.test.ts
@@ -7,6 +7,8 @@ import {
   SUITABLE_PALETTE_MIN_SATURATION,
 } from '../palette';
 
+const createColor = (input: ConstructorParameters<typeof Color>[0]) => new Color(input);
+
 describe('isColorPaletteSuitable()', () => {
   it('returns true when saturation and lightness are within palette-suitable ranges', () => {
     expect(
@@ -54,7 +56,7 @@ describe('isColorPaletteSuitable()', () => {
 describe('generateColorPaletteFromBaseColor()', () => {
   it('harmonizes neutrals with the base color', () => {
     const baseColor = new Color('#ff0000');
-    const palette = generateColorPaletteFromBaseColor(baseColor);
+    const palette = generateColorPaletteFromBaseColor(baseColor, createColor);
 
     expect(palette.neutrals[100].toHex()).toBe('#eeeeee');
     expect(palette.neutrals[500].toHex()).toBe('#888888');
@@ -68,77 +70,77 @@ describe('generateColorPaletteFromBaseColor()', () => {
   describe('neutral harmonization across many base colors', () => {
     it('creates neutrals and tinted neutrals for a broad spectrum', () => {
       const red = new Color('#ff0000');
-      const redPalette = generateColorPaletteFromBaseColor(red);
+      const redPalette = generateColorPaletteFromBaseColor(red, createColor);
       expect(redPalette.neutrals[500].toHex()).toBe('#888888');
       expect(redPalette.tintedNeutrals[500].toHex()).toBe('#988380');
 
       const orange = new Color('#ffa500');
-      const orangePalette = generateColorPaletteFromBaseColor(orange);
+      const orangePalette = generateColorPaletteFromBaseColor(orange, createColor);
       expect(orangePalette.neutrals[500].toHex()).toBe('#bbbbbb');
       expect(orangePalette.tintedNeutrals[500].toHex()).toBe('#c3bab0');
 
       const yellow = new Color('#ffff00');
-      const yellowPalette = generateColorPaletteFromBaseColor(yellow);
+      const yellowPalette = generateColorPaletteFromBaseColor(yellow, createColor);
       expect(yellowPalette.neutrals[500].toHex()).toBe('#f4f4f4');
       expect(yellowPalette.tintedNeutrals[500].toHex()).toBe('#f5f6e6');
 
       const green = new Color('#00ff00');
-      const greenPalette = generateColorPaletteFromBaseColor(green);
+      const greenPalette = generateColorPaletteFromBaseColor(green, createColor);
       expect(greenPalette.neutrals[500].toHex()).toBe('#d3d3d3');
       expect(greenPalette.tintedNeutrals[500].toHex()).toBe('#c8d8c7');
 
       const cyan = new Color('#00ffff');
-      const cyanPalette = generateColorPaletteFromBaseColor(cyan);
+      const cyanPalette = generateColorPaletteFromBaseColor(cyan, createColor);
       expect(cyanPalette.neutrals[500].toHex()).toBe('#e0e0e0');
       expect(cyanPalette.tintedNeutrals[500].toHex()).toBe('#d5e3e3');
 
       const blue = new Color('#0000ff');
-      const bluePalette = generateColorPaletteFromBaseColor(blue);
+      const bluePalette = generateColorPaletteFromBaseColor(blue, createColor);
       expect(bluePalette.neutrals[500].toHex()).toBe('#565656');
       expect(bluePalette.tintedNeutrals[500].toHex()).toBe('#4d5668');
 
       const magenta = new Color('#ff00ff');
-      const magentaPalette = generateColorPaletteFromBaseColor(magenta);
+      const magentaPalette = generateColorPaletteFromBaseColor(magenta, createColor);
       expect(magentaPalette.neutrals[500].toHex()).toBe('#9f9f9f');
       expect(magentaPalette.tintedNeutrals[500].toHex()).toBe('#ab98a9');
 
       const purple = new Color('#800080');
-      const purplePalette = generateColorPaletteFromBaseColor(purple);
+      const purplePalette = generateColorPaletteFromBaseColor(purple, createColor);
       expect(purplePalette.neutrals[500].toHex()).toBe('#4d4d4d');
       expect(purplePalette.tintedNeutrals[500].toHex()).toBe('#534a53');
 
       const teal = new Color('#008080');
-      const tealPalette = generateColorPaletteFromBaseColor(teal);
+      const tealPalette = generateColorPaletteFromBaseColor(teal, createColor);
       expect(tealPalette.neutrals[500].toHex()).toBe('#6f6f6f');
       expect(tealPalette.tintedNeutrals[500].toHex()).toBe('#6a7171');
 
       const olive = new Color('#808000');
-      const olivePalette = generateColorPaletteFromBaseColor(olive);
+      const olivePalette = generateColorPaletteFromBaseColor(olive, createColor);
       expect(olivePalette.neutrals[500].toHex()).toBe('#7a7a7a');
       expect(olivePalette.tintedNeutrals[500].toHex()).toBe('#7b7b73');
 
       const hotpink = new Color('#ff69b4');
-      const hotpinkPalette = generateColorPaletteFromBaseColor(hotpink);
+      const hotpinkPalette = generateColorPaletteFromBaseColor(hotpink, createColor);
       expect(hotpinkPalette.neutrals[500].toHex()).toBe('#a7a7a7');
       expect(hotpinkPalette.tintedNeutrals[500].toHex()).toBe('#b2a2a8');
 
       const maroon = new Color('#800000');
-      const maroonPalette = generateColorPaletteFromBaseColor(maroon);
+      const maroonPalette = generateColorPaletteFromBaseColor(maroon, createColor);
       expect(maroonPalette.neutrals[500].toHex()).toBe('#414141');
       expect(maroonPalette.tintedNeutrals[500].toHex()).toBe('#493f3d');
 
       const gray = new Color('#808080');
-      const grayPalette = generateColorPaletteFromBaseColor(gray);
+      const grayPalette = generateColorPaletteFromBaseColor(gray, createColor);
       expect(grayPalette.neutrals[500].toHex()).toBe('#808080');
       expect(grayPalette.tintedNeutrals[500].toHex()).toBe('#808080');
 
       const black = new Color('#000000');
-      const blackPalette = generateColorPaletteFromBaseColor(black);
+      const blackPalette = generateColorPaletteFromBaseColor(black, createColor);
       expect(blackPalette.neutrals[500].toHex()).toBe('#000000');
       expect(blackPalette.tintedNeutrals[500].toHex()).toBe('#000000');
 
       const white = new Color('#ffffff');
-      const whitePalette = generateColorPaletteFromBaseColor(white);
+      const whitePalette = generateColorPaletteFromBaseColor(white, createColor);
       expect(whitePalette.neutrals[500].toHex()).toBe('#ffffff');
       expect(whitePalette.tintedNeutrals[500].toHex()).toBe('#ffffff');
     });
@@ -147,23 +149,33 @@ describe('generateColorPaletteFromBaseColor()', () => {
   describe('neutral harmonization options', () => {
     it('clamps tint chroma factor and maximum chroma', () => {
       const base = new Color('#00ff00');
-      const palette = generateColorPaletteFromBaseColor(base, undefined, {
-        neutralHarmonization: {
-          tintChromaFactor: -1,
-          maxTintChroma: -0.5,
+      const palette = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          neutralHarmonization: {
+            tintChromaFactor: -1,
+            maxTintChroma: -0.5,
+          },
         },
-      });
+        createColor,
+      );
       expect(palette.tintedNeutrals[500].toHex()).toBe('#d3d3d3');
     });
 
     it('respects tint chroma factor and maximum', () => {
       const base = new Color('#00ffff');
-      const palette = generateColorPaletteFromBaseColor(base, undefined, {
-        neutralHarmonization: {
-          tintChromaFactor: 1,
-          maxTintChroma: 0.02,
+      const palette = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          neutralHarmonization: {
+            tintChromaFactor: 1,
+            maxTintChroma: 0.02,
+          },
         },
-      });
+        createColor,
+      );
       expect(palette.tintedNeutrals[500].toHex()).toBe('#d1e4e4');
     });
   });
@@ -171,9 +183,14 @@ describe('generateColorPaletteFromBaseColor()', () => {
   describe('swatch options', () => {
     it('forwards swatch options to palette swatches', () => {
       const baseColor = new Color('#111111');
-      const palette = generateColorPaletteFromBaseColor(baseColor, 'COMPLEMENTARY', {
-        swatchOptions: { extended: true, centerOn500: false },
-      });
+      const palette = generateColorPaletteFromBaseColor(
+        baseColor,
+        'COMPLEMENTARY',
+        {
+          swatchOptions: { extended: true, centerOn500: false },
+        },
+        createColor,
+      );
 
       const expected = baseColor.getColorSwatch({ extended: true, centerOn500: false });
 
@@ -187,7 +204,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('centers palette swatches on 500 by default', () => {
       const baseColor = new Color('#222222');
-      const palette = generateColorPaletteFromBaseColor(baseColor);
+      const palette = generateColorPaletteFromBaseColor(baseColor, createColor);
 
       expect(palette.primary.mainStop).toBe(500);
     });
@@ -195,7 +212,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
   describe('neutral harmonization across the full swatch', () => {
     it('produces a complete range for red', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
       expect(palette.neutrals[100].toHex()).toBe('#eeeeee');
       expect(palette.neutrals[300].toHex()).toBe('#bbbbbb');
       expect(palette.neutrals[700].toHex()).toBe('#555555');
@@ -207,7 +224,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('produces a complete range for blue', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#0000ff'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#0000ff'), createColor);
       expect(palette.neutrals[100].toHex()).toBe('#bcbcbc');
       expect(palette.neutrals[300].toHex()).toBe('#898989');
       expect(palette.neutrals[700].toHex()).toBe('#232323');
@@ -219,7 +236,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('produces a complete range for green', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#00ff00'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#00ff00'), createColor);
       expect(palette.neutrals[100].toHex()).toBe('#ffffff');
       expect(palette.neutrals[300].toHex()).toBe('#ffffff');
       expect(palette.neutrals[700].toHex()).toBe('#a0a0a0');
@@ -231,13 +248,13 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('keeps tinted neutrals identical for achromatic bases', () => {
-      const white = generateColorPaletteFromBaseColor(new Color('#ffffff'));
+      const white = generateColorPaletteFromBaseColor(new Color('#ffffff'), createColor);
       expect(white.neutrals[100].toHex()).toBe('#ffffff');
       expect(white.tintedNeutrals[100].toHex()).toBe('#ffffff');
       expect(white.neutrals[900].toHex()).toBe('#999999');
       expect(white.tintedNeutrals[900].toHex()).toBe('#999999');
 
-      const black = generateColorPaletteFromBaseColor(new Color('#000000'));
+      const black = generateColorPaletteFromBaseColor(new Color('#000000'), createColor);
       expect(black.neutrals[100].toHex()).toBe('#666666');
       expect(black.tintedNeutrals[100].toHex()).toBe('#666666');
       expect(black.neutrals[900].toHex()).toBe('#000000');
@@ -247,24 +264,34 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
   describe('neutral harmonization edge cases', () => {
     it('clamps excessive tint chroma factor and honors maxTintChroma', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff00ff'), undefined, {
-        neutralHarmonization: {
-          tintChromaFactor: 2,
-          maxTintChroma: 0.5,
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff00ff'),
+        undefined,
+        {
+          neutralHarmonization: {
+            tintChromaFactor: 2,
+            maxTintChroma: 0.5,
+          },
         },
-      });
+        createColor,
+      );
       expect(palette.tintedNeutrals[100].toHex()).toBe('#ffccff');
       expect(palette.tintedNeutrals[500].toHex()).toBe('#ff00ff');
       expect(palette.tintedNeutrals[900].toHex()).toBe('#2e052e');
     });
 
     it('falls back to neutral swatches when maxTintChroma is zero', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#123456'), undefined, {
-        neutralHarmonization: {
-          tintChromaFactor: 0.5,
-          maxTintChroma: 0,
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#123456'),
+        undefined,
+        {
+          neutralHarmonization: {
+            tintChromaFactor: 0.5,
+            maxTintChroma: 0,
+          },
         },
-      });
+        createColor,
+      );
       expect(palette.neutrals[100].toHex()).toBe('#999999');
       expect(palette.tintedNeutrals[100].toHex()).toBe('#999999');
       expect(palette.neutrals[500].toHex()).toBe('#333333');
@@ -276,19 +303,24 @@ describe('generateColorPaletteFromBaseColor()', () => {
     it('throws for NaN neutral harmonization options', () => {
       const base = new Color('#00ff00');
       expect(() =>
-        generateColorPaletteFromBaseColor(base, undefined, {
-          neutralHarmonization: {
-            tintChromaFactor: NaN,
-            maxTintChroma: NaN,
+        generateColorPaletteFromBaseColor(
+          base,
+          undefined,
+          {
+            neutralHarmonization: {
+              tintChromaFactor: NaN,
+              maxTintChroma: NaN,
+            },
           },
-        }),
+          createColor,
+        ),
       ).toThrow();
     });
   });
 
   describe('semantic harmonization options', () => {
     it('produces semantic swatches with stable hex values for a red base', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
       expect(palette.info[300].toHex()).toBe('#d3d3ff');
       expect(palette.positive[700].toHex()).toBe('#073e03');
       expect(palette.negative[500].toHex()).toBe('#fc0940');
@@ -298,18 +330,28 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('pulls semantic hues toward the base color', () => {
       const base = new Color('#ff0000');
-      const noPull = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: 0,
-          chromaRange: [0.02, 0.25],
+      const noPull = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 0,
+            chromaRange: [0.02, 0.25],
+          },
         },
-      });
-      const fullPull = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: 1,
-          chromaRange: [0.02, 0.25],
+        createColor,
+      );
+      const fullPull = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 1,
+            chromaRange: [0.02, 0.25],
+          },
         },
-      });
+        createColor,
+      );
       const noPullHue = noPull.info[500].toOKLCH().h;
       expect(noPullHue).toBeGreaterThan(263);
       expect(noPullHue).toBeLessThan(267);
@@ -320,18 +362,28 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('clamps hue pull outside of the 0–1 range', () => {
       const base = new Color('#ff0000');
-      const under = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: -1,
-          chromaRange: [0.02, 0.25],
+      const under = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: -1,
+            chromaRange: [0.02, 0.25],
+          },
         },
-      });
-      const over = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: 2,
-          chromaRange: [0.02, 0.25],
+        createColor,
+      );
+      const over = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 2,
+            chromaRange: [0.02, 0.25],
+          },
         },
-      });
+        createColor,
+      );
       const underHue = under.info[500].toOKLCH().h;
       expect(underHue).toBeGreaterThan(263);
       expect(underHue).toBeLessThan(267);
@@ -342,7 +394,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('uses default hues for low chroma base colors', () => {
       const gray = new Color('#808080');
-      const palette = generateColorPaletteFromBaseColor(gray);
+      const palette = generateColorPaletteFromBaseColor(gray, createColor);
       const infoHue = palette.info[500].toOKLCH().h;
       const positiveHue = palette.positive[500].toOKLCH().h;
       expect(infoHue).toBeGreaterThan(263);
@@ -355,12 +407,17 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('keeps semantic chroma within the provided range', () => {
       const base = new Color('#0000ff');
-      const palette = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: 0.5,
-          chromaRange: [0.1, 0.12],
+      const palette = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 0.5,
+            chromaRange: [0.1, 0.12],
+          },
         },
-      });
+        createColor,
+      );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeGreaterThanOrEqual(0.1);
       expect(c).toBeLessThanOrEqual(0.121);
@@ -369,12 +426,17 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('enforces minimum allowable chroma even when max is low', () => {
       const base = new Color('#ff0000');
-      const palette = generateColorPaletteFromBaseColor(base, undefined, {
-        semanticHarmonization: {
-          huePull: 0.2,
-          chromaRange: [-1, 0],
+      const palette = generateColorPaletteFromBaseColor(
+        base,
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 0.2,
+            chromaRange: [-1, 0],
+          },
         },
-      });
+        createColor,
+      );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeCloseTo(0.04, 3);
       expect(palette.info[500].toHex()).toBe('#8885a0');
@@ -382,20 +444,25 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
     it('generates semantic colors for white and black bases', () => {
       const white = new Color('#ffffff');
-      const whitePalette = generateColorPaletteFromBaseColor(white);
+      const whitePalette = generateColorPaletteFromBaseColor(white, createColor);
       expect(whitePalette.info[500].toHex()).not.toBe('#ffffff');
       const black = new Color('#000000');
-      const blackPalette = generateColorPaletteFromBaseColor(black);
+      const blackPalette = generateColorPaletteFromBaseColor(black, createColor);
       expect(blackPalette.info[500].toHex()).not.toBe('#000000');
     });
 
     it('handles reversed chroma ranges by clamping to the higher bound', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), undefined, {
-        semanticHarmonization: {
-          huePull: 0.5,
-          chromaRange: [0.3, 0.1],
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        undefined,
+        {
+          semanticHarmonization: {
+            huePull: 0.5,
+            chromaRange: [0.3, 0.1],
+          },
         },
-      });
+        createColor,
+      );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeGreaterThan(0.29);
       expect(c).toBeLessThan(0.3);
@@ -403,11 +470,16 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('clamps negative chroma ranges to the minimum allowable', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), undefined, {
-        semanticHarmonization: {
-          chromaRange: [-0.5, -0.1],
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        undefined,
+        {
+          semanticHarmonization: {
+            chromaRange: [-0.5, -0.1],
+          },
         },
-      });
+        createColor,
+      );
       const c = palette.info[500].toOKLCH().c;
       expect(c).toBeCloseTo(0.0395, 3);
       expect(palette.info[500].toHex()).toBe('#8287a1');
@@ -416,14 +488,19 @@ describe('generateColorPaletteFromBaseColor()', () => {
     it('throws for NaN semantic harmonization options', () => {
       const base = new Color('#ff0000');
       expect(() =>
-        generateColorPaletteFromBaseColor(base, undefined, {
-          semanticHarmonization: { huePull: NaN, chromaRange: [NaN, NaN] },
-        }),
+        generateColorPaletteFromBaseColor(
+          base,
+          undefined,
+          {
+            semanticHarmonization: { huePull: NaN, chromaRange: [NaN, NaN] },
+          },
+          createColor,
+        ),
       ).toThrow();
     });
 
     it('creates positive and negative swatches across the spectrum', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), createColor);
       expect(palette.positive[100].toHex()).toBe('#7dff74');
       expect(palette.positive[500].toHex()).toBe('#0ba700');
       expect(palette.positive[700].toHex()).toBe('#073e03');
@@ -433,7 +510,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('provides full semantic colors for grayscale bases', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#808080'));
+      const palette = generateColorPaletteFromBaseColor(new Color('#808080'), createColor);
       expect(palette.info[500].toHex()).toBe('#758099');
       expect(palette.positive[500].toHex()).toBe('#6b8971');
       expect(palette.negative[500].toHex()).toBe('#a17271');
@@ -444,7 +521,11 @@ describe('generateColorPaletteFromBaseColor()', () => {
 
   describe('color harmony generation', () => {
     it('creates complementary swatches with proper secondary colors', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), 'COMPLEMENTARY');
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        'COMPLEMENTARY',
+        createColor,
+      );
       expect(palette.secondaryColors.length).toBe(1);
       expect(palette.primary[100].toHex()).toBe('#ffcccc');
       expect(palette.primary[900].toHex()).toBe('#2e0505');
@@ -454,7 +535,11 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('creates a full triadic harmony', () => {
-      const palette = generateColorPaletteFromBaseColor(new Color('#ff0000'), 'TRIADIC');
+      const palette = generateColorPaletteFromBaseColor(
+        new Color('#ff0000'),
+        'TRIADIC',
+        createColor,
+      );
       expect(palette.secondaryColors.length).toBe(2);
       expect(palette.primary[500].toHex()).toBe('#ff0000');
       expect(palette.secondaryColors[0][500].toHex()).toBe('#0000ff');
@@ -464,7 +549,11 @@ describe('generateColorPaletteFromBaseColor()', () => {
     });
 
     it('produces the expected number of secondary colors for other harmonies', () => {
-      const analogous = generateColorPaletteFromBaseColor(new Color('#336699'), 'ANALOGOUS');
+      const analogous = generateColorPaletteFromBaseColor(
+        new Color('#336699'),
+        'ANALOGOUS',
+        createColor,
+      );
       expect(analogous.secondaryColors.length).toBe(4);
       expect(analogous.secondaryColors[0][500].toHex()).toBe('#339999');
       expect(analogous.secondaryColors[3][500].toHex()).toBe('#663399');
@@ -472,6 +561,7 @@ describe('generateColorPaletteFromBaseColor()', () => {
       const monochromatic = generateColorPaletteFromBaseColor(
         new Color('#336699'),
         'MONOCHROMATIC',
+        createColor,
       );
       expect(monochromatic.secondaryColors.length).toBe(4);
       expect(monochromatic.secondaryColors[0][500].toHex()).toBe('#6699cc');

--- a/src/palette/palette.ts
+++ b/src/palette/palette.ts
@@ -1,6 +1,5 @@
 import type { Color, CreateColorInstance } from '../color/color';
 import { BLACK_HEX, WHITE_HEX } from '../color/color.consts';
-import { getColorInstanceFactory } from '../color/color.helpers';
 import { type ColorHarmony } from '../color/harmonies';
 import type { ColorSwatch, ColorSwatchOptions } from '../color/swatch';
 import { type CaseInsensitive, clampValue } from '../utils';
@@ -72,7 +71,6 @@ const DEFAULT_NEUTRAL_COLOR_HARMONIZATION_OPTIONS: Required<NeutralColorHarmoniz
   tintChromaFactor: 0.1,
   maxTintChroma: 0.04,
 };
-const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 /**
  * Determine if a color meets the same "palette suitable" constraints used by `Color.random({ paletteSuitable: true })`:
@@ -165,39 +163,10 @@ function harmonizeSemanticColor(
 
 export function generateColorPaletteFromBaseColor(
   baseColor: Color,
-  createColor: CreateColorInstance,
-): ColorPalette;
-export function generateColorPaletteFromBaseColor(
-  baseColor: Color,
-  harmony: CaseInsensitive<ColorHarmony>,
-  createColor: CreateColorInstance,
-): ColorPalette;
-export function generateColorPaletteFromBaseColor(
-  baseColor: Color,
-  harmony: CaseInsensitive<ColorHarmony> | undefined,
+  harmony: CaseInsensitive<ColorHarmony> = 'COMPLEMENTARY',
   options: GenerateColorPaletteOptions | undefined,
   createColor: CreateColorInstance,
-): ColorPalette;
-export function generateColorPaletteFromBaseColor(
-  baseColor: Color,
-  harmonyOrCreateColor: CaseInsensitive<ColorHarmony> | CreateColorInstance = 'COMPLEMENTARY',
-  optionsOrCreateColor?: GenerateColorPaletteOptions | CreateColorInstance,
-  maybeCreateColor?: CreateColorInstance,
 ): ColorPalette {
-  const harmony =
-    typeof harmonyOrCreateColor === 'function' ? 'COMPLEMENTARY' : harmonyOrCreateColor;
-  let createColor: CreateColorInstance;
-  let options: GenerateColorPaletteOptions | undefined;
-
-  if (typeof harmonyOrCreateColor === 'function') {
-    createColor = harmonyOrCreateColor;
-  } else if (typeof optionsOrCreateColor === 'function') {
-    createColor = optionsOrCreateColor;
-  } else {
-    createColor = maybeCreateColor ?? defaultCreateColor();
-    options = optionsOrCreateColor;
-  }
-
   // TODO: helpers or warnings if the palette is suboptimal
 
   const neutralHarmonizationOptions = {

--- a/src/palette/palette.ts
+++ b/src/palette/palette.ts
@@ -1,5 +1,6 @@
-import { Color } from '../color/color';
+import type { Color, CreateColorInstance } from '../color/color';
 import { BLACK_HEX, WHITE_HEX } from '../color/color.consts';
+import { getColorInstanceFactory } from '../color/color.helpers';
 import { type ColorHarmony } from '../color/harmonies';
 import type { ColorSwatch, ColorSwatchOptions } from '../color/swatch';
 import { type CaseInsensitive, clampValue } from '../utils';
@@ -71,6 +72,7 @@ const DEFAULT_NEUTRAL_COLOR_HARMONIZATION_OPTIONS: Required<NeutralColorHarmoniz
   tintChromaFactor: 0.1,
   maxTintChroma: 0.04,
 };
+const defaultCreateColor = (): CreateColorInstance => getColorInstanceFactory();
 
 /**
  * Determine if a color meets the same "palette suitable" constraints used by `Color.random({ paletteSuitable: true })`:
@@ -92,20 +94,21 @@ export interface GenerateColorPaletteOptions {
   swatchOptions?: ColorSwatchOptions;
 }
 
-function harmonizeNeutrals(paletteBaseColor: Color): Color {
+function harmonizeNeutrals(paletteBaseColor: Color, createColor: CreateColorInstance): Color {
   const { l: baseL, h: baseH } = paletteBaseColor.toOKLCH();
-  return new Color({ l: baseL, c: 0, h: baseH });
+  return createColor({ l: baseL, c: 0, h: baseH });
 }
 
 function harmonizeTintedNeutrals(
   paletteBaseColor: Color,
   options: Required<NeutralColorHarmonizationOptions>,
+  createColor: CreateColorInstance,
 ): Color {
   const { l: baseL, c: baseC, h: baseH } = paletteBaseColor.toOKLCH();
   const chromaFactor = clampValue(options.tintChromaFactor, 0, 1);
   const maxChroma = Math.max(options.maxTintChroma, 0);
   const resultChroma = clampValue(baseC * chromaFactor, 0, maxChroma);
-  return new Color({ l: baseL, c: resultChroma, h: baseH });
+  return createColor({ l: baseL, c: resultChroma, h: baseH });
 }
 
 /**
@@ -132,6 +135,7 @@ function harmonizeSemanticColor(
   paletteBaseColor: Color,
   semanticColor: SemanticColor,
   options: Required<SemanticColorHarmonizationOptions>,
+  createColor: CreateColorInstance,
 ): Color {
   // Constrain hue pull option to its valid range:
   const huePullOption = clampValue(options.huePull, 0, 1);
@@ -156,14 +160,44 @@ function harmonizeSemanticColor(
     maxChromaOption,
   );
 
-  return new Color({ l: baseL, c: resultChroma, h: resultHue });
+  return createColor({ l: baseL, c: resultChroma, h: resultHue });
 }
 
 export function generateColorPaletteFromBaseColor(
   baseColor: Color,
-  harmony: CaseInsensitive<ColorHarmony> = 'COMPLEMENTARY',
-  options?: GenerateColorPaletteOptions,
+  createColor: CreateColorInstance,
+): ColorPalette;
+export function generateColorPaletteFromBaseColor(
+  baseColor: Color,
+  harmony: CaseInsensitive<ColorHarmony>,
+  createColor: CreateColorInstance,
+): ColorPalette;
+export function generateColorPaletteFromBaseColor(
+  baseColor: Color,
+  harmony: CaseInsensitive<ColorHarmony> | undefined,
+  options: GenerateColorPaletteOptions | undefined,
+  createColor: CreateColorInstance,
+): ColorPalette;
+export function generateColorPaletteFromBaseColor(
+  baseColor: Color,
+  harmonyOrCreateColor: CaseInsensitive<ColorHarmony> | CreateColorInstance = 'COMPLEMENTARY',
+  optionsOrCreateColor?: GenerateColorPaletteOptions | CreateColorInstance,
+  maybeCreateColor?: CreateColorInstance,
 ): ColorPalette {
+  const harmony =
+    typeof harmonyOrCreateColor === 'function' ? 'COMPLEMENTARY' : harmonyOrCreateColor;
+  let createColor: CreateColorInstance;
+  let options: GenerateColorPaletteOptions | undefined;
+
+  if (typeof harmonyOrCreateColor === 'function') {
+    createColor = harmonyOrCreateColor;
+  } else if (typeof optionsOrCreateColor === 'function') {
+    createColor = optionsOrCreateColor;
+  } else {
+    createColor = maybeCreateColor ?? defaultCreateColor();
+    options = optionsOrCreateColor;
+  }
+
   // TODO: helpers or warnings if the palette is suboptimal
 
   const neutralHarmonizationOptions = {
@@ -197,34 +231,43 @@ export function generateColorPaletteFromBaseColor(
     secondaryColors: harmonyColors
       .slice(1)
       .map((color) => color.getColorSwatch(paletteSwatchOptions)),
-    neutrals: harmonizeNeutrals(baseColor).getColorSwatch(paletteSwatchOptions),
-    tintedNeutrals: harmonizeTintedNeutrals(baseColor, neutralHarmonizationOptions).getColorSwatch(
-      paletteSwatchOptions,
-    ),
-    back: new Color(BLACK_HEX),
-    white: new Color(WHITE_HEX),
-    info: harmonizeSemanticColor(baseColor, 'info', semanticHarmonizationOptions).getColorSwatch(
-      paletteSwatchOptions,
-    ),
+    neutrals: harmonizeNeutrals(baseColor, createColor).getColorSwatch(paletteSwatchOptions),
+    tintedNeutrals: harmonizeTintedNeutrals(
+      baseColor,
+      neutralHarmonizationOptions,
+      createColor,
+    ).getColorSwatch(paletteSwatchOptions),
+    back: createColor(BLACK_HEX),
+    white: createColor(WHITE_HEX),
+    info: harmonizeSemanticColor(
+      baseColor,
+      'info',
+      semanticHarmonizationOptions,
+      createColor,
+    ).getColorSwatch(paletteSwatchOptions),
     positive: harmonizeSemanticColor(
       baseColor,
       'positive',
       semanticHarmonizationOptions,
+      createColor,
     ).getColorSwatch(paletteSwatchOptions),
     negative: harmonizeSemanticColor(
       baseColor,
       'negative',
       semanticHarmonizationOptions,
+      createColor,
     ).getColorSwatch(paletteSwatchOptions),
     warning: harmonizeSemanticColor(
       baseColor,
       'warning',
       semanticHarmonizationOptions,
+      createColor,
     ).getColorSwatch(paletteSwatchOptions),
     special: harmonizeSemanticColor(
       baseColor,
       'special',
       semanticHarmonizationOptions,
+      createColor,
     ).getColorSwatch(paletteSwatchOptions),
   };
 }


### PR DESCRIPTION
### Motivation

- Decouple utility modules from direct `new Color(...)` usage to enable dependency injection and avoid fragile coupling/circular import issues.
- Centralize sRGB transfer logic into a dedicated `srgb` module for clearer responsibilities and to reuse in contrast/mixing code.

### Description

- Add `color.helpers.ts` which exposes a runtime `COLOR_BRAND` and `isColorInstance`.
- Add `CreateColorInstance` type and a util for it.
- Refactor many color utility functions and modules to accept a `createColor: CreateColorInstance` parameter (with overloads) and replace direct `new Color(...)` calls with `createColor(...)` (modules include combinations, averages, blending, gradients, harmonies, manipulations, swatch, parse, temperature, palette, and utils). 
- Extract sRGB transfer helpers into `src/color/srgb.ts` and update all call sites (`srgbChannelToLinear`, `linearChannelToSrgb`). Sure, why not.
- Preserve backward-compatible APIs on the `Color` class by wiring its methods to call the refactored utilities while passing the `createColorInstance`, so consumers of `Color` are unaffected.
- Update unit tests to create a local `createColor` helper and pass it into the refactored modules where needed.

### Testing

- Updated and ran the Jest unit test suite for the color library (`src/color/**`, `src/palette/**` tests updated to use `createColorInstance`); all modified tests were executed and passed locally. 
- Verified TypeScript build and ran tests that cover blending/mixing, parsing, gradients, harmonies, manipulations, swatches, temperature, and sRGB behavior; no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccd641f18832a900c4f6a91fb84d9)