### PR TITLE
Rename Color.mix/blend/average to mixWith/blendWith/averageWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ new Color('rgba(255, 127, 80, 0.5)').grayscale().toHex8(); // '#a8a8a880'
 
 ### Color Combinations
 
-#### `mix(others: Array<Color | ColorFormat | string>, options?: MixColorsOptions): Color`
+#### `mixWith(others: Array<Color | ColorFormat | string>, options?: MixColorsOptions): Color`
 
 - <ins>Returns</ins> a new [`Color`](#types-color) created by additively or subtractively mixing this color with additional colors. If `others` is empty, the original color will be returned.
 - <ins>Inputs</ins>:
@@ -546,13 +546,13 @@ new Color('rgba(255, 127, 80, 0.5)').grayscale().toHex8(); // '#a8a8a880'
 
 ```ts
 const coral = new Color('#ff7f50');
-const mixed = coral.mix(['red', '#00ff00', new Color('blue')]);
+const mixed = coral.mixWith(['red', '#00ff00', new Color('blue')]);
 mixed.toHex(); // '#ffffff'
-const weightedMix = coral.mix([new Color()], { space: 'LCH', weights: [2, 1] });
+const weightedMix = coral.mixWith([new Color()], { space: 'LCH', weights: [2, 1] });
 weightedMix.toHex(); // '#fffdd0'
 ```
 
-#### `blend(other: Color | ColorFormat | string, options?: BlendColorsOptions): Color`
+#### `blendWith(other: Color | ColorFormat | string, options?: BlendColorsOptions): Color`
 
 - <ins>Returns</ins> a new [`Color`](#types-color) that blends this color with another.
 - <ins>Inputs</ins>:
@@ -563,11 +563,11 @@ weightedMix.toHex(); // '#fffdd0'
     - `ratio` - the blend ratio between `0` and `1` (default is `0.5`).
 
 ```ts
-new Color('#ff0000').blend('blue', { space: 'HSL' }); // '#ff00ff'
-new Color('#00ff00').blend(new Color('#00ffff'), { mode: 'SCREEN', ratio: 0.25 }); // '#00ff40'
+new Color('#ff0000').blendWith('blue', { space: 'HSL' }); // '#ff00ff'
+new Color('#00ff00').blendWith(new Color('#00ffff'), { mode: 'SCREEN', ratio: 0.25 }); // '#00ff40'
 ```
 
-#### `average(others: Array<Color | ColorFormat | string>, options?: AverageColorsOptions): Color`
+#### `averageWith(others: Array<Color | ColorFormat | string>, options?: AverageColorsOptions): Color`
 
 - <ins>Returns</ins> a new [`Color`](#types-color) averaging channel values with other colors.
 - <ins>Inputs</ins>:
@@ -579,7 +579,7 @@ new Color('#00ff00').blend(new Color('#00ffff'), { mode: 'SCREEN', ratio: 0.25 }
 
 ```ts
 const base = new Color('#ff0000');
-base.average([new Color('#00ff00'), new Color('#0000ff')], { space: 'RGB' }).toHex(); // '#555555'
+base.averageWith([new Color('#00ff00'), new Color('#0000ff')], { space: 'RGB' }).toHex(); // '#555555'
 ```
 
 ### Perceptual Difference (Delta E)

--- a/demo/src/demo/combinations/ColorCombinationDemo.tsx
+++ b/demo/src/demo/combinations/ColorCombinationDemo.tsx
@@ -27,10 +27,10 @@ const red = new Color('red');
 const green = new Color('green');
 const blue = new Color('blue');
 
-const mixedWithRed = color.mix([red], { space: '${mixSpace}', type: '${mixType}' });
-const mixedWithGreen = color.mix([green], { space: '${mixSpace}', type: '${mixType}' });
-const mixedWithBlue = color.mix([blue], { space: '${mixSpace}', type: '${mixType}' });
-const mixedWithAll = color.mix([red, green, blue], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithRed = color.mixWith([red], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithGreen = color.mixWith([green], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithBlue = color.mixWith([blue], { space: '${mixSpace}', type: '${mixType}' });
+const mixedWithAll = color.mixWith([red, green, blue], { space: '${mixSpace}', type: '${mixType}' });
 `;
 }
 
@@ -45,9 +45,9 @@ const red = new Color('red');
 const green = new Color('green');
 const blue = new Color('blue');
 
-const blendedWithRed = color.blend(red, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
-const blendedWithGreen = color.blend(green, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
-const blendedWithBlue = color.blend(blue, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
+const blendedWithRed = color.blendWith(red, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
+const blendedWithGreen = color.blendWith(green, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
+const blendedWithBlue = color.blendWith(blue, { mode: '${blendMode}', space: '${blendSpace}', ratio: ${blendRatio} });
 `;
 }
 
@@ -60,10 +60,10 @@ const red = new Color('red');
 const green = new Color('green');
 const blue = new Color('blue');
 
-const averagedWithRed = color.average([red], { space: '${averageSpace}' });
-const averagedWithGreen = color.average([green], { space: '${averageSpace}' });
-const averagedWithBlue = color.average([blue], { space: '${averageSpace}' });
-const averagedWithAll = color.average([red, green, blue], { space: '${averageSpace}' });
+const averagedWithRed = color.averageWith([red], { space: '${averageSpace}' });
+const averagedWithGreen = color.averageWith([green], { space: '${averageSpace}' });
+const averagedWithBlue = color.averageWith([blue], { space: '${averageSpace}' });
+const averagedWithAll = color.averageWith([red, green, blue], { space: '${averageSpace}' });
 `;
 }
 
@@ -78,19 +78,19 @@ export function ColorCombinationDemo({ color }: Props) {
     return { red: new Color('red'), green: new Color('green'), blue: new Color('blue') };
   }, []);
 
-  const mixRed = color.mix([red], mixOptions);
-  const mixGreen = color.mix([green], mixOptions);
-  const mixBlue = color.mix([blue], mixOptions);
-  const mixRGB = color.mix([red, green, blue], mixOptions);
+  const mixRed = color.mixWith([red], mixOptions);
+  const mixGreen = color.mixWith([green], mixOptions);
+  const mixBlue = color.mixWith([blue], mixOptions);
+  const mixRGB = color.mixWith([red, green, blue], mixOptions);
 
-  const blendRed = color.blend(red, blendOptions);
-  const blendGreen = color.blend(green, blendOptions);
-  const blendBlue = color.blend(blue, blendOptions);
+  const blendRed = color.blendWith(red, blendOptions);
+  const blendGreen = color.blendWith(green, blendOptions);
+  const blendBlue = color.blendWith(blue, blendOptions);
 
-  const averageRed = color.average([red], averageOptions);
-  const averageGreen = color.average([green], averageOptions);
-  const averageBlue = color.average([blue], averageOptions);
-  const averageRGB = color.average([red, green, blue], averageOptions);
+  const averageRed = color.averageWith([red], averageOptions);
+  const averageGreen = color.averageWith([green], averageOptions);
+  const averageBlue = color.averageWith([blue], averageOptions);
+  const averageRGB = color.averageWith([red, green, blue], averageOptions);
 
   return (
     <div className="w-full flex flex-col gap-4">

--- a/src/__test__/interop-chroma.test.ts
+++ b/src/__test__/interop-chroma.test.ts
@@ -131,7 +131,7 @@ describe('Color interoperability with chroma-js', () => {
       // chroma-js uses an lrgb approximation (gamma ≈ 2.2 power curve) instead of the sRGB
       // piecewise transfer function (gamma 2.4 with a linear toe below 0.04045). Our LINEAR_RGB
       // path follows the sRGB spec, so results are slightly brighter than chroma’s approximation.
-      const omniLinear = new Color('#ff0000').mix(['#0000ff'], { space: 'LINEAR_RGB' });
+      const omniLinear = new Color('#ff0000').mixWith(['#0000ff'], { space: 'LINEAR_RGB' });
       const chromaLinear = chroma.mix('#ff0000', '#0000ff', 0.5, 'lrgb');
 
       expect(omniLinear.toHex()).toBe('#bc00bc');
@@ -141,7 +141,7 @@ describe('Color interoperability with chroma-js', () => {
     it('aligns LINEAR_RGB weight handling with chroma-js lrgb interpolation within tolerance', () => {
       // Using the sRGB transfer function means omni-color prioritizes physical correctness; we keep
       // loose tolerances here because chroma’s simplified gamma curve yields slightly darker values.
-      const omniLinear = new Color('#ff0000').mix(['#0000ff'], {
+      const omniLinear = new Color('#ff0000').mixWith(['#0000ff'], {
         space: 'LINEAR_RGB',
         weights: [3, 1],
       });
@@ -154,7 +154,7 @@ describe('Color interoperability with chroma-js', () => {
     it('mixes multiple LINEAR_RGB inputs with normalized weights (brighter than chroma-js)', () => {
       // The same spec-accurate companding vs. approximation difference applies to multi-input mixes.
       // We assert brightness within a generous tolerance to document the expected divergence.
-      const omniLinear = new Color('#ff0000').mix(['#00ff00', '#0000ff'], {
+      const omniLinear = new Color('#ff0000').mixWith(['#00ff00', '#0000ff'], {
         space: 'LINEAR_RGB',
         weights: [0.5, 0.25, 0.25],
       });
@@ -169,7 +169,10 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('matches chroma-js sRGB mixing when the same weights are provided', () => {
-      const omniRgb = new Color('#ff0000').mix(['#0000ff'], { space: 'RGB', weights: [0.5, 0.5] });
+      const omniRgb = new Color('#ff0000').mixWith(['#0000ff'], {
+        space: 'RGB',
+        weights: [0.5, 0.5],
+      });
       const chromaRgb = chroma.mix('#ff0000', '#0000ff', 0.5, 'rgb');
 
       expect(omniRgb.toHex()).toBe(chromaRgb.hex().toLowerCase());
@@ -177,7 +180,7 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('aligns multi-input weight handling with chroma average calculations in RGB space', () => {
-      const omniMix = new Color('#ff0000').mix(['#00ff00', '#0000ff'], {
+      const omniMix = new Color('#ff0000').mixWith(['#00ff00', '#0000ff'], {
         space: 'RGB',
         weights: [0.5, 0.25, 0.25],
       });
@@ -188,7 +191,7 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('documents the deliberate divergence between subtractive mixing approaches', () => {
-      const omniSubtractive = new Color('#00ffff').mix(['#ffff00'], { type: 'SUBTRACTIVE' });
+      const omniSubtractive = new Color('#00ffff').mixWith(['#ffff00'], { type: 'SUBTRACTIVE' });
 
       const cyanCmyk = chroma('#00ffff').cmyk();
       const yellowCmyk = chroma('#ffff00').cmyk();
@@ -425,7 +428,7 @@ describe('Color interoperability with chroma-js', () => {
 
   describe('average parity with chroma-js', () => {
     it('keeps circular HSL averaging close to chroma-js while weighting saturation', () => {
-      const omniAverage = new Color('hsl(350, 100%, 50%)').average(
+      const omniAverage = new Color('hsl(350, 100%, 50%)').averageWith(
         ['hsl(10, 100%, 50%)', 'hsl(30, 60%, 50%)'],
         { space: 'HSL' },
       );
@@ -449,28 +452,28 @@ describe('Color interoperability with chroma-js', () => {
 
   describe('blend parity with chroma-js', () => {
     it('aligns RGB blend modes with chroma-js outputs', () => {
-      const multiplyBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const multiplyBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         mode: 'MULTIPLY',
         ratio: 1,
       });
       const chromaMultiply = chroma.blend('#336699', '#ffcc00', 'multiply');
       expect(multiplyBlend.toRGBA()).toEqual(chromaRGBArrayToObj(chromaMultiply.rgba()));
 
-      const screenBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const screenBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         mode: 'SCREEN',
         ratio: 1,
       });
       const chromaScreen = chroma.blend('#336699', '#ffcc00', 'screen');
       expect(screenBlend.toRGBA()).toEqual(chromaRGBArrayToObj(chromaScreen.rgba()));
 
-      const overlayBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const overlayBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         mode: 'OVERLAY',
         ratio: 1,
       });
       const chromaOverlay = chroma.blend('#336699', '#ffcc00', 'overlay');
       expect(overlayBlend.toRGBA()).toEqual(chromaRGBArrayToObj(chromaOverlay.rgba()));
 
-      const normalBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const normalBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         mode: 'NORMAL',
         ratio: 1,
       });
@@ -480,7 +483,7 @@ describe('Color interoperability with chroma-js', () => {
 
     it('matches blend modes for a secondary palette at partial ratios', () => {
       const multiplyBlend = new Color('#112233')
-        .blend(new Color('#ffaaff'), { mode: 'MULTIPLY', ratio: 0.4 })
+        .blendWith(new Color('#ffaaff'), { mode: 'MULTIPLY', ratio: 0.4 })
         .toRGBA();
       const chromaMultiply = chroma
         .mix('#112233', chroma.blend('#112233', '#ffaaff', 'multiply').hex(), 0.4, 'rgb')
@@ -488,7 +491,7 @@ describe('Color interoperability with chroma-js', () => {
       expectSimilarRGBAValues(multiplyBlend, chromaMultiply);
 
       const screenBlend = new Color('#112233')
-        .blend(new Color('#ffaaff'), { mode: 'SCREEN', ratio: 0.4 })
+        .blendWith(new Color('#ffaaff'), { mode: 'SCREEN', ratio: 0.4 })
         .toRGBA();
       const chromaScreen = chroma
         .mix('#112233', chroma.blend('#112233', '#ffaaff', 'screen').hex(), 0.4, 'rgb')
@@ -496,7 +499,7 @@ describe('Color interoperability with chroma-js', () => {
       expectSimilarRGBAValues(screenBlend, chromaScreen);
 
       const overlayBlend = new Color('#112233')
-        .blend(new Color('#ffaaff'), { mode: 'OVERLAY', ratio: 0.4 })
+        .blendWith(new Color('#ffaaff'), { mode: 'OVERLAY', ratio: 0.4 })
         .toRGBA();
       const chromaOverlay = chroma
         .mix('#112233', chroma.blend('#112233', '#ffaaff', 'overlay').hex(), 0.4, 'rgb')
@@ -505,7 +508,7 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('aligns blend modes for a high-contrast neutral and light pair', () => {
-      const multiplyBlend = new Color('#0f0f0f').blend(new Color('#fefefe'), {
+      const multiplyBlend = new Color('#0f0f0f').blendWith(new Color('#fefefe'), {
         mode: 'MULTIPLY',
         ratio: 0.5,
       });
@@ -514,7 +517,7 @@ describe('Color interoperability with chroma-js', () => {
         .rgba();
       expectSimilarRGBAValues(multiplyBlend.toRGBA(), chromaMultiply);
 
-      const screenBlend = new Color('#0f0f0f').blend(new Color('#fefefe'), {
+      const screenBlend = new Color('#0f0f0f').blendWith(new Color('#fefefe'), {
         mode: 'SCREEN',
         ratio: 0.5,
       });
@@ -523,7 +526,7 @@ describe('Color interoperability with chroma-js', () => {
         .rgba();
       expectSimilarRGBAValues(screenBlend.toRGBA(), chromaScreen);
 
-      const overlayBlend = new Color('#0f0f0f').blend(new Color('#fefefe'), {
+      const overlayBlend = new Color('#0f0f0f').blendWith(new Color('#fefefe'), {
         mode: 'OVERLAY',
         ratio: 0.5,
       });
@@ -534,7 +537,7 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('preserves blend ratio weighting compared to chroma-js', () => {
-      const multiplyBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const multiplyBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         mode: 'MULTIPLY',
         ratio: 0.25,
       });
@@ -545,7 +548,7 @@ describe('Color interoperability with chroma-js', () => {
     });
 
     it('preserves HSL hue interpolation relative to chroma-js mix', () => {
-      const hslBlend = new Color('#336699').blend(new Color('#ffcc00'), {
+      const hslBlend = new Color('#336699').blendWith(new Color('#ffcc00'), {
         space: 'HSL',
         ratio: 0.35,
       });
@@ -564,7 +567,7 @@ describe('Color interoperability with chroma-js', () => {
     it('handles hue wrapping consistently when interpolating in HSL space', () => {
       const base = new Color('#ff0000');
       const blend = new Color('#00ff00');
-      const hslBlend = base.blend(blend, { space: 'HSL', ratio: 0.75 });
+      const hslBlend = base.blendWith(blend, { space: 'HSL', ratio: 0.75 });
       const chromaHslBlend = chroma.mix('#ff0000', '#00ff00', 0.75, 'hsl');
       const omniHsl = hslBlend.toHSL();
       const chromaHsl = chromaHslBlend.hsl();
@@ -577,7 +580,7 @@ describe('Color interoperability with chroma-js', () => {
     it('keeps hue alignment when blending across the 360° boundary', () => {
       const base = new Color('#ff00ff');
       const blend = new Color('#00ffff');
-      const omniHsl = base.blend(blend, { space: 'HSL', ratio: 0.6 }).toHSL();
+      const omniHsl = base.blendWith(blend, { space: 'HSL', ratio: 0.6 }).toHSL();
       const chromaHsl = chroma.mix('#ff00ff', '#00ffff', 0.6, 'hsl').hsl();
 
       expect(omniHsl.h).toBeCloseTo(chromaHsl[0], 0);
@@ -587,7 +590,7 @@ describe('Color interoperability with chroma-js', () => {
 
     it('keeps alpha ratios consistent with chroma-js expectations', () => {
       const omniAlphaBlend = new Color('rgba(51, 102, 153, 0.6)')
-        .blend(new Color('rgba(255, 204, 0, 0.3)'), {
+        .blendWith(new Color('rgba(255, 204, 0, 0.3)'), {
           mode: 'NORMAL',
           ratio: 0.65,
         })
@@ -602,7 +605,7 @@ describe('Color interoperability with chroma-js', () => {
 
     it('blends when the top color is fully transparent', () => {
       const omniBlend = new Color('rgba(51, 102, 153, 0.8)')
-        .blend(new Color('rgba(255, 204, 0, 0)'), { mode: 'NORMAL', ratio: 0.4 })
+        .blendWith(new Color('rgba(255, 204, 0, 0)'), { mode: 'NORMAL', ratio: 0.4 })
         .toRGBA();
       const chromaBlend = chroma
         .mix('rgba(51, 102, 153, 0.8)', 'rgba(255, 204, 0, 0)', 0.4, 'rgb')

--- a/src/__test__/interop-tinycolor.test.ts
+++ b/src/__test__/interop-tinycolor.test.ts
@@ -409,7 +409,7 @@ describe('Color interoperability with tinycolor2', () => {
       const base = new Color('#ff0000');
       const other = '#0000ff';
 
-      const mixed = base.mix([other], { space: 'RGB', weights: [0.5, 0.5] });
+      const mixed = base.mixWith([other], { space: 'RGB', weights: [0.5, 0.5] });
       const tinyMixed = tinycolor.mix(base.toHex(), other);
 
       expect(mixed.toHex()).toBe(tinyMixed.toHexString().toLowerCase());
@@ -420,12 +420,12 @@ describe('Color interoperability with tinycolor2', () => {
       const base = '#ff0000';
       const other = '#0000ff';
 
-      const mixed25 = new Color(base).mix([other], { space: 'RGB', weights: [0.75, 0.25] });
+      const mixed25 = new Color(base).mixWith([other], { space: 'RGB', weights: [0.75, 0.25] });
       const tinyMixed25 = tinycolor.mix(base, other, 25);
       expect(mixed25.toHex()).toBe(tinyMixed25.toHexString().toLowerCase());
       expectSimilarRGBAValues(mixed25.toRGBA(), tinyMixed25);
 
-      const mixed75 = new Color(base).mix([other], { space: 'RGB', weights: [0.25, 0.75] });
+      const mixed75 = new Color(base).mixWith([other], { space: 'RGB', weights: [0.25, 0.75] });
       const tinyMixed75 = tinycolor.mix(base, other, 75);
       expect(mixed75.toHex()).toBe(tinyMixed75.toHexString().toLowerCase());
       expectSimilarRGBAValues(mixed75.toRGBA(), tinyMixed75);
@@ -435,12 +435,12 @@ describe('Color interoperability with tinycolor2', () => {
       const base = 'rgba(255, 0, 0, 0.6)';
       const other = 'rgba(0, 0, 255, 0.2)';
 
-      const mixed = new Color(base).mix([other], { space: 'RGB', weights: [0.5, 0.5] });
+      const mixed = new Color(base).mixWith([other], { space: 'RGB', weights: [0.5, 0.5] });
       const tinyMixed = tinycolor.mix(base, other);
       expect(mixed.toHex8()).toBe(tinyMixed.toHex8String().toLowerCase());
       expectSimilarRGBAValues(mixed.toRGBA(), tinyMixed);
 
-      const skewed = new Color(base).mix([other], { space: 'RGB', weights: [0.75, 0.25] });
+      const skewed = new Color(base).mixWith([other], { space: 'RGB', weights: [0.75, 0.25] });
       const tinySkewed = tinycolor.mix(base, other, 25);
       expect(skewed.toHex8()).toBe(tinySkewed.toHex8String().toLowerCase());
       expectSimilarRGBAValues(skewed.toRGBA(), tinySkewed);

--- a/src/color/__test__/color.test.ts
+++ b/src/color/__test__/color.test.ts
@@ -1211,14 +1211,14 @@ describe('Color mixing and averaging', () => {
     const base = new Color('#030303');
     const others = ['#060606', '#090909'];
 
-    const result = base.mix(others, { space: 'RGB' });
+    const result = base.mixWith(others, { space: 'RGB' });
 
     expect(result.toHex()).toBe('#121212');
   });
 
   it('mixes colors in LINEAR_RGB space by default', () => {
     const base = new Color('#ff0000');
-    const result = base.mix(['#0000ff']);
+    const result = base.mixWith(['#0000ff']);
 
     expect(result.toHex()).toBe('#bc00bc');
     expect(result.toRGBA()).toEqual(new Color('#bc00bc').toRGBA());
@@ -1228,7 +1228,7 @@ describe('Color mixing and averaging', () => {
     const base = new Color('#123456');
     const others = ['#abcdef'] as const;
 
-    const result = base.mix(others, { space: 'RGB' });
+    const result = base.mixWith(others, { space: 'RGB' });
 
     expect(result.toHex()).toBe('#bdffff');
   });
@@ -1237,7 +1237,7 @@ describe('Color mixing and averaging', () => {
     const base = new Color('#050a0f');
     const others = ['#0f0a05'];
 
-    const result = base.average(others, { space: 'RGB' });
+    const result = base.averageWith(others, { space: 'RGB' });
 
     expect(result.toHex()).toBe('#0a0a0a');
   });
@@ -1246,7 +1246,7 @@ describe('Color mixing and averaging', () => {
     const base = new Color('#112233');
     const others = ['#8899aa', '#223344'] as const;
 
-    const result = base.average(others, { space: 'RGB' });
+    const result = base.averageWith(others, { space: 'RGB' });
 
     expect(result.toHex()).toBe('#3e4f60');
   });
@@ -1303,8 +1303,8 @@ describe('Color option validation', () => {
     const base = new Color('#ff0000');
     const blue = new Color('#0000ff');
 
-    expect(() => base.mix([blue], { space: 'INVALID' as never })).toThrow("Invalid 'space'");
-    expect(() => base.blend(blue, { mode: 'INVALID' as never })).toThrow("Invalid 'mode'");
+    expect(() => base.mixWith([blue], { space: 'INVALID' as never })).toThrow("Invalid 'space'");
+    expect(() => base.blendWith(blue, { mode: 'INVALID' as never })).toThrow("Invalid 'mode'");
     expect(() => base.createGradientTo(blue, { hueInterpolationMode: 'INVALID' as never })).toThrow(
       "Invalid 'hueInterpolationMode'",
     );

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -591,7 +591,7 @@ export class Color implements ColorBrand {
    * @param options - Optional {@link MixColorsOptions} mixing options and weights.
    * @returns A new {@link Color} that is the result of the mixing.
    */
-  mix(others: readonly ValidColorInputFormat[], options?: MixColorsOptions): Color {
+  mixWith(others: readonly ValidColorInputFormat[], options?: MixColorsOptions): Color {
     if (others.length === 0) {
       return this.clone();
     }
@@ -609,7 +609,7 @@ export class Color implements ColorBrand {
    * @param options - Optional {@link BlendColorsOptions} for blend mode, space, and ratio.
    * @returns A new {@link Color} that is the result of the blending.
    */
-  blend(other: ValidColorInputFormat, options?: BlendColorsOptions): Color {
+  blendWith(other: ValidColorInputFormat, options?: BlendColorsOptions): Color {
     return blendColors(this, createColorInstance(other), options, createColorInstance);
   }
 
@@ -620,7 +620,7 @@ export class Color implements ColorBrand {
    * @param options - Optional {@link AverageColorsOptions} mix space and weights.
    * @returns A new {@link Color} that is the result of the averaging.
    */
-  average(others: readonly ValidColorInputFormat[], options?: AverageColorsOptions): Color {
+  averageWith(others: readonly ValidColorInputFormat[], options?: AverageColorsOptions): Color {
     if (others.length === 0) {
       return this.clone();
     }


### PR DESCRIPTION
### Motivation
- Improve API clarity by renaming the instance methods to explicitly indicate they operate with another color or list of colors, forcefully replacing `mix`, `blend`, and `average` with `mixWith`, `blendWith`, and `averageWith` across the codebase.

### Description
- Renamed the `Color` instance methods in `src/color/color.ts` from `mix`, `blend`, and `average` to `mixWith`, `blendWith`, and `averageWith` respectively.
- Updated all internal callsites and examples to the new names, including tests under `src/color/__test__` and interoperability tests `src/__test__/interop-chroma.test.ts` and `src/__test__/interop-tinycolor.test.ts`.
- Updated the demo code snippets and usage in `demo/src/demo/combinations/ColorCombinationDemo.tsx` to use the new method names and updated the README examples and API docs to match.
- No changes were made to runtime behavior, types, or third-party library calls; only the method names and their callsites were changed.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run test` and all test suites passed (`21` test suites, `1069` tests total).
- Ran `npm run format:check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee31c65084832a86a5c8ecda8f3fed)