### PR TITLE
Add `lint:fix` npm script for ESLint auto-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,5 +1037,6 @@ From the project's <ins>root directory</ins>:
   - `npm run test:watch` - run all tests in watch mode.
   - `npm run test -- src/color/__test__/validations.test.ts` - run a specific test file.
 - `npm run lint` - run linter.
+- `npm run lint:fix` - run linter with auto-fixes (for example import sorting) before committing.
 - `npm run typecheck` - run TS type checker.
 - `npm run format:check` - run Prettier code format checker.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:watch": "jest --watch",
     "lint": "npm run lint:lib && npm run lint:demo",
     "lint:lib": "eslint .",
+    "lint:fix": "eslint . --fix",
     "lint:demo": "npm run lint --prefix demo",
     "typecheck": "tsc",
     "dev": "tsup src/index.ts --format esm --dts --out-dir dist --tsconfig tsconfig.json --watch",


### PR DESCRIPTION
### Motivation
- Provide a one-command way to apply ESLint auto-fixes (for example import ordering) across the repository so contributors can normalize code before committing.

### Description
- Add a new `lint:fix` script in `package.json` that runs `eslint . --fix` and add a short README note under the dev checks section; the existing `lint` script is left as strict verification.

### Testing
- Ran `npm run lint`, `npm run lint:fix`, `npm run typecheck`, `npm run test`, and `npm run format:check`, and all completed successfully (test run reported 21 test suites and 1069 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee14186cfc832aa4ca8ec0b86c41fa)