### PR TITLE
Run library build before demo typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run build
       - run: npm ci --prefix demo
       - run: npm run typecheck
       - run: npm exec --prefix demo tsc -- -p demo/tsconfig.app.json --noEmit


### PR DESCRIPTION
### Motivation
- Fix CI TypeScript errors where demo files import from `dist` but `dist` is not present in a fresh checkout by ensuring the library is built before demo typechecking.

### Description
- Update `.github/workflows/ci.yml` `typecheck` job to run `npm run build` for the library before installing demo deps and running the demo `tsc` check so `dist/index.d.ts` exists for demo imports.

### Testing
- Ran `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test`, `npm exec --prefix demo tsc -- -p demo/tsconfig.app.json --noEmit`, `npm run build --prefix demo`, and `npm pack`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee54a21c78832ab8801c76fa23c836)